### PR TITLE
Fixes to the installer

### DIFF
--- a/clarity.py
+++ b/clarity.py
@@ -128,6 +128,8 @@ def _cmd_install(args: argparse.Namespace) -> None:
         desktop_argv: list[str] = []
         if args.release:
             desktop_argv.append("--release")
+        if args.auto_install:
+            desktop_argv.append("--auto-install")
         desktop_install(desktop_argv, source_dir=source_dir)
 
 
@@ -560,6 +562,18 @@ def main() -> None:
         help=(
             "Skip the test run that the CLI install performs in dev "
             "mode.  Ignored in --mode desktop."
+        ),
+    )
+    install_parser.add_argument(
+        "--auto-install",
+        action="store_true",
+        help=(
+            "After building the desktop app, install it directly into "
+            "the platform's standard location (/Applications on macOS, "
+            "via msiexec /qb on Windows, dpkg/AppImage copy on Linux) "
+            "rather than opening the installer for the user to drive.  "
+            "Convenient for developers; may need elevated privileges "
+            "on Windows/Linux.  Ignored in --mode cli."
         ),
     )
 

--- a/clarity.py
+++ b/clarity.py
@@ -91,12 +91,44 @@ def _cmd_doctor(_args: argparse.Namespace) -> None:
 
 
 def _cmd_install(args: argparse.Namespace) -> None:
-    from clarity_agent.setup.desktop import _cli_main as desktop_install
+    """Run the CLI install, the desktop build, or both.
 
-    argv: list[str] = []
-    if args.release:
-        argv.append("--release")
-    desktop_install(argv, source_dir=_SCRIPT_DIR.resolve())
+    Each phase delegates to its own ``_cli_main`` so behavior matches
+    invoking the underlying tools directly (color output, auth prompt,
+    final messaging).  Phases run in order — CLI first, then desktop —
+    because the desktop build's ``_ensure_build_deps`` step pip-installs
+    into the venv that the CLI install creates.
+
+    Either phase raising ``SystemExit(non-zero)`` propagates out and
+    short-circuits the rest, so a failed CLI install never wastes time
+    on an unbuildable desktop app.
+    """
+    source_dir = _SCRIPT_DIR.resolve()
+    do_cli = args.mode in ("all", "cli")
+    do_desktop = args.mode in ("all", "desktop")
+
+    if do_cli:
+        from clarity_agent.setup.installer import _cli_main as cli_install
+
+        if do_desktop:
+            print("\n=== Phase 1 of 2: CLI install ===\n")
+        cli_argv: list[str] = [
+            "--mode", "standalone",
+            "--target", str(source_dir),
+        ]
+        if args.skip_tests:
+            cli_argv.append("--skip-tests")
+        cli_install(cli_argv)
+
+    if do_desktop:
+        from clarity_agent.setup.desktop import _cli_main as desktop_install
+
+        if do_cli:
+            print("\n=== Phase 2 of 2: desktop app build ===\n")
+        desktop_argv: list[str] = []
+        if args.release:
+            desktop_argv.append("--release")
+        desktop_install(desktop_argv, source_dir=source_dir)
 
 
 def _cmd_embed(args: argparse.Namespace) -> None:
@@ -494,12 +526,41 @@ def main() -> None:
     # ---- clarity install --------------------------------------------------
     install_parser = subparsers.add_parser(
         "install",
-        help="Install Clarity as a desktop application",
+        help="Install Clarity (CLI tooling and/or the desktop app)",
+        description=(
+            "Install the Clarity CLI tooling, the desktop app, or both.  "
+            "Default mode 'all' runs the CLI install first (creates a "
+            "venv, pip-installs runtime deps, sets up .env, drops a "
+            "`clarity` shim on PATH) and then builds the desktop app "
+            "(PyInstaller sidecar + Tauri .app/.dmg/.msi/.deb).  Use "
+            "--mode to install just one component."
+        ),
+    )
+    install_parser.add_argument(
+        "--mode",
+        choices=["all", "cli", "desktop"],
+        default="all",
+        help=(
+            "Which components to install.  'all' (default) does both; "
+            "'cli' only sets up the CLI install (venv + shim + .env); "
+            "'desktop' only builds the native app."
+        ),
     )
     install_parser.add_argument(
         "--release",
         action="store_true",
-        help="Produce an optimized release build (default: debug)",
+        help=(
+            "Produce an optimized release build of the desktop app "
+            "(default: debug).  Ignored in --mode cli."
+        ),
+    )
+    install_parser.add_argument(
+        "--skip-tests",
+        action="store_true",
+        help=(
+            "Skip the test run that the CLI install performs in dev "
+            "mode.  Ignored in --mode desktop."
+        ),
     )
 
     # ---- clarity embed ----------------------------------------------------

--- a/src/clarity_agent/app_paths.py
+++ b/src/clarity_agent/app_paths.py
@@ -60,10 +60,14 @@ def clarity_data_dir() -> Path:
     # Windows: %LOCALAPPDATA%\Clarity\data\
     if sys.platform == "win32":
         local_app_data = os.environ.get("LOCALAPPDATA")
-        if local_app_data:
-            candidate = Path(local_app_data) / "Clarity" / "data"
-            if candidate.parent.is_dir():
-                return candidate
+        # Validate that LOCALAPPDATA itself points at a real directory —
+        # not the Clarity subdir, which won't exist on first run (callers
+        # mkdir(parents=True) it on demand, same pattern as every other
+        # data-dir API).  The earlier ``candidate.parent.is_dir()`` check
+        # required %LOCALAPPDATA%\Clarity\ to pre-exist, which silently
+        # fell through to ``~/.clarity`` for every fresh install.
+        if local_app_data and Path(local_app_data).is_dir():
+            return Path(local_app_data) / "Clarity" / "data"
 
     # Linux / developer fallback.
     return Path.home() / ".clarity"

--- a/src/clarity_agent/setup/desktop.py
+++ b/src/clarity_agent/setup/desktop.py
@@ -280,7 +280,8 @@ def _build_tauri(source_dir: Path, *, release: bool = False) -> StepResult:
     # Finder/AppleScript interaction in headless builds; the separate CI
     # check below uses the *original* env value so local builds still get
     # all bundle types.
-    _in_ci = bool(os.environ.get("CI"))
+    # Use an explicit check so that CI=false / CI=0 is treated as non-CI.
+    _in_ci = os.environ.get("CI", "").lower() in ("1", "true", "yes")
 
     # Set CI=true so the DMG bundler skips Finder/AppleScript interaction
     # (which opens windows and can hang in headless environments).

--- a/src/clarity_agent/setup/desktop.py
+++ b/src/clarity_agent/setup/desktop.py
@@ -275,6 +275,13 @@ def _build_web(source_dir: Path) -> StepResult:
 
 def _build_tauri(source_dir: Path, *, release: bool = False) -> StepResult:
     """Run tauri build to produce the native app bundle."""
+    # Capture whether we are running in CI *before* setdefault mutates the
+    # environment.  setdefault is used solely so the DMG bundler skips
+    # Finder/AppleScript interaction in headless builds; the separate CI
+    # check below uses the *original* env value so local builds still get
+    # all bundle types.
+    _in_ci = bool(os.environ.get("CI"))
+
     # Set CI=true so the DMG bundler skips Finder/AppleScript interaction
     # (which opens windows and can hang in headless environments).
     os.environ.setdefault("CI", "true")
@@ -282,6 +289,13 @@ def _build_tauri(source_dir: Path, *, release: bool = False) -> StepResult:
     cmd = ["npx", "--prefix", str(source_dir / "web"), "tauri", "build"]
     if not release:
         cmd.append("--debug")
+
+    # In CI on macOS, skip the DMG bundle.  hdiutil DMG creation is
+    # unreliable in headless runners (bundle_dmg.sh can fail with no
+    # useful diagnostics), and distribution artifacts are not needed
+    # for build verification.  The .app bundle is sufficient.
+    if _in_ci and sys.platform == "darwin":
+        cmd.extend(["--bundles", "app"])
 
     # Ensure the Tauri build targets the same architecture as the Rust
     # toolchain.  Without this, ARM64 Windows with an x86_64 Rust

--- a/src/clarity_agent/setup/desktop.py
+++ b/src/clarity_agent/setup/desktop.py
@@ -375,6 +375,190 @@ def _collect_outputs(source_dir: Path, *, release: bool = False) -> StepResult:
 
 
 # ---------------------------------------------------------------------------
+# Persistence + install
+# ---------------------------------------------------------------------------
+
+def _persistence_target() -> Path:
+    """Where built bundles get moved before installation.
+
+    The build runs from a tmpdir when invoked via ``install.sh`` —
+    the ``dist/`` directory ends up inside ``$WORK`` and gets nuked
+    on script exit, so the user has nothing to install from.  Move
+    the artifacts to the platform's stable user data location
+    instead, alongside the rest of Clarity's persistent state.
+    """
+    from clarity_agent.app_paths import clarity_data_dir
+    return clarity_data_dir() / "builds" / "dist"
+
+
+def _persist_dist(source_dir: Path) -> StepResult:
+    """Move the built bundle out of the (potentially-tmp) source dir."""
+    src = source_dir / "dist"
+    if not src.exists() or not any(src.iterdir()):
+        return StepResult(Outcome.WARN, "No dist/ to persist (build produced no artifacts)")
+    dst = _persistence_target()
+    if dst.exists():
+        shutil.rmtree(dst)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.move(str(src), str(dst))
+    return StepResult(Outcome.OK, f"Bundle persisted to {dst}")
+
+
+def _open_installer(persisted_dist: Path) -> StepResult:
+    """Hand off to the platform's standard install flow.
+
+    macOS: ``open Clarity.dmg`` (Finder shows the drag-to-Applications
+    window).  Windows: ``start Clarity.msi`` (MSI wizard with its own
+    UAC prompt).  Linux: print the install commands — there's no
+    universal Linux installer GUI, and silently auto-installing would
+    need ``sudo``.
+
+    Falls back to printing the path when the platform's open command
+    is missing (e.g. headless CI).
+    """
+    if sys.platform == "darwin":
+        dmg = next(iter(persisted_dist.glob("*.dmg")), None)
+        if dmg is None:
+            return StepResult(
+                Outcome.WARN,
+                f"No .dmg found in {persisted_dist} — open the .app there manually",
+            )
+        try:
+            subprocess.run(["open", str(dmg)], check=True, timeout=30)
+            return StepResult(
+                Outcome.OK,
+                f"Opened {dmg.name} — drag Clarity into Applications",
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            return StepResult(
+                Outcome.WARN,
+                f"Could not launch 'open' — install manually from {dmg}",
+            )
+
+    if sys.platform == "win32":
+        msi = next(iter(persisted_dist.glob("*.msi")), None)
+        if msi is None:
+            return StepResult(
+                Outcome.WARN,
+                f"No .msi found in {persisted_dist}",
+            )
+        try:
+            subprocess.run(["cmd", "/c", "start", "", str(msi)], check=True, timeout=30)
+            return StepResult(
+                Outcome.OK, f"Launched {msi.name} installer wizard",
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            return StepResult(
+                Outcome.WARN,
+                f"Could not launch installer — run {msi} manually",
+            )
+
+    # Linux: print instructions for whatever's in the dist.
+    deb = next(iter(persisted_dist.glob("*.deb")), None)
+    appimage = next(iter(persisted_dist.glob("*.AppImage")), None)
+    instructions: list[str] = []
+    if deb is not None:
+        instructions.append(f"sudo dpkg -i {deb}")
+    if appimage is not None:
+        instructions.append(f"chmod +x {appimage}  # then run it directly")
+    if not instructions:
+        return StepResult(
+            Outcome.WARN,
+            f"No .deb or .AppImage in {persisted_dist}",
+        )
+    return StepResult(
+        Outcome.OK,
+        "Install with: " + "  OR  ".join(instructions),
+    )
+
+
+def _auto_install(persisted_dist: Path) -> StepResult:
+    """Install directly into the platform's standard location.
+
+    macOS: copy ``.app`` to ``/Applications`` (falls back to
+    ``~/Applications`` if no write permission), and strip the
+    ``com.apple.quarantine`` attr so the app launches without the
+    "downloaded from internet" Gatekeeper prompt.
+
+    Windows: ``msiexec /i <file>.msi /qb`` for a basic-UI silent
+    install.  May trigger a UAC prompt; if elevation is denied the
+    msiexec exit code surfaces in the FAIL message.
+
+    Linux: ``sudo dpkg -i <file>.deb`` (errors out if no sudo /
+    user is not in sudoers — that's the operator's problem to
+    resolve).  AppImage gets ``chmod +x`` and is left in place.
+    """
+    if sys.platform == "darwin":
+        app = next(iter(persisted_dist.glob("*.app")), None)
+        if app is None:
+            return StepResult(Outcome.FAIL, f"No .app found in {persisted_dist}")
+        # Try /Applications first, fall back to ~/Applications on
+        # permission denial.  Prefer the global install when possible
+        # — that's what users expect from a "real" installation.
+        for target in (Path("/Applications"), Path.home() / "Applications"):
+            try:
+                target.mkdir(parents=True, exist_ok=True)
+                dst = target / app.name
+                if dst.exists():
+                    shutil.rmtree(dst)
+                shutil.copytree(app, dst)
+                # Best-effort quarantine strip — fine if xattr is missing.
+                subprocess.run(
+                    ["xattr", "-dr", "com.apple.quarantine", str(dst)],
+                    capture_output=True,
+                )
+                return StepResult(
+                    Outcome.OK, f"Installed to {dst}",
+                )
+            except PermissionError:
+                continue
+        return StepResult(
+            Outcome.FAIL,
+            "Could not write to /Applications or ~/Applications",
+        )
+
+    if sys.platform == "win32":
+        msi = next(iter(persisted_dist.glob("*.msi")), None)
+        if msi is None:
+            return StepResult(Outcome.FAIL, f"No .msi found in {persisted_dist}")
+        r = subprocess.run(
+            ["msiexec", "/i", str(msi), "/qb"],
+            capture_output=True, text=True, timeout=300,
+        )
+        if r.returncode != 0:
+            return StepResult(
+                Outcome.FAIL,
+                f"msiexec exit {r.returncode}: "
+                f"{(r.stderr or r.stdout or '').strip() or 'no output'}",
+            )
+        return StepResult(Outcome.OK, f"Installed {msi.name}")
+
+    # Linux
+    deb = next(iter(persisted_dist.glob("*.deb")), None)
+    appimage = next(iter(persisted_dist.glob("*.AppImage")), None)
+    if deb is not None:
+        r = subprocess.run(
+            ["sudo", "dpkg", "-i", str(deb)],
+            capture_output=True, text=True, timeout=120,
+        )
+        if r.returncode != 0:
+            return StepResult(
+                Outcome.FAIL,
+                f"dpkg exit {r.returncode}: {(r.stderr or '').strip()}",
+            )
+        return StepResult(Outcome.OK, f"Installed {deb.name}")
+    if appimage is not None:
+        appimage.chmod(appimage.stat().st_mode | 0o111)
+        return StepResult(
+            Outcome.OK,
+            f"{appimage.name} marked executable in {persisted_dist}",
+        )
+    return StepResult(
+        Outcome.FAIL, f"No .deb or .AppImage in {persisted_dist}",
+    )
+
+
+# ---------------------------------------------------------------------------
 # Orchestrator
 # ---------------------------------------------------------------------------
 
@@ -382,14 +566,20 @@ def run_desktop_install(
     source_dir: Path,
     *,
     release: bool = False,
+    auto_install: bool = False,
     on_step: Callable[[StepResult], None] | None = None,
 ) -> list[StepResult]:
     """Build the Clarity desktop app for the current platform.
 
     Args:
-        source_dir: The clarity-agent repo root.
-        release:    If True, produce an optimized release build.
-        on_step:    Optional callback for real-time progress output.
+        source_dir:   The clarity-agent repo root.
+        release:      If True, produce an optimized release build.
+        auto_install: If True, after building, copy the .app into
+                      /Applications (or run msiexec /qb on Windows,
+                      dpkg on Linux) directly instead of opening the
+                      installer for the user to drive.  Convenient
+                      for developers; may need elevated privileges.
+        on_step:      Optional callback for real-time progress output.
     """
     results: list[StepResult] = []
 
@@ -441,6 +631,23 @@ def run_desktop_install(
 
     # Collect outputs
     _record(_collect_outputs(source_dir, release=release))
+    if results[-1].outcome == Outcome.FAIL:
+        return results
+
+    # Move dist/ out of source_dir.  Critical when source_dir is a
+    # tmpdir (e.g. install.sh's $WORK), where the artifacts would
+    # otherwise be deleted on script exit.
+    _record(_persist_dist(source_dir))
+    if results[-1].outcome == Outcome.FAIL:
+        return results
+
+    # Final step: hand off to the platform's install flow, or
+    # auto-install if the operator asked for it.
+    persisted = _persistence_target()
+    if auto_install:
+        _record(_auto_install(persisted))
+    else:
+        _record(_open_installer(persisted))
 
     return results
 
@@ -460,6 +667,16 @@ def _cli_main(argv: Sequence[str] | None = None, source_dir: Path | None = None)
         "--release",
         action="store_true",
         help="Produce an optimized release build",
+    )
+    parser.add_argument(
+        "--auto-install",
+        action="store_true",
+        help=(
+            "Install the built bundle directly into the platform's "
+            "standard location (/Applications, msiexec /qb, dpkg) "
+            "instead of opening the installer for the user.  "
+            "Convenient for developers; may need elevated privileges."
+        ),
     )
     args = parser.parse_args(argv)
 
@@ -484,7 +701,12 @@ def _cli_main(argv: Sequence[str] | None = None, source_dir: Path | None = None)
 
     info(f"Building Clarity for {_PLATFORM_LABEL}")
 
-    results = run_desktop_install(source_dir, release=args.release, on_step=emit)
+    results = run_desktop_install(
+        source_dir,
+        release=args.release,
+        auto_install=args.auto_install,
+        on_step=emit,
+    )
 
     if any(r.outcome == Outcome.FAIL for r in results):
         print()
@@ -495,17 +717,15 @@ def _cli_main(argv: Sequence[str] | None = None, source_dir: Path | None = None)
     info("Build complete!")
     print()
 
-    dist_dir = source_dir / "dist"
-    print(f"  Outputs in: {dist_dir}/")
-    if dist_dir.exists():
-        for f in sorted(dist_dir.iterdir()):
+    # source_dir/dist/ has been moved to the persisted location by
+    # _persist_dist; show the operator where to find the artifacts.
+    persisted = _persistence_target()
+    if persisted.exists():
+        print(f"  Outputs in: {persisted}/")
+        for f in sorted(persisted.iterdir()):
             if not f.name.startswith("."):
                 size_mb = sum(
                     p.stat().st_size for p in (f.rglob("*") if f.is_dir() else [f]) if p.is_file()
                 ) / (1024 * 1024)
                 print(f"    {f.name}  ({size_mb:.0f} MB)")
-    if sys.platform == "darwin":
-        app = dist_dir / "Clarity.app"
-        if app.exists():
-            print(f'\n  To run: open "{app}"')
     print()

--- a/src/clarity_agent/setup/installer.py
+++ b/src/clarity_agent/setup/installer.py
@@ -371,44 +371,69 @@ def install_python_deps(
     venv_dir: Path,
     pip_spec: str,
 ) -> list[StepResult]:
-    """Install Python dependencies via pip.
+    """Install Python dependencies into *venv_dir*.
 
-    Returns a list of :class:`StepResult` because the optional pip
-    upgrade is reported separately from the actual dependency install
-    — the upgrade is a nice-to-have (modern venvs ship a recent
-    enough pip), so its failure becomes a WARN rather than blocking
-    the dependency install that follows.  If that next install hits
-    a problem the bundled pip really can't handle, its own error
-    message will say so.
+    Picks an installer based on what's available, in this order:
+
+    1. ``uv pip install --python <venv-python> -e <spec>`` when ``uv``
+       is on ``$PATH``.  Required when the venv was created by
+       ``uv run`` — uv-made venvs ship without pip by default, so
+       ``python -m pip`` would fail with "No module named pip."  When
+       uv is in play, the explicit "upgrade pip" step is skipped: uv
+       has its own resolver and doesn't depend on pip's version.
+    2. ``<venv-python> -m pip install -e <spec>`` otherwise.  The
+       upgrade-pip step still runs but its failure is now a WARN, not
+       a FAIL — the venv's bundled pip is usually fine, and the
+       dependency install that follows reports a real error if not.
+
+    Returns a list of :class:`StepResult` so each phase (upgrade /
+    install) can be reported separately rather than collapsed into a
+    single misleading message.
     """
     venv_python = _venv_python(venv_dir)
     results: list[StepResult] = []
+    use_uv = shutil.which("uv") is not None
 
-    upgrade = subprocess.run(
-        [venv_python, "-m", "pip", "install", "--upgrade", "pip", "--quiet"],
-        capture_output=True, text=True, timeout=120,
-    )
-    if upgrade.returncode != 0:
-        # WARN, not FAIL — the venv's bundled pip is usually fine.
-        # Most common cause is a uv-managed Python that lacks pip
-        # entirely ("No module named pip"), in which case the next
-        # step will fail with a clear message of its own anyway.
+    if use_uv:
+        # uv handles its own resolver; no pip upgrade needed (and
+        # would fail anyway on uv venvs that don't ship pip).
         results.append(StepResult(
-            Outcome.WARN,
-            _subprocess_failure(
-                "pip upgrade skipped (continuing with bundled pip)", upgrade,
-            ),
+            Outcome.SKIP,
+            "pip upgrade skipped (using uv pip; not applicable)",
         ))
     else:
-        results.append(StepResult(Outcome.OK, "pip upgraded"))
+        upgrade = subprocess.run(
+            [venv_python, "-m", "pip", "install", "--upgrade", "pip", "--quiet"],
+            capture_output=True, text=True, timeout=120,
+        )
+        if upgrade.returncode != 0:
+            # WARN, not FAIL — bundled pip is usually fine.
+            results.append(StepResult(
+                Outcome.WARN,
+                _subprocess_failure(
+                    "pip upgrade skipped (continuing with bundled pip)",
+                    upgrade,
+                ),
+            ))
+        else:
+            results.append(StepResult(Outcome.OK, "pip upgraded"))
 
+    if use_uv:
+        install_cmd = [
+            "uv", "pip", "install",
+            "--python", venv_python,
+            "-e", pip_spec,
+        ]
+        installer_label = "uv pip install"
+    else:
+        install_cmd = [venv_python, "-m", "pip", "install", "-e", pip_spec]
+        installer_label = "pip install"
     install = subprocess.run(
-        [venv_python, "-m", "pip", "install", "-e", pip_spec],
-        cwd=cwd, capture_output=True, text=True, timeout=300,
+        install_cmd, cwd=cwd, capture_output=True, text=True, timeout=300,
     )
     if install.returncode != 0:
         results.append(StepResult(
-            Outcome.FAIL, _subprocess_failure("pip install", install),
+            Outcome.FAIL, _subprocess_failure(installer_label, install),
         ))
     else:
         results.append(StepResult(Outcome.OK, "Python dependencies installed"))

--- a/src/clarity_agent/setup/installer.py
+++ b/src/clarity_agent/setup/installer.py
@@ -644,12 +644,6 @@ def run_tests(target: Path, venv_dir: Path) -> list[StepResult]:
             cwd=target, capture_output=True, text=True, timeout=300,
         )
     except FileNotFoundError as exc:
-<<<<<<< Updated upstream
-        results.append(StepResult(Outcome.FAIL, f"Python tests: {exc}"))
-        return results
-    if r.returncode != 0:
-=======
->>>>>>> Stashed changes
         results.append(StepResult(
             Outcome.FAIL, f"Python tests: interpreter not found ({exc})",
         ))
@@ -663,10 +657,6 @@ def run_tests(target: Path, venv_dir: Path) -> list[StepResult]:
 
     web_dir = target / "web"
     if (web_dir / "package.json").exists():
-<<<<<<< Updated upstream
-        # On Windows, npx is npx.cmd and requires shell=True to resolve.
-=======
->>>>>>> Stashed changes
         try:
             r = subprocess.run(
                 ["npx", "vitest", "run"],
@@ -674,12 +664,6 @@ def run_tests(target: Path, venv_dir: Path) -> list[StepResult]:
                 shell=_IS_WINDOWS,
             )
         except FileNotFoundError:
-<<<<<<< Updated upstream
-            results.append(StepResult(Outcome.WARN, "npx not found — skipping frontend tests"))
-            return results
-        if r.returncode != 0:
-=======
->>>>>>> Stashed changes
             results.append(StepResult(
                 Outcome.WARN,
                 "npx not found — skipping frontend tests",

--- a/src/clarity_agent/setup/installer.py
+++ b/src/clarity_agent/setup/installer.py
@@ -619,10 +619,14 @@ def run_tests(target: Path, venv_dir: Path) -> list[StepResult]:
     results: list[StepResult] = []
     venv_python = _venv_python(venv_dir)
 
-    r = subprocess.run(
-        [venv_python, "-m", "pytest", "tests/", "-x", "-q"],
-        cwd=target, capture_output=True, text=True, timeout=300,
-    )
+    try:
+        r = subprocess.run(
+            [venv_python, "-m", "pytest", "tests/", "-x", "-q"],
+            cwd=target, capture_output=True, text=True, timeout=300,
+        )
+    except FileNotFoundError as exc:
+        results.append(StepResult(Outcome.FAIL, f"Python tests: {exc}"))
+        return results
     if r.returncode != 0:
         results.append(StepResult(
             Outcome.FAIL, _subprocess_failure("Python tests", r),
@@ -632,10 +636,16 @@ def run_tests(target: Path, venv_dir: Path) -> list[StepResult]:
 
     web_dir = target / "web"
     if (web_dir / "package.json").exists():
-        r = subprocess.run(
-            ["npx", "vitest", "run"],
-            cwd=web_dir, capture_output=True, text=True, timeout=300,
-        )
+        # On Windows, npx is npx.cmd and requires shell=True to resolve.
+        try:
+            r = subprocess.run(
+                ["npx", "vitest", "run"],
+                cwd=web_dir, capture_output=True, text=True, timeout=300,
+                shell=_IS_WINDOWS,
+            )
+        except FileNotFoundError:
+            results.append(StepResult(Outcome.WARN, "npx not found — skipping frontend tests"))
+            return results
         if r.returncode != 0:
             results.append(StepResult(
                 Outcome.FAIL, _subprocess_failure("Frontend tests", r),
@@ -817,7 +827,12 @@ def _cli_main(argv: Sequence[str] | None = None) -> None:
     # -- Auth check & interactive prompt ---------------------------------
     claude_available, claude_logged_in = check_claude_auth()
 
-    if not claude_logged_in:
+    # Skip the interactive auth prompt in CI or when stdin is not a TTY
+    # (e.g. piped input).  The .env file will still be created from
+    # .env.sample by setup_env_file if auth is not configured.
+    _interactive = not os.environ.get("CI") and sys.stdin.isatty()
+
+    if not claude_logged_in and _interactive:
         print()
         if claude_available:
             info("Claude CLI detected but not logged in")

--- a/src/clarity_agent/setup/installer.py
+++ b/src/clarity_agent/setup/installer.py
@@ -830,7 +830,9 @@ def _cli_main(argv: Sequence[str] | None = None) -> None:
     # Skip the interactive auth prompt in CI or when stdin is not a TTY
     # (e.g. piped input).  The .env file will still be created from
     # .env.sample by setup_env_file if auth is not configured.
-    _interactive = not os.environ.get("CI") and sys.stdin.isatty()
+    # Use an explicit check so that CI=false / CI=0 is treated as non-CI.
+    _in_ci = os.environ.get("CI", "").lower() in ("1", "true", "yes")
+    _interactive = not _in_ci and sys.stdin.isatty()
 
     if not claude_logged_in and _interactive:
         print()

--- a/src/clarity_agent/setup/installer.py
+++ b/src/clarity_agent/setup/installer.py
@@ -37,6 +37,27 @@ def _venv_python(venv_dir: Path) -> str:
     return str(venv_dir / "bin" / "python")
 
 
+def _subprocess_failure(
+    label: str, result: subprocess.CompletedProcess[str],
+) -> str:
+    """Build a multi-line failure message that includes captured output.
+
+    The default ``"X failed"`` message is useless when the install
+    breaks — the operator has nothing to grep, no stack to follow.
+    Including the last lines of stderr (preferred) or stdout makes
+    failures self-diagnosing.  Uses last ~12 lines so a long npm
+    error doesn't bury the actual exit reason.
+    """
+    tail_lines = 12
+    body = (result.stderr or "").strip() or (result.stdout or "").strip()
+    if body:
+        lines = body.splitlines()
+        if len(lines) > tail_lines:
+            body = "\n".join(["...(earlier output omitted)"] + lines[-tail_lines:])
+        return f"{label} (exit {result.returncode}):\n{body}"
+    return f"{label} (exit {result.returncode}, no output captured)"
+
+
 # ---------------------------------------------------------------------------
 # Result type
 # ---------------------------------------------------------------------------
@@ -290,7 +311,7 @@ def clone_or_update(target: Path, clone_url: str) -> StepResult:
         capture_output=True, text=True, timeout=120,
     )
     if r.returncode != 0:
-        return StepResult(Outcome.FAIL, "git clone failed")
+        return StepResult(Outcome.FAIL, _subprocess_failure("git clone", r))
     return StepResult(Outcome.OK, f"Cloned clarity agent into {CLARITY_DIR}")
 
 
@@ -339,7 +360,9 @@ def create_venv(venv_dir: Path) -> StepResult:
         capture_output=True, text=True, timeout=60,
     )
     if r.returncode != 0:
-        return StepResult(Outcome.FAIL, "Failed to create virtual environment")
+        return StepResult(
+            Outcome.FAIL, _subprocess_failure("venv creation", r),
+        )
     return StepResult(Outcome.OK, f"Created {venv_dir.name}")
 
 
@@ -347,24 +370,49 @@ def install_python_deps(
     cwd: Path,
     venv_dir: Path,
     pip_spec: str,
-) -> StepResult:
-    """Install Python dependencies via pip."""
-    venv_python = _venv_python(venv_dir)
+) -> list[StepResult]:
+    """Install Python dependencies via pip.
 
-    r = subprocess.run(
+    Returns a list of :class:`StepResult` because the optional pip
+    upgrade is reported separately from the actual dependency install
+    — the upgrade is a nice-to-have (modern venvs ship a recent
+    enough pip), so its failure becomes a WARN rather than blocking
+    the dependency install that follows.  If that next install hits
+    a problem the bundled pip really can't handle, its own error
+    message will say so.
+    """
+    venv_python = _venv_python(venv_dir)
+    results: list[StepResult] = []
+
+    upgrade = subprocess.run(
         [venv_python, "-m", "pip", "install", "--upgrade", "pip", "--quiet"],
         capture_output=True, text=True, timeout=120,
     )
-    if r.returncode != 0:
-        return StepResult(Outcome.FAIL, "pip upgrade failed")
+    if upgrade.returncode != 0:
+        # WARN, not FAIL — the venv's bundled pip is usually fine.
+        # Most common cause is a uv-managed Python that lacks pip
+        # entirely ("No module named pip"), in which case the next
+        # step will fail with a clear message of its own anyway.
+        results.append(StepResult(
+            Outcome.WARN,
+            _subprocess_failure(
+                "pip upgrade skipped (continuing with bundled pip)", upgrade,
+            ),
+        ))
+    else:
+        results.append(StepResult(Outcome.OK, "pip upgraded"))
 
-    r = subprocess.run(
+    install = subprocess.run(
         [venv_python, "-m", "pip", "install", "-e", pip_spec],
         cwd=cwd, capture_output=True, text=True, timeout=300,
     )
-    if r.returncode != 0:
-        return StepResult(Outcome.FAIL, "pip install failed")
-    return StepResult(Outcome.OK, "Python dependencies installed")
+    if install.returncode != 0:
+        results.append(StepResult(
+            Outcome.FAIL, _subprocess_failure("pip install", install),
+        ))
+    else:
+        results.append(StepResult(Outcome.OK, "Python dependencies installed"))
+    return results
 
 
 def build_web_frontend(web_dir: Path) -> StepResult:
@@ -386,7 +434,7 @@ def build_web_frontend(web_dir: Path) -> StepResult:
             Outcome.WARN, "npm not found — skipping web frontend build",
         )
     if r.returncode != 0:
-        return StepResult(Outcome.FAIL, "npm install failed")
+        return StepResult(Outcome.FAIL, _subprocess_failure("npm install", r))
 
     try:
         r = subprocess.run(
@@ -398,7 +446,7 @@ def build_web_frontend(web_dir: Path) -> StepResult:
             Outcome.WARN, "npm not found — skipping web frontend build",
         )
     if r.returncode != 0:
-        return StepResult(Outcome.FAIL, "npm run build failed")
+        return StepResult(Outcome.FAIL, _subprocess_failure("npm run build", r))
     return StepResult(Outcome.OK, "Web frontend built")
 
 
@@ -551,7 +599,9 @@ def run_tests(target: Path, venv_dir: Path) -> list[StepResult]:
         cwd=target, capture_output=True, text=True, timeout=300,
     )
     if r.returncode != 0:
-        results.append(StepResult(Outcome.FAIL, "Python tests failed"))
+        results.append(StepResult(
+            Outcome.FAIL, _subprocess_failure("Python tests", r),
+        ))
     else:
         results.append(StepResult(Outcome.OK, "Python tests passed"))
 
@@ -562,7 +612,9 @@ def run_tests(target: Path, venv_dir: Path) -> list[StepResult]:
             cwd=web_dir, capture_output=True, text=True, timeout=300,
         )
         if r.returncode != 0:
-            results.append(StepResult(Outcome.FAIL, "Frontend tests failed"))
+            results.append(StepResult(
+                Outcome.FAIL, _subprocess_failure("Frontend tests", r),
+            ))
         else:
             results.append(StepResult(Outcome.OK, "Frontend tests passed"))
 
@@ -651,9 +703,11 @@ def run_install(
         return results
 
     # -- Pip install -----------------------------------------------------
-    r = install_python_deps(config.pip_cwd, config.venv_dir, config.pip_install_spec)
-    _record(r)
-    if r.outcome == Outcome.FAIL:
+    pip_results = install_python_deps(
+        config.pip_cwd, config.venv_dir, config.pip_install_spec,
+    )
+    _record_all(pip_results)
+    if any(r.outcome == Outcome.FAIL for r in pip_results):
         return results
 
     # -- Web frontend ----------------------------------------------------

--- a/src/clarity_agent/setup/installer.py
+++ b/src/clarity_agent/setup/installer.py
@@ -441,7 +441,15 @@ def install_python_deps(
 
 
 def build_web_frontend(web_dir: Path) -> StepResult:
-    """Run npm install + build in the given web directory."""
+    """Run npm install + build in the given web directory.
+
+    On Windows, ``npm`` ships as ``npm.cmd``; ``subprocess.run(["npm",
+    ...])`` without ``shell=True`` calls ``CreateProcess`` directly,
+    which only resolves ``.exe`` — so the bare-list call raises
+    ``FileNotFoundError`` even when ``shutil.which("npm")`` succeeded
+    (since ``shutil.which`` honors ``PATHEXT``).  Pass ``shell=True``
+    on Windows so ``cmd.exe`` resolves the ``.cmd`` shim.
+    """
     if not (web_dir / "package.json").exists():
         return StepResult(Outcome.SKIP, "web/package.json not found")
     if not shutil.which("npm"):
@@ -453,6 +461,7 @@ def build_web_frontend(web_dir: Path) -> StepResult:
         r = subprocess.run(
             ["npm", "install"], cwd=web_dir,
             capture_output=True, text=True, timeout=120,
+            shell=_IS_WINDOWS,
         )
     except FileNotFoundError:
         return StepResult(
@@ -465,6 +474,7 @@ def build_web_frontend(web_dir: Path) -> StepResult:
         r = subprocess.run(
             ["npm", "run", "build"], cwd=web_dir,
             capture_output=True, text=True, timeout=120,
+            shell=_IS_WINDOWS,
         )
     except FileNotFoundError:
         return StepResult(
@@ -615,7 +625,16 @@ def insert_agent_snippet(target: Path, agent_dir: Path) -> StepResult:
 
 
 def run_tests(target: Path, venv_dir: Path) -> list[StepResult]:
-    """Run pytest and vitest.  Only used in dev mode."""
+    """Run pytest and vitest.  Only used in dev mode.
+
+    Both subprocess calls are wrapped in ``FileNotFoundError`` handlers
+    so a missing interpreter (broken venv) or missing ``npx`` shim
+    surfaces as a FAIL StepResult instead of crashing the whole
+    install with an unhandled ``WinError 2`` / ``ENOENT``.  The npx
+    call also passes ``shell=True`` on Windows — same reason as
+    :func:`build_web_frontend` (bare ``CreateProcess`` won't resolve
+    ``npx.cmd``).
+    """
     results: list[StepResult] = []
     venv_python = _venv_python(venv_dir)
 
@@ -625,18 +644,29 @@ def run_tests(target: Path, venv_dir: Path) -> list[StepResult]:
             cwd=target, capture_output=True, text=True, timeout=300,
         )
     except FileNotFoundError as exc:
+<<<<<<< Updated upstream
         results.append(StepResult(Outcome.FAIL, f"Python tests: {exc}"))
         return results
     if r.returncode != 0:
+=======
+>>>>>>> Stashed changes
         results.append(StepResult(
-            Outcome.FAIL, _subprocess_failure("Python tests", r),
+            Outcome.FAIL, f"Python tests: interpreter not found ({exc})",
         ))
     else:
-        results.append(StepResult(Outcome.OK, "Python tests passed"))
+        if r.returncode != 0:
+            results.append(StepResult(
+                Outcome.FAIL, _subprocess_failure("Python tests", r),
+            ))
+        else:
+            results.append(StepResult(Outcome.OK, "Python tests passed"))
 
     web_dir = target / "web"
     if (web_dir / "package.json").exists():
+<<<<<<< Updated upstream
         # On Windows, npx is npx.cmd and requires shell=True to resolve.
+=======
+>>>>>>> Stashed changes
         try:
             r = subprocess.run(
                 ["npx", "vitest", "run"],
@@ -644,14 +674,23 @@ def run_tests(target: Path, venv_dir: Path) -> list[StepResult]:
                 shell=_IS_WINDOWS,
             )
         except FileNotFoundError:
+<<<<<<< Updated upstream
             results.append(StepResult(Outcome.WARN, "npx not found — skipping frontend tests"))
             return results
         if r.returncode != 0:
+=======
+>>>>>>> Stashed changes
             results.append(StepResult(
-                Outcome.FAIL, _subprocess_failure("Frontend tests", r),
+                Outcome.WARN,
+                "npx not found — skipping frontend tests",
             ))
         else:
-            results.append(StepResult(Outcome.OK, "Frontend tests passed"))
+            if r.returncode != 0:
+                results.append(StepResult(
+                    Outcome.FAIL, _subprocess_failure("Frontend tests", r),
+                ))
+            else:
+                results.append(StepResult(Outcome.OK, "Frontend tests passed"))
 
     return results
 

--- a/src/clarity_agent/setup/updater.py
+++ b/src/clarity_agent/setup/updater.py
@@ -267,9 +267,10 @@ def run_update(
 
     # -- Pip install -----------------------------------------------------
     venv_dir, pip_cwd, pip_spec = _detect_pip_spec(agent_dir)
-    r = install_python_deps(pip_cwd, venv_dir, pip_spec)
-    _record(r)
-    if r.outcome == Outcome.FAIL:
+    pip_results = install_python_deps(pip_cwd, venv_dir, pip_spec)
+    for pr in pip_results:
+        _record(pr)
+    if any(pr.outcome == Outcome.FAIL for pr in pip_results):
         return results
 
     # -- Web frontend rebuild -------------------------------------------

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import patch
 
 from clarity_agent.setup.desktop import (
+    _build_tauri,
     _persist_dist,
     _persistence_target,
     run_desktop_install,
@@ -155,6 +157,56 @@ class TestRunDesktopInstall:
         assert Outcome.FAIL not in outcomes
         assert any("Outputs" in r.message or "artifacts" in r.message.lower()
                    for r in results if r.outcome in (Outcome.OK, Outcome.WARN))
+
+
+class TestBuildTauri:
+    """``_build_tauri`` command-line composition."""
+
+    def test_ci_macos_skips_dmg(self, tmp_path: Path) -> None:
+        """In CI on macOS, --bundles app is added to skip the DMG bundle.
+
+        hdiutil DMG creation is unreliable in headless runners so we verify
+        that the flag is injected rather than relying on it working end-to-end.
+        """
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs):  # type: ignore[no-untyped-def]
+            captured.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0)
+
+        with patch("clarity_agent.setup.desktop._run_build", side_effect=fake_run), \
+             patch("clarity_agent.setup.desktop._get_target_triple", return_value=""), \
+             patch("clarity_agent.setup.desktop.sys") as mock_sys, \
+             patch.dict(os.environ, {"CI": "true"}):
+            mock_sys.platform = "darwin"
+            _build_tauri(tmp_path, release=True)
+
+        assert captured, "expected _run_build to be called"
+        cmd = captured[0]
+        assert "--bundles" in cmd
+        idx = cmd.index("--bundles")
+        assert cmd[idx + 1] == "app"
+
+    def test_non_ci_macos_does_not_skip_dmg(self, tmp_path: Path) -> None:
+        """Outside CI on macOS, --bundles is not added so Tauri creates all
+        configured bundle types (including DMG for distribution)."""
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs):  # type: ignore[no-untyped-def]
+            captured.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0)
+
+        env_without_ci = {k: v for k, v in os.environ.items() if k != "CI"}
+        with patch("clarity_agent.setup.desktop._run_build", side_effect=fake_run), \
+             patch("clarity_agent.setup.desktop._get_target_triple", return_value=""), \
+             patch("clarity_agent.setup.desktop.sys") as mock_sys, \
+             patch.dict(os.environ, env_without_ci, clear=True):
+            mock_sys.platform = "darwin"
+            _build_tauri(tmp_path, release=True)
+
+        assert captured, "expected _run_build to be called"
+        cmd = captured[0]
+        assert "--bundles" not in cmd
 
 
 class TestPersistDist:

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -7,7 +7,11 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
-from clarity_agent.setup.desktop import run_desktop_install
+from clarity_agent.setup.desktop import (
+    _persist_dist,
+    _persistence_target,
+    run_desktop_install,
+)
 from clarity_agent.setup.installer import Outcome
 
 
@@ -47,6 +51,73 @@ class TestRunDesktopInstall:
         assert len(called) > 0
         assert all(hasattr(r, "outcome") for r in called)
 
+    def test_orchestrator_routes_to_open_installer_by_default(
+        self, tmp_path: Path,
+    ) -> None:
+        """Without --auto-install, the open-installer step runs and the
+        auto-install step does not.  Verifies the routing in
+        ``run_desktop_install`` rather than re-testing the helpers
+        themselves."""
+        ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        sidecar_dir = tmp_path / "build" / "pyinstaller"
+        sidecar_dir.mkdir(parents=True)
+        (sidecar_dir / "clarity-server").write_bytes(b"\x00" * 100)
+        (tmp_path / "clarity-server.spec").write_text("# spec")
+        (tmp_path / "web" / "node_modules" / "@tauri-apps" / "cli").mkdir(parents=True)
+        bundle_dir = tmp_path / "src-tauri" / "target" / "debug" / "bundle" / "macos"
+        bundle_dir.mkdir(parents=True)
+        (bundle_dir / "Clarity.app" / "Contents" / "MacOS").mkdir(parents=True)
+        (bundle_dir / "Clarity.app" / "Contents" / "MacOS" / "clarity").write_bytes(b"\x00")
+
+        with patch("clarity_agent.setup.desktop.shutil.which", return_value="/usr/bin/dummy"), \
+             patch("clarity_agent.setup.desktop._get_target_triple",
+                   return_value="aarch64-apple-darwin"), \
+             patch("clarity_agent.setup.desktop.subprocess.run", return_value=ok), \
+             patch("clarity_agent.setup.desktop.sys") as mock_sys, \
+             patch("clarity_agent.setup.desktop._open_installer",
+                   return_value=__import__("clarity_agent.setup.installer", fromlist=["StepResult"]).StepResult(Outcome.OK, "opened")) as mock_open, \
+             patch("clarity_agent.setup.desktop._auto_install") as mock_auto:
+            mock_sys.platform = "darwin"
+            mock_sys.executable = sys.executable
+            run_desktop_install(tmp_path, auto_install=False)
+
+        assert mock_open.called, "default flow must call _open_installer"
+        assert not mock_auto.called, "default flow must NOT call _auto_install"
+
+    def test_orchestrator_routes_to_auto_install_when_flag_set(
+        self, tmp_path: Path,
+    ) -> None:
+        """With --auto-install, the auto-install step runs and the
+        open-installer step does not."""
+        ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        sidecar_dir = tmp_path / "build" / "pyinstaller"
+        sidecar_dir.mkdir(parents=True)
+        (sidecar_dir / "clarity-server").write_bytes(b"\x00" * 100)
+        (tmp_path / "clarity-server.spec").write_text("# spec")
+        (tmp_path / "web" / "node_modules" / "@tauri-apps" / "cli").mkdir(parents=True)
+        bundle_dir = tmp_path / "src-tauri" / "target" / "debug" / "bundle" / "macos"
+        bundle_dir.mkdir(parents=True)
+        (bundle_dir / "Clarity.app" / "Contents" / "MacOS").mkdir(parents=True)
+        (bundle_dir / "Clarity.app" / "Contents" / "MacOS" / "clarity").write_bytes(b"\x00")
+
+        installer_mod = __import__(
+            "clarity_agent.setup.installer", fromlist=["StepResult"],
+        )
+        with patch("clarity_agent.setup.desktop.shutil.which", return_value="/usr/bin/dummy"), \
+             patch("clarity_agent.setup.desktop._get_target_triple",
+                   return_value="aarch64-apple-darwin"), \
+             patch("clarity_agent.setup.desktop.subprocess.run", return_value=ok), \
+             patch("clarity_agent.setup.desktop.sys") as mock_sys, \
+             patch("clarity_agent.setup.desktop._open_installer") as mock_open, \
+             patch("clarity_agent.setup.desktop._auto_install",
+                   return_value=installer_mod.StepResult(Outcome.OK, "installed")) as mock_auto:
+            mock_sys.platform = "darwin"
+            mock_sys.executable = sys.executable
+            run_desktop_install(tmp_path, auto_install=True)
+
+        assert mock_auto.called, "--auto-install must call _auto_install"
+        assert not mock_open.called, "--auto-install must NOT call _open_installer"
+
     def test_full_build_with_mocked_steps(self, tmp_path: Path) -> None:
         """Verify the full build sequence runs when all steps succeed."""
         ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
@@ -84,3 +155,57 @@ class TestRunDesktopInstall:
         assert Outcome.FAIL not in outcomes
         assert any("Outputs" in r.message or "artifacts" in r.message.lower()
                    for r in results if r.outcome in (Outcome.OK, Outcome.WARN))
+
+
+class TestPersistDist:
+    """``_persist_dist`` moves the built bundle out of source_dir.
+
+    Critical when source_dir is a tmpdir (install.sh's ``$WORK``):
+    leaving artifacts there means they're deleted on script exit.
+    """
+
+    def test_moves_dist_to_persistence_target(self, tmp_path: Path) -> None:
+        # CLARITY_DATA_DIR is set to tmp_path by the autouse fixture
+        # in conftest.py, so _persistence_target lands under tmp_path.
+        source_dir = tmp_path / "source"
+        (source_dir / "dist").mkdir(parents=True)
+        (source_dir / "dist" / "Clarity.dmg").write_bytes(b"fake")
+
+        result = _persist_dist(source_dir)
+
+        assert result.outcome == Outcome.OK
+        target = _persistence_target()
+        assert target.exists()
+        assert (target / "Clarity.dmg").read_bytes() == b"fake"
+        # Source dist moved away (shutil.move semantics).
+        assert not (source_dir / "dist").exists()
+
+    def test_warns_on_missing_dist(self, tmp_path: Path) -> None:
+        """No build artifacts → WARN, not FAIL.  Lets the orchestrator
+        continue to a meaningful "no installer to launch" message
+        instead of aborting cryptically."""
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()  # dist/ deliberately absent
+
+        result = _persist_dist(source_dir)
+
+        assert result.outcome == Outcome.WARN
+        assert "no dist" in result.message.lower()
+
+    def test_replaces_existing_target(self, tmp_path: Path) -> None:
+        """Re-running install overwrites the previous bundle in place
+        — operator gets the freshest artifacts at the same path each
+        time, no per-run subdirectories to navigate."""
+        source_dir = tmp_path / "source"
+        (source_dir / "dist").mkdir(parents=True)
+        (source_dir / "dist" / "Clarity-new.dmg").write_bytes(b"new")
+
+        # Pre-populate the destination with stale content.
+        target = _persistence_target()
+        target.mkdir(parents=True, exist_ok=True)
+        (target / "Clarity-old.dmg").write_bytes(b"old")
+
+        _persist_dist(source_dir)
+
+        assert (target / "Clarity-new.dmg").exists()
+        assert not (target / "Clarity-old.dmg").exists()

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -589,6 +589,43 @@ class TestRunTests:
             results = run_tests(tmp_path, venv)
         assert len(results) == 1  # only pytest
 
+    def test_npx_file_not_found_warns(self, tmp_path: Path) -> None:
+        """FileNotFoundError from npx (Windows: npx.cmd not found without
+        shell=True) must surface as a WARN and not propagate as an
+        uncaught exception that swallows the pytest result."""
+        venv = tmp_path / ".venv"
+        web = tmp_path / "web"
+        web.mkdir()
+        (web / "package.json").write_text("{}")
+        ok_cp = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+
+        call_count = [0]
+
+        def side_effect(*args, **kwargs):  # type: ignore[no-untyped-def]
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return ok_cp  # pytest succeeds
+            raise FileNotFoundError("npx not found")
+
+        with patch("clarity_agent.setup.installer.subprocess.run", side_effect=side_effect):
+            results = run_tests(tmp_path, venv)
+
+        assert any(r.outcome == Outcome.OK and "Python" in r.message for r in results)
+        assert any(r.outcome == Outcome.WARN and "npx" in r.message.lower() for r in results)
+
+    def test_pytest_file_not_found_fails(self, tmp_path: Path) -> None:
+        """FileNotFoundError from venv Python (e.g. missing venv) surfaces as FAIL."""
+        venv = tmp_path / ".venv"
+
+        with patch(
+            "clarity_agent.setup.installer.subprocess.run",
+            side_effect=FileNotFoundError("python not found"),
+        ):
+            results = run_tests(tmp_path, venv)
+
+        assert len(results) == 1
+        assert results[0].outcome == Outcome.FAIL
+
 
 # ---------------------------------------------------------------------------
 # run_install (orchestrator)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -630,56 +630,18 @@ class TestRunTests:
             results = run_tests(tmp_path, venv)
         assert len(results) == 1  # only pytest
 
-<<<<<<< Updated upstream
-    def test_npx_file_not_found_warns(self, tmp_path: Path) -> None:
-        """FileNotFoundError from npx (Windows: npx.cmd not found without
-        shell=True) must surface as a WARN and not propagate as an
-        uncaught exception that swallows the pytest result."""
-=======
     def test_npx_uses_shell_on_windows(self, tmp_path: Path) -> None:
         """The vitest run must pass shell=True on Windows.
 
-        Same regression as build_web_frontend: ``["npx", ...]``
-        without shell raises FileNotFoundError on Windows because
-        ``CreateProcess`` won't resolve ``npx.cmd``.  This crashed
-        the whole install with an unhandled ``[WinError 2]`` on the
-        install-fix branch.
+        ``["npx", ...]`` without shell raises FileNotFoundError on
+        Windows because ``CreateProcess`` won't resolve ``npx.cmd``.
+        This crashed the whole install with an unhandled
+        ``[WinError 2]`` on the install-fix branch.
         """
->>>>>>> Stashed changes
         venv = tmp_path / ".venv"
         web = tmp_path / "web"
         web.mkdir()
         (web / "package.json").write_text("{}")
-<<<<<<< Updated upstream
-        ok_cp = subprocess.CompletedProcess([], 0, stdout="", stderr="")
-
-        call_count = [0]
-
-        def side_effect(*args, **kwargs):  # type: ignore[no-untyped-def]
-            call_count[0] += 1
-            if call_count[0] == 1:
-                return ok_cp  # pytest succeeds
-            raise FileNotFoundError("npx not found")
-
-        with patch("clarity_agent.setup.installer.subprocess.run", side_effect=side_effect):
-            results = run_tests(tmp_path, venv)
-
-        assert any(r.outcome == Outcome.OK and "Python" in r.message for r in results)
-        assert any(r.outcome == Outcome.WARN and "npx" in r.message.lower() for r in results)
-
-    def test_pytest_file_not_found_fails(self, tmp_path: Path) -> None:
-        """FileNotFoundError from venv Python (e.g. missing venv) surfaces as FAIL."""
-        venv = tmp_path / ".venv"
-
-        with patch(
-            "clarity_agent.setup.installer.subprocess.run",
-            side_effect=FileNotFoundError("python not found"),
-        ):
-            results = run_tests(tmp_path, venv)
-
-        assert len(results) == 1
-        assert results[0].outcome == Outcome.FAIL
-=======
         cp = subprocess.CompletedProcess([], 0, stdout="", stderr="")
         with patch("clarity_agent.setup.installer._IS_WINDOWS", True), \
              patch(
@@ -689,10 +651,10 @@ class TestRunTests:
         # Two calls: pytest (no shell needed — venv_python is absolute)
         # and npx vitest (shell=True on Windows).
         assert mock_run.call_count == 2
-        pytest_call, npx_call = mock_run.call_args_list
         # The pytest invocation does not need shell=True even on
         # Windows because venv_python resolves to an absolute .exe;
         # we don't enforce its value, only the npx call's.
+        npx_call = mock_run.call_args_list[1]
         assert npx_call.args[0][0] == "npx"
         assert npx_call.kwargs.get("shell") is True
 
@@ -736,7 +698,6 @@ class TestRunTests:
         assert results[0].outcome == Outcome.OK  # pytest
         assert results[1].outcome == Outcome.WARN  # vitest skipped
         assert "npx not found" in results[1].message
->>>>>>> Stashed changes
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -481,6 +481,47 @@ class TestBuildWebFrontend:
                 r = build_web_frontend(tmp_path)
         assert r.outcome == Outcome.OK
 
+    def test_passes_shell_true_on_windows(self, tmp_path: Path) -> None:
+        """On Windows, npm calls must use shell=True to resolve npm.cmd.
+
+        Bare ``CreateProcess`` with ``["npm", ...]`` won't find the
+        ``.cmd`` shim — Python's ``subprocess`` only resolves ``.exe``
+        unless ``shell=True`` routes the invocation through cmd.exe.
+        Regression test for the Windows ``[WinError 2]`` install
+        failure on the install-fix branch.
+        """
+        (tmp_path / "package.json").write_text("{}")
+        cp = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        with patch("clarity_agent.setup.installer._IS_WINDOWS", True), \
+             patch("clarity_agent.setup.installer.shutil.which", return_value="C:\\npm.cmd"), \
+             patch(
+                 "clarity_agent.setup.installer.subprocess.run", return_value=cp,
+             ) as mock_run:
+            build_web_frontend(tmp_path)
+        # Both npm install and npm run build must pass shell=True.
+        assert mock_run.call_count == 2
+        for call in mock_run.call_args_list:
+            assert call.kwargs.get("shell") is True, (
+                f"npm subprocess on Windows must pass shell=True, got {call.kwargs}"
+            )
+
+    def test_no_shell_on_non_windows(self, tmp_path: Path) -> None:
+        """Inverse: on Mac/Linux, shell=True would be wrong — without
+        shell, the args list is execed directly, which is the safe
+        and idiomatic path on POSIX."""
+        (tmp_path / "package.json").write_text("{}")
+        cp = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        with patch("clarity_agent.setup.installer._IS_WINDOWS", False), \
+             patch("clarity_agent.setup.installer.shutil.which", return_value="/usr/bin/npm"), \
+             patch(
+                 "clarity_agent.setup.installer.subprocess.run", return_value=cp,
+             ) as mock_run:
+            build_web_frontend(tmp_path)
+        for call in mock_run.call_args_list:
+            assert call.kwargs.get("shell") is False, (
+                f"npm subprocess on POSIX must not use shell=True, got {call.kwargs}"
+            )
+
 
 # ---------------------------------------------------------------------------
 # setup_env_file
@@ -589,14 +630,27 @@ class TestRunTests:
             results = run_tests(tmp_path, venv)
         assert len(results) == 1  # only pytest
 
+<<<<<<< Updated upstream
     def test_npx_file_not_found_warns(self, tmp_path: Path) -> None:
         """FileNotFoundError from npx (Windows: npx.cmd not found without
         shell=True) must surface as a WARN and not propagate as an
         uncaught exception that swallows the pytest result."""
+=======
+    def test_npx_uses_shell_on_windows(self, tmp_path: Path) -> None:
+        """The vitest run must pass shell=True on Windows.
+
+        Same regression as build_web_frontend: ``["npx", ...]``
+        without shell raises FileNotFoundError on Windows because
+        ``CreateProcess`` won't resolve ``npx.cmd``.  This crashed
+        the whole install with an unhandled ``[WinError 2]`` on the
+        install-fix branch.
+        """
+>>>>>>> Stashed changes
         venv = tmp_path / ".venv"
         web = tmp_path / "web"
         web.mkdir()
         (web / "package.json").write_text("{}")
+<<<<<<< Updated upstream
         ok_cp = subprocess.CompletedProcess([], 0, stdout="", stderr="")
 
         call_count = [0]
@@ -625,6 +679,64 @@ class TestRunTests:
 
         assert len(results) == 1
         assert results[0].outcome == Outcome.FAIL
+=======
+        cp = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        with patch("clarity_agent.setup.installer._IS_WINDOWS", True), \
+             patch(
+                 "clarity_agent.setup.installer.subprocess.run", return_value=cp,
+             ) as mock_run:
+            run_tests(tmp_path, venv)
+        # Two calls: pytest (no shell needed — venv_python is absolute)
+        # and npx vitest (shell=True on Windows).
+        assert mock_run.call_count == 2
+        pytest_call, npx_call = mock_run.call_args_list
+        # The pytest invocation does not need shell=True even on
+        # Windows because venv_python resolves to an absolute .exe;
+        # we don't enforce its value, only the npx call's.
+        assert npx_call.args[0][0] == "npx"
+        assert npx_call.kwargs.get("shell") is True
+
+    def test_pytest_missing_interpreter_does_not_crash(
+        self, tmp_path: Path,
+    ) -> None:
+        """Broken venv → FAIL StepResult, not unhandled exception.
+
+        Before the fix, ``subprocess.run`` raising FileNotFoundError
+        for a missing ``.venv/bin/python`` propagated all the way out
+        of ``run_install`` and crashed the install script.  Now it
+        surfaces as a normal FAIL the orchestrator can format.
+        """
+        venv = tmp_path / ".venv"
+        with patch(
+            "clarity_agent.setup.installer.subprocess.run",
+            side_effect=FileNotFoundError("no such file"),
+        ):
+            results = run_tests(tmp_path, venv)
+        assert len(results) == 1
+        assert results[0].outcome == Outcome.FAIL
+        assert "interpreter not found" in results[0].message
+
+    def test_npx_missing_does_not_crash(self, tmp_path: Path) -> None:
+        """Missing npx → WARN, not unhandled exception.
+
+        Defensive companion to the pytest case — pytest passes,
+        npx is missing, install proceeds with a warning.
+        """
+        venv = tmp_path / ".venv"
+        web = tmp_path / "web"
+        web.mkdir()
+        (web / "package.json").write_text("{}")
+        ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        with patch(
+            "clarity_agent.setup.installer.subprocess.run",
+            side_effect=[ok, FileNotFoundError("npx missing")],
+        ):
+            results = run_tests(tmp_path, venv)
+        assert len(results) == 2
+        assert results[0].outcome == Outcome.OK  # pytest
+        assert results[1].outcome == Outcome.WARN  # vitest skipped
+        assert "npx not found" in results[1].message
+>>>>>>> Stashed changes
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -333,12 +333,19 @@ class TestCreateVenv:
 # ---------------------------------------------------------------------------
 
 class TestInstallPythonDeps:
-    def test_ok(self, tmp_path: Path) -> None:
+    def test_ok_with_pip_path(self, tmp_path: Path) -> None:
+        """Without uv on PATH, both pip upgrade and pip install run."""
         venv = tmp_path / ".venv"
         cp = subprocess.CompletedProcess([], 0, stdout="", stderr="")
-        with patch("clarity_agent.setup.installer.subprocess.run", return_value=cp):
+        with patch(
+            "clarity_agent.setup.installer.shutil.which", return_value=None,
+        ), patch(
+            "clarity_agent.setup.installer.subprocess.run", return_value=cp,
+        ):
             results = install_python_deps(tmp_path, venv, ".[dev]")
-        assert all(r.outcome == Outcome.OK for r in results)
+        assert len(results) == 2
+        assert results[0].outcome == Outcome.OK  # pip upgrade
+        assert results[1].outcome == Outcome.OK  # pip install
 
     def test_pip_upgrade_fail_is_warn_not_fail(self, tmp_path: Path) -> None:
         """Pip-upgrade failures don't block the install — venv's bundled
@@ -349,6 +356,8 @@ class TestInstallPythonDeps:
         upgrade_fail = subprocess.CompletedProcess([], 1, stdout="", stderr="err")
         install_ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
         with patch(
+            "clarity_agent.setup.installer.shutil.which", return_value=None,
+        ), patch(
             "clarity_agent.setup.installer.subprocess.run",
             side_effect=[upgrade_fail, install_ok],
         ):
@@ -370,7 +379,9 @@ class TestInstallPythonDeps:
             [], 1, stdout="", stderr="ResolutionImpossible: ...",
         )
         with patch(
-            "clarity_agent.setup.installer.subprocess.run", side_effect=[ok, fail]
+            "clarity_agent.setup.installer.shutil.which", return_value=None,
+        ), patch(
+            "clarity_agent.setup.installer.subprocess.run", side_effect=[ok, fail],
         ):
             results = install_python_deps(tmp_path, venv, ".[dev]")
         assert any(r.outcome == Outcome.FAIL for r in results)
@@ -378,6 +389,51 @@ class TestInstallPythonDeps:
         assert "pip install" in fail_result.message
         # Captured stderr propagates so the operator sees the real reason.
         assert "ResolutionImpossible" in fail_result.message
+
+    def test_uses_uv_when_available(self, tmp_path: Path) -> None:
+        """When uv is on PATH, use ``uv pip install --python <venv>`` and
+        skip the pip-upgrade step entirely.  This is the path that fixes
+        the "No module named pip" failure on uv-managed venvs (which
+        ship without pip by default).
+        """
+        venv = tmp_path / ".venv"
+        ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        with patch(
+            "clarity_agent.setup.installer.shutil.which", return_value="/usr/local/bin/uv",
+        ), patch(
+            "clarity_agent.setup.installer.subprocess.run", return_value=ok,
+        ) as run_mock:
+            results = install_python_deps(tmp_path, venv, ".[dev]")
+
+        # Only one subprocess call was made (the install) — no upgrade.
+        assert run_mock.call_count == 1
+        cmd = run_mock.call_args.args[0]
+        assert cmd[:3] == ["uv", "pip", "install"]
+        assert "--python" in cmd
+        # The pip-upgrade phase still produces a result, but as SKIP
+        # (no command run, just an explanatory note).
+        assert len(results) == 2
+        assert results[0].outcome == Outcome.SKIP
+        assert results[1].outcome == Outcome.OK
+
+    def test_uv_install_failure_propagates_with_stderr(
+        self, tmp_path: Path,
+    ) -> None:
+        """A uv-install failure surfaces the captured stderr in the FAIL
+        message — same self-diagnosing behavior as the pip path."""
+        venv = tmp_path / ".venv"
+        fail = subprocess.CompletedProcess(
+            [], 1, stdout="", stderr="error: package not found",
+        )
+        with patch(
+            "clarity_agent.setup.installer.shutil.which", return_value="/usr/local/bin/uv",
+        ), patch(
+            "clarity_agent.setup.installer.subprocess.run", return_value=fail,
+        ):
+            results = install_python_deps(tmp_path, venv, ".[dev]")
+        fail_result = next(r for r in results if r.outcome == Outcome.FAIL)
+        assert "uv pip install" in fail_result.message
+        assert "package not found" in fail_result.message
 
 
 # ---------------------------------------------------------------------------
@@ -564,6 +620,11 @@ class TestRunInstall:
         url_cp = subprocess.CompletedProcess(
             [], 0, stdout=f"{url}\n", stderr="",
         )
+        # The test sequences subprocess calls precisely; pin the
+        # installer to the pip path (not the uv-pip shortcut) so the
+        # call count matches.  ``which`` returns the npm path for
+        # "npm" but None for everything else (notably "uv").
+        which_results = {"npm": "/usr/bin/npm"}
         with patch("clarity_agent.setup.installer.run_preflight", return_value=ok_preflight), \
              patch("clarity_agent.setup.installer.subprocess.run", side_effect=[
                  url_cp,   # resolve_clone_url
@@ -574,7 +635,10 @@ class TestRunInstall:
                  ok_cp,    # npm install
                  ok_cp,    # npm run build
              ]), \
-             patch("clarity_agent.setup.installer.shutil.which", return_value="/usr/bin/npm"):
+             patch(
+                 "clarity_agent.setup.installer.shutil.which",
+                 side_effect=lambda cmd: which_results.get(cmd),
+             ):
             # Need .clarity-agent/web/package.json for build_web_frontend
             web = tmp_path / CLARITY_DIR / "web"
             web.mkdir(parents=True)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -337,28 +337,47 @@ class TestInstallPythonDeps:
         venv = tmp_path / ".venv"
         cp = subprocess.CompletedProcess([], 0, stdout="", stderr="")
         with patch("clarity_agent.setup.installer.subprocess.run", return_value=cp):
-            r = install_python_deps(tmp_path, venv, ".[dev]")
-        assert r.outcome == Outcome.OK
+            results = install_python_deps(tmp_path, venv, ".[dev]")
+        assert all(r.outcome == Outcome.OK for r in results)
 
-    def test_pip_upgrade_fail(self, tmp_path: Path) -> None:
+    def test_pip_upgrade_fail_is_warn_not_fail(self, tmp_path: Path) -> None:
+        """Pip-upgrade failures don't block the install — venv's bundled
+        pip is usually fine.  Reported as WARN so the operator sees the
+        captured stderr but the dependency install still proceeds.
+        """
         venv = tmp_path / ".venv"
-        cp = subprocess.CompletedProcess([], 1, stdout="", stderr="err")
-        with patch("clarity_agent.setup.installer.subprocess.run", return_value=cp):
-            r = install_python_deps(tmp_path, venv, ".[dev]")
-        assert r.outcome == Outcome.FAIL
-        assert "pip upgrade" in r.message
+        upgrade_fail = subprocess.CompletedProcess([], 1, stdout="", stderr="err")
+        install_ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
+        with patch(
+            "clarity_agent.setup.installer.subprocess.run",
+            side_effect=[upgrade_fail, install_ok],
+        ):
+            results = install_python_deps(tmp_path, venv, ".[dev]")
+        # Two results: the WARN upgrade + the OK install.
+        assert len(results) == 2
+        assert results[0].outcome == Outcome.WARN
+        assert "pip upgrade" in results[0].message
+        # Captured stderr propagates into the message so the operator
+        # can diagnose without reproducing.
+        assert "err" in results[0].message
+        assert results[1].outcome == Outcome.OK
 
     def test_pip_install_fail(self, tmp_path: Path) -> None:
-        """pip upgrade succeeds but pip install fails."""
+        """pip upgrade succeeds but pip install fails — overall FAIL."""
         venv = tmp_path / ".venv"
         ok = subprocess.CompletedProcess([], 0, stdout="", stderr="")
-        fail = subprocess.CompletedProcess([], 1, stdout="", stderr="err")
+        fail = subprocess.CompletedProcess(
+            [], 1, stdout="", stderr="ResolutionImpossible: ...",
+        )
         with patch(
             "clarity_agent.setup.installer.subprocess.run", side_effect=[ok, fail]
         ):
-            r = install_python_deps(tmp_path, venv, ".[dev]")
-        assert r.outcome == Outcome.FAIL
-        assert "pip install" in r.message
+            results = install_python_deps(tmp_path, venv, ".[dev]")
+        assert any(r.outcome == Outcome.FAIL for r in results)
+        fail_result = next(r for r in results if r.outcome == Outcome.FAIL)
+        assert "pip install" in fail_result.message
+        # Captured stderr propagates so the operator sees the real reason.
+        assert "ResolutionImpossible" in fail_result.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registry_sync.py
+++ b/tests/test_registry_sync.py
@@ -250,7 +250,7 @@ class TestThinkerSync:
         thinker_files = self._thinker_files()
         if not thinker_files or not README_DEV.exists():
             return
-        readme_text = README_DEV.read_text()
+        readme_text = README_DEV.read_text(encoding="utf-8")
         missing = [
             name for name in sorted(thinker_files)
             if f"{name}.md" not in readme_text
@@ -337,7 +337,7 @@ class TestProcessSync:
         readme_path = PROCESSES_DIR / "README.md"
         if not process_files or not readme_path.exists():
             return
-        readme_text = readme_path.read_text()
+        readme_text = readme_path.read_text(encoding="utf-8")
         missing = [
             name for name in sorted(process_files)
             if f"{name}.md" not in readme_text
@@ -482,7 +482,7 @@ class TestDataDirSync:
         if not self.RUST_SOURCE.exists():
             pytest.skip("src-tauri/src/main.rs not found (not in repo root?)")
 
-        source = self.RUST_SOURCE.read_text()
+        source = self.RUST_SOURCE.read_text(encoding="utf-8")
 
         # Extract the function body.
         fn_start = source.find("fn projects_json_path()")
@@ -506,7 +506,7 @@ class TestDataDirSync:
         if not self.RUST_SOURCE.exists():
             pytest.skip("src-tauri/src/main.rs not found")
 
-        source = self.RUST_SOURCE.read_text()
+        source = self.RUST_SOURCE.read_text(encoding="utf-8")
         # The Rust code should define a ProjectsFile struct with a projects field.
         assert "ProjectsFile" in source, (
             "Rust source must define a ProjectsFile struct to parse the "

--- a/tests/test_registry_sync.py
+++ b/tests/test_registry_sync.py
@@ -529,6 +529,7 @@ class TestDataDirSync:
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Without env var, Python uses the platform-specific default."""
+        import os
         import sys
 
         from clarity_agent.app_paths import clarity_data_dir
@@ -538,6 +539,16 @@ class TestDataDirSync:
         if sys.platform == "darwin":
             assert result == Path.home() / "Library" / "Application Support" / "Clarity"
         elif sys.platform == "win32":
-            assert "Clarity" in str(result)
+            # Mirror the production resolution exactly: %LOCALAPPDATA%\Clarity\data
+            # when LOCALAPPDATA is set and points at a real directory, otherwise
+            # the universal ~/.clarity fallback.  The earlier assertion
+            # (``"Clarity" in str(result)``) was too loose — it accepted both
+            # outcomes silently and missed a production bug where the function
+            # always fell through to ~/.clarity on first run.
+            local_app_data = os.environ.get("LOCALAPPDATA")
+            if local_app_data and Path(local_app_data).is_dir():
+                assert result == Path(local_app_data) / "Clarity" / "data"
+            else:
+                assert result == Path.home() / ".clarity"
         else:
             assert result == Path.home() / ".clarity"


### PR DESCRIPTION
* Restore the creation of all the stuff needed to run `clarity web` and so on
* Fix bugs in how pip was being fetched and used, and some missing files, that caused the Mac binary not to compile during a clean install
* Actually propagate the compiled binary into a standard place after building it, so it doesn't get auto-deleted as soon as the installer finishes
* Actually surface errors from subprocesses so the user can tell what's going on