### PR TITLE
Agents.md update to have more active bahavior in embedded mode 

### DIFF
--- a/.clarity-protocol/config.json
+++ b/.clarity-protocol/config.json
@@ -24,7 +24,7 @@
       }
     },
     "solution/solution.md": {
-      "contentHash": "233d74cb390313e18d6102b12a6d51358dc8abd8a762c6ee8b846c23f30a96c1",
+      "contentHash": "9380340a5f9c5953e460e5bb9e0272317160eb9f50f26a51e45ef2f60e267428",
       "dependencyHashes": {
         "goal/problem.md": "d95b8256682688b5d8035e9df24f3eec7e2bdabed0e7e1d066b16fc32c512455",
         "goal/requirements.md": "68205d0f7d5bc8d1f66e2f5e30e871406aa4e1cd543761c17f2a6371b2c5f57d",
@@ -32,9 +32,9 @@
       }
     },
     "solution/architecture.md": {
-      "contentHash": "a593e3a045e136473efc77eeb477802925a70aa17d0ae330920c109f02a5b8e2",
+      "contentHash": "f22fcb7f59b3d3737d59e611da4403d8a0e3469940269f6d4124544908855c43",
       "dependencyHashes": {
-        "solution/solution.md": "233d74cb390313e18d6102b12a6d51358dc8abd8a762c6ee8b846c23f30a96c1",
+        "solution/solution.md": "9380340a5f9c5953e460e5bb9e0272317160eb9f50f26a51e45ef2f60e267428",
         "failures/failures.md": "b53e841eebecc123c016387ea931e0966e31d465cd6f1b6f90ff299c14397188"
       }
     },

--- a/.clarity-protocol/solution/architecture.md
+++ b/.clarity-protocol/solution/architecture.md
@@ -102,7 +102,7 @@ Composite of typed `ContentSource` objects, each knowing how to read one part of
 Three components manage installation and ongoing health:
 
 - **Installer** (`installer.py`) — runs the full install sequence (preflight checks, venv, pip, web build, snippet insertion). Stdlib-only at the top level so it can run before pip install; submodules like `snippet` are imported lazily after dependencies are available.
-- **Snippet** (`snippet.py` + `snippet.md`) — a ~15-line markdown snippet inserted into the project's agent config file (CLAUDE.md or AGENTS.md) with `<!-- clarity-begin -->` / `<!-- clarity-end -->` delimiters for idempotent updates. The snippet has two behavioral modes: *thinking mode* (invoke full clarity processes) and *maintenance mode* (update protocol documents as a TODO after implementation work). Target file auto-detected; `{{PROCESSES_DIR}}` placeholder substituted at insertion time.
+- **Snippet** (`snippet.py` + `snippet.md`) — a markdown snippet inserted into the project's agent config file (CLAUDE.md or AGENTS.md) with `<!-- clarity-begin -->` / `<!-- clarity-end -->` delimiters for idempotent updates. The snippet instructs coding agents to engage clarity at two points: *before building* (triggered by the user asking, or by the agent recognizing a consequential architectural choice that would be expensive to reverse) and *after building* (checking protocol staleness after significant implementation work). Target file auto-detected; `{{PROCESSES_DIR}}` placeholder substituted at insertion time.
 - **Doctor** (`doctor.py`) — validates installation health (Python version, dependencies, protocol directory, snippet presence) and offers auto-fix for common issues.
 
 #### Web Backend (`web/app.py` + `session_manager.py`)
@@ -412,7 +412,7 @@ All products share the protocol format as the interoperability point. A user's `
 
 **Full-implementation products** embed or connect to the Layer 3 infrastructure. Architecture varies by product:
 
-- **Coding agent integration** — a short snippet inserted into the project's agent config file (CLAUDE.md or AGENTS.md) with idempotent delimiters. Zero infrastructure of its own; the coding agent's shell access provides Layer 3 via direct invocation. Migration to MCP tools would let the snippet work with coding agents that support MCP but not shell access.
+- **Coding agent integration** — a snippet inserted into the project's agent config file (CLAUDE.md or AGENTS.md) with idempotent delimiters. Instructs the agent to proactively check protocol context before making consequential choices (not just when the user asks), and to maintain protocol freshness after implementation. Zero infrastructure of its own; the coding agent's shell access provides Layer 3 via direct invocation. Migration to MCP tools would let the snippet work with coding agents that support MCP but not shell access.
 - **Web app** — runs Layer 3 infrastructure in-process. Could additionally expose it as an MCP server for other tools to connect to.
 - **Hosted web service** — runs Layer 3 server-side with multi-tenant isolation. New architectural concerns: user authentication, project isolation, storage backend (filesystem may not be appropriate at scale), and cost management per tenant.
 - **IDE integration** — connects to a local MCP server running Layer 3 infrastructure.

--- a/.clarity-protocol/solution/solution.md
+++ b/.clarity-protocol/solution/solution.md
@@ -36,7 +36,7 @@ The current implementation is a **full-implementation product** with three entry
 
 **Three entry points (products):**
 
-- **Coding agent integration (AGENTS.md)** — an `AGENTS.md` file in a project root causes AI coding agents (currently Claude Code) to follow the clarity agent's process guides. The coding agent session itself becomes the clarity conversation.
+- **Coding agent integration (AGENTS.md)** — an `AGENTS.md` file in a project root instructs AI coding agents to engage clarity at inflection points: when the user asks to think, and proactively when the agent recognizes a choice that would be expensive to reverse. The coding agent session itself becomes the clarity conversation.
 - **Web application** — FastAPI + React for dedicated clarity conversations, protocol browsing, and staleness monitoring.
 - **CLI** — initialization, packet status checking, session management.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,13 +137,29 @@ Several registries are intentionally decoupled (packet status graph, packet rend
 This project uses the Clarity Protocol (`.clarity-protocol/`) for structured
 thinking about problems, solutions, and failure modes.
 
-**Thinking mode:** When the user is exploring what to build, requirements are
-unclear, or they ask to brainstorm, clarify, or analyze risks — read and follow
-`processes/clarity-agent.md`.
+**Before building — think when it matters.** Two triggers:
 
-**Maintenance mode:** After completing significant implementation work (new
-features, architectural changes, important decisions), add a task to update
-protocol documents:
+1. *The user asks.* When they want to explore what to build, clarify
+   requirements, brainstorm risks, or work through a decision — read and
+   follow `processes/clarity-agent.md`.
+
+2. *You recognize an inflection point.* Before making choices that would be
+   expensive to reverse — new services, auth/trust models, data schemas,
+   external integrations, significant API contracts — check
+   `.clarity-protocol/` for existing decisions and context. If a relevant
+   decision exists, follow it. If the choice contradicts existing requirements
+   or architecture, surface the conflict before proceeding. If nothing exists
+   and the choice is consequential, offer to think it through:
+   "This is a significant architectural choice — want to spend a minute
+   thinking through alternatives and risks before I build it?"
+
+   Don't interrupt for routine implementation. The test: "If this turns out
+   wrong, is it a 5-minute fix or a multi-day rework?" Interrupt for the
+   latter.
+
+**After building — keep the record current.** After completing significant
+implementation work (new features, architectural changes), check whether
+protocol documents need updating:
 
 1. Run: `python -m clarity_agent.protocol.packet_status . --agent`
 2. Update documents the tool identifies as stale or inaccurate

--- a/src/clarity_agent/setup/snippet.md
+++ b/src/clarity_agent/setup/snippet.md
@@ -4,13 +4,29 @@
 This project uses the Clarity Protocol (`.clarity-protocol/`) for structured
 thinking about problems, solutions, and failure modes.
 
-**Thinking mode:** When the user is exploring what to build, requirements are
-unclear, or they ask to brainstorm, clarify, or analyze risks — read and follow
-`{{PROCESSES_DIR}}/clarity-agent.md`.
+**Before building — think when it matters.** Two triggers:
 
-**Maintenance mode:** After completing significant implementation work (new
-features, architectural changes, important decisions), add a task to update
-protocol documents:
+1. *The user asks.* When they want to explore what to build, clarify
+   requirements, brainstorm risks, or work through a decision — read and
+   follow `{{PROCESSES_DIR}}/clarity-agent.md`.
+
+2. *You recognize an inflection point.* Before making choices that would be
+   expensive to reverse — new services, auth/trust models, data schemas,
+   external integrations, significant API contracts — check
+   `.clarity-protocol/` for existing decisions and context. If a relevant
+   decision exists, follow it. If the choice contradicts existing requirements
+   or architecture, surface the conflict before proceeding. If nothing exists
+   and the choice is consequential, offer to think it through:
+   "This is a significant architectural choice — want to spend a minute
+   thinking through alternatives and risks before I build it?"
+
+   Don't interrupt for routine implementation. The test: "If this turns out
+   wrong, is it a 5-minute fix or a multi-day rework?" Interrupt for the
+   latter.
+
+**After building — keep the record current.** After completing significant
+implementation work (new features, architectural changes), check whether
+protocol documents need updating:
 
 1. Run: `python -m clarity_agent.protocol.packet_status . --agent`
 2. Update documents the tool identifies as stale or inaccurate


### PR DESCRIPTION
Updating the human triggered thinking/maintenance modes with two clearer behavioral triggers: (1) the user asks to think, and (2) the agent recognizes a consequential architectural choice that would be expensive to reverse.

The snippet now instructs coding agents to proactively check protocol context before committing to irreversible decisions, surface conflicts with existing requirements, and offer to think through alternatives — while staying silent for routine implementation work.

Updated in lockstep: AGENTS.md, snippet.md template, solution.md, and architecture.md. Protocol config hashes updated to match.