### PR TITLE
Slim Clarity MCP to agent-facing protocol tools

### DIFF
--- a/UPDATE-CHECKLIST.md
+++ b/UPDATE-CHECKLIST.md
@@ -28,6 +28,7 @@ Process files are auto-discovered from the `processes/` directory, so no registr
 - [ ] **`src/clarity_agent/llm/config.py`** — `_DEFAULT_PROCESS_TIERS`: add process name → tier mapping
 - [ ] **`src/clarity_agent/protocol/packet_status.py`** — `DOCUMENT_PROCESS`: if the process creates/updates tracked documents, add mappings
 - [ ] **`processes/clarity-agent.md`** — Add routing logic and add to the Process Map section
+- [ ] **`src/clarity_agent/mcp/server.py`** — MCP `instructions` string and `run_clarity` inline guide: check if the new process should be mentioned in tool instructions or inlined by `run_clarity`
 - [ ] **`processes/README.md`** — Add to the process list and status table
 - [ ] **`CONTRIBUTING.md`** — Add to semantic stages table and file reference table
 

--- a/src/clarity_agent/mcp/README.md
+++ b/src/clarity_agent/mcp/README.md
@@ -120,10 +120,6 @@ The MCP server exposes 8 tools, designed around three moments in a coding agent'
 | `record_failure` | Record a failure mode or risk |
 | `record_suggestion` | Record a suggestion to update a project document |
 
-### What's not a tool (and why)
-
-Process guides, thinker guides, and behavioral guidelines are available as MCP **resources** (`clarity://processes/{name}`, `clarity://thinkers/{name}`, `clarity://behaviors`). Protocol initialization, mailbox management, and packet generation are internal functions used by the desktop/web/CLI modes. `run_clarity` handles initialization and inlines process guide content when recommending a next step, so the coding agent doesn't need separate tools for those.
-
 ## How It Works
 
 The server uses two directories:
@@ -145,7 +141,7 @@ The AGENTS.md snippet (inserted by `clarity embed`) tells your coding agent when
 Before making choices that would be expensive to reverse, call check_decision.
 When starting work or returning after a break, call run_clarity.
 After completing significant implementation, call get_packet_status.
-Record significant choices with record_decision. Drop risks with record_failure.
+Record significant choices with record_decision. Add risks with record_failure.
 ```
 
 **New project:**

--- a/src/clarity_agent/mcp/README.md
+++ b/src/clarity_agent/mcp/README.md
@@ -4,14 +4,7 @@ This MCP server gives coding agents access to the clarity-agent process: problem
 
 ## Why
 
-Coding agents write code but don't stop to ask whether the right thing is being built or what could go wrong. This server adds that capability. When connected, the agent can:
-
-- Check which protocol documents are stale and what process to run next
-- Read process guides for problem clarification, solution design, failure analysis
-- Record decisions, failure modes, and suggestions as structured documents
-- Generate review packets for stakeholders
-
-The agent calls these tools during normal conversation. You get structured thinking without switching tools.
+Coding agents write code but don't stop to ask whether the right thing is being built or what could go wrong. This server adds that capability with a small, focused tool surface designed for how coding agents actually work.
 
 ## Quick Start
 
@@ -48,13 +41,6 @@ This creates `.vscode/mcp.json`, the `.clarity-protocol/` directory, and an agen
 If you move your clarity-agent installation after running embed in uv mode, re-run `clarity embed` to update the path in `.vscode/mcp.json`.
 
 **Option B: Manual**
-
-Create or go to your project directory:
-
-```bash
-mkdir /path/to/[YOUR-PROJECT]
-cd /path/to/[YOUR-PROJECT]
-```
 
 For **Claude Code** or **`gh copilot`**, create `.mcp.json` in your project root:
 
@@ -105,29 +91,38 @@ If you installed from a local clone with uv (not pip), use `uv run` with `--extr
 }
 ```
 
-Replace `/path/to/clarity-agent` with the absolute path to your clarity-agent clone. On Windows, use backslashes or forward slashes (both work in VS Code).
+Replace `/path/to/clarity-agent` with the absolute path to your clarity-agent clone.
 
-### 5. Launch your agent
+## Available Tools
 
-**Claude Code:**
+The MCP server exposes 8 tools, designed around three moments in a coding agent's workflow:
 
-```bash
-claude
-```
+### Before acting: check for conflicts
 
-Claude Code reads `.mcp.json` on startup. Ask it to "run clarity" to get started.
+| Tool | Purpose |
+|---|---|
+| `check_decision` | Check whether a proposed change conflicts with existing decisions or requirements |
 
-**GitHub Copilot CLI:**
+### Assess and navigate
 
-```bash
-gh copilot --mcp-config .mcp.json
-```
+| Tool | Purpose |
+|---|---|
+| `run_clarity` | Assess project state, get recommended next step with process guide inlined |
+| `get_packet_status` | Check document staleness after completing significant work |
 
-**Cursor / VS Code with Roo:**
+### Read, write, record
 
-Add the same config to `.roo/mcp.json` or Cursor's MCP settings. The command and args are identical.
+| Tool | Purpose |
+|---|---|
+| `read_protocol_document` | Read a protocol document |
+| `write_protocol_document` | Write or update a protocol document (auto-records content hash) |
+| `record_decision` | Record a structured decision with context, rationale, and alternatives |
+| `record_failure` | Record a failure mode or risk |
+| `record_suggestion` | Record a suggestion to update a project document |
 
-> **Note:** An npm wrapper (`npx @clarity-agent/mcp`) also exists in [`mcp-server/`](../../mcp-server/README.md) for MCP clients that expect npx. It will not work until the Python package is published to PyPI. Use the Python server directly until then.
+### What's not a tool (and why)
+
+Process guides, thinker guides, and behavioral guidelines are available as MCP **resources** (`clarity://processes/{name}`, `clarity://thinkers/{name}`, `clarity://behaviors`). Protocol initialization, mailbox management, and packet generation are internal functions used by the desktop/web/CLI modes. `run_clarity` handles initialization and inlines process guide content when recommending a next step, so the coding agent doesn't need separate tools for those.
 
 ## How It Works
 
@@ -136,59 +131,36 @@ The server uses two directories:
 - **project-dir**: your project, where `.clarity-protocol/` lives
 - **agent-dir**: the installed clarity-agent package, where process guides and thinker guides live (resolved automatically)
 
-When the agent calls `run_clarity()`, the server checks the project directory for `.clarity-protocol/`. If none exists, it returns the startup guide. If one exists, it checks document staleness and recommends the next process.
+When the agent calls `run_clarity()`, the server checks the project directory for `.clarity-protocol/`. If none exists, it returns the startup guide. If one exists, it checks document staleness, recommends the next process, and inlines the process guide content so the agent can follow it immediately.
+
+`write_protocol_document` automatically records content hashes so the staleness tracker stays current without a separate `record_packet_status` call.
 
 All read/write operations are scoped to the project directory with path traversal protection.
 
-## Available Tools
-
-| Tool | Purpose |
-|---|---|
-| `run_clarity` | Assess project state, recommend next step |
-| `init_protocol` | Create `.clarity-protocol/` directory |
-| `read_protocol_document` | Read a protocol document |
-| `write_protocol_document` | Write or update a protocol document |
-| `list_protocol_documents` | List all protocol files |
-| `get_packet_status` | Check document staleness |
-| `record_packet_status` | Record content baselines after writing documents |
-| `get_next_action` | Get recommended next process |
-| `record_failure` | Record a failure mode |
-| `record_suggestion` | Record a document suggestion |
-| `record_decision` | Record a structured decision |
-| `list_processes` | List available process guides |
-| `read_process_guide` | Read a process guide |
-| `list_thinkers` | List failure brainstorming thinkers |
-| `read_thinker_guide` | Read a thinker's methodology |
-| `read_behaviors` | Read AGENTS.md behavioral guidelines |
-| `generate_packet` | Generate a review packet |
-| `get_mailbox_status` | Check async operation mailboxes |
-| `check_failure_state` | Check failure analysis progress |
-
 ## Recommended Usage
 
-Start every session by asking the agent to call `run_clarity`. It returns a status assessment and tells the agent which process guide to follow. The conversation flows from there.
+The AGENTS.md snippet (inserted by `clarity embed`) tells your coding agent when to call each tool:
+
+```markdown
+Before making choices that would be expensive to reverse, call check_decision.
+When starting work or returning after a break, call run_clarity.
+After completing significant implementation, call get_packet_status.
+Record significant choices with record_decision. Drop risks with record_failure.
+```
 
 **New project:**
 1. Agent calls `run_clarity`, sees no protocol
 2. It gets the startup process guide and walks you through problem clarification
-3. It calls `init_protocol`, then `write_protocol_document` to capture what you discuss
+3. It calls `write_protocol_document` to capture what you discuss
 
 **Returning to a project:**
-1. Agent calls `run_clarity`, gets a staleness report
-2. It identifies stale documents and the right process to update them
-3. You continue where you left off
+1. Agent calls `run_clarity`, gets a staleness report with the recommended process guide inlined
+2. It follows the guide, updating documents as it goes
 
 **During implementation:**
-- Call `record_decision` for meaningful technical choices (library selection, architecture tradeoffs). This creates a durable record.
-- Call `record_failure` when you spot a risk worth tracking.
-- Call `generate_packet` before a design review or stakeholder check-in.
-
-**Failure brainstorming:**
-- `list_thinkers` shows available specialist perspectives (security, human factors, adversarial).
-- `read_thinker_guide` loads a thinker's methodology. Use `record_failure` for each failure mode found.
-- `check_failure_state` shows where you are in the brainstorm/analyze/manage pipeline.
-
-The process guides produce natural conversation, not form-filling. The agent moves quickly through obvious steps and slows down for genuine ambiguity.
+- Calls `check_decision` before significant architectural choices
+- Calls `record_decision` after making a choice
+- Calls `record_failure` when spotting a risk
 
 ## Options
 
@@ -197,60 +169,3 @@ The process guides produce natural conversation, not form-filling. The agent mov
 | `--project-dir DIR` | `CLARITY_PROJECT_DIR` env var, then cwd | Project directory to operate on |
 | `--transport TYPE` | `stdio` | Transport: `stdio`, `sse`, or `streamable-http` |
 | `--port PORT` | `8421` | Port for SSE/HTTP transport |
-
-## Demo Session
-
-A real session from Claude Code on an empty project directory. The agent invented a demo project and completed problem clarification in about 90 seconds.
-
-```
-~/Documents/Repos/tests/testing-april-17
-
-❯ run clarity on this project
-
-  Called clarity-agent                        # Tool: run_clarity()
-                                              # Returns: no protocol found + startup guide
-
-● This looks like a fresh project, no clarity protocol yet. What are you working on here?
-
-❯ you can decide what im working on!
-
-● Two options:
-  1. Demo project, I invent a toy problem and we walk the clarity flow.
-  2. Something real, give me a one-liner and we'll work on that.
-
-❯ demo project
-
-  Called clarity-agent 3 times               # Tools: init_protocol()
-                                              #        read_process_guide("problem-clarification")
-                                              #        read_process_guide("clarity-agent")
-
-● Protocol initialized. Running problem clarification for a CLI tool
-  that summarizes your recent git activity for standups.
-
-  Called clarity-agent 6 times               # Tools: write_protocol_document("summary.md", ...)
-                                              #        write_protocol_document("goal/problem.md", ...)
-                                              #        write_protocol_document("goal/stakeholders.md", ...)
-                                              #        write_protocol_document("goal/requirements.md", ...)
-                                              #        write_protocol_document("goal/open-questions.md", ...)
-                                              #        get_packet_status()
-
-● All goal documents are current. Here's where we are:
-
-  Created in .clarity-protocol/:
-  - goal/problem.md, developers forget what they worked on, give vague standups
-  - goal/stakeholders.md, primary user (developer), indirect (standup audience)
-  - goal/requirements.md, scan local repos, filter by author/time, output bullets in <5s
-  - goal/open-questions.md, how to summarize commits (heuristics vs. LLM)
-  - summary.md, the elevator pitch
-
-  Next steps:
-  1. solution-brainstorming, pick an approach
-  2. failure-brainstorming, think through what could go wrong
-  3. discovery-prototype, test the summarization approach first
-
-  Want to continue into solution brainstorming?
-
-✻ Total time: 1m 23s
-```
-
-The agent called `run_clarity` to assess state, read the process guides, then used `init_protocol` and `write_protocol_document` to create all the problem clarification documents. The flow was driven by the process guide instructions, not hardcoded behavior.

--- a/src/clarity_agent/mcp/server.py
+++ b/src/clarity_agent/mcp/server.py
@@ -1,9 +1,11 @@
 """Clarity Agent MCP Server.
 
-Exposes the complete clarity-agent process as MCP tools and resources
-using the FastMCP framework.  Tools are thin wrappers around existing
-Python infrastructure in ``clarity_agent.protocol``, ``clarity_agent.packet``,
-and ``clarity_agent.ai_actions``.
+Exposes the clarity-agent process as MCP tools and resources using the
+FastMCP framework. The tool surface is intentionally small: a coding
+agent needs only a handful of tools to integrate clarity into its
+workflow. Internal helper functions (process guide access, mailbox
+management, packet generation) remain available as plain functions for
+the desktop/web/CLI modes but are not exposed as MCP tools.
 
 Run via::
 
@@ -38,10 +40,16 @@ DEFAULT_SSE_PORT = 8421
 mcp = FastMCP(
     "clarity-agent",
     instructions=(
-        "Clarity Agent — structured thinking about what you're building, "
-        "why, and what could go wrong.  Use run_clarity to assess project "
-        "state, read process guides via resources, and use support tools "
-        "to manage protocol documents."
+        "Clarity Agent provides structured thinking about what you're "
+        "building, why, and what could go wrong. "
+        "IMPORTANT: Before making architectural decisions (new services, "
+        "auth/trust models, data schemas, external integrations, "
+        "significant API contracts), call check_decision with a "
+        "description of what you plan to do. "
+        "Call run_clarity when starting work on a project or returning "
+        "after a break. "
+        "After completing significant implementation, call "
+        "get_packet_status to check if protocol documents need updating."
     ),
 )
 
@@ -79,13 +87,10 @@ def _resolve_agent_dir() -> Path:
     if (candidate / "processes").is_dir():
         return candidate
 
-    # Installed via pip: processes/ and thinkers/ are bundled as
-    # package data under clarity_agent/_data/
     pkg_data = Path(__file__).resolve().parent.parent / "_data"
     if (pkg_data / "processes").is_dir():
         return pkg_data
 
-    # Last resort: check if CLARITY_AGENT_DIR env var is set
     env = os.environ.get("CLARITY_AGENT_DIR")
     if env:
         return Path(env).resolve()
@@ -94,7 +99,7 @@ def _resolve_agent_dir() -> Path:
 
 
 # ===================================================================
-# TOP-LEVEL SKILL
+# MCP TOOLS (8 tools — the coding agent surface)
 # ===================================================================
 
 
@@ -102,28 +107,26 @@ def _resolve_agent_dir() -> Path:
 def run_clarity(project_dir: str | None = None) -> str:
     """Assess project state and recommend what to work on next.
 
-    This is the main entry point.  It checks whether a clarity protocol
-    exists, evaluates document staleness, and returns a structured
-    assessment with the recommended next process to follow.
+    This is the main entry point. Call this when starting work on a project,
+    returning after a break, or when unsure what to do next. It checks whether
+    a clarity protocol exists, evaluates document staleness, and returns a
+    structured assessment with the recommended next process to follow.
 
-    Call this when starting work, returning to a project, or when
-    unsure what to do next.
+    Auto-initializes the protocol if it doesn't exist yet.
     """
     proto_dir = _resolve_protocol_dir(project_dir)
 
     if not proto_dir.exists():
-        # New project — return the clarity-agent guide
         agent_dir = _resolve_agent_dir()
         guide_path = agent_dir / "processes" / "clarity-agent.md"
         guide = guide_path.read_text(encoding="utf-8") if guide_path.exists() else ""
         return (
             "# New Project\n\n"
-            "No clarity protocol found.  This is a new project.\n\n"
+            "No clarity protocol found. This is a new project.\n\n"
             "Follow the clarity-agent process guide below to get started.\n\n"
             "---\n\n" + guide
         )
 
-    # Existing project — run packet status
     from clarity_agent.protocol.packet_status import (
         check_decision_triggers,
         check_packet_status,
@@ -137,17 +140,14 @@ def run_clarity(project_dir: str | None = None) -> str:
     phases = check_process_availability(report)
     dreport = check_decision_triggers(proto_dir)
 
-    # Format the status report
     status_text = format_for_agent(report)
 
-    # Add decision info if there are triggers
     if dreport.get("triggers"):
         status_text += "\n\n## Triggered Decisions\n\n"
         for t in dreport["triggers"]:
             docs = ", ".join(t["changed_docs"])
             status_text += f"- **{t['decision']}**: grounding documents changed ({docs})\n"
 
-    # Add process availability
     if phases:
         status_text += "\n\n## Process Availability\n\n"
         for p in phases:
@@ -156,7 +156,6 @@ def run_clarity(project_dir: str | None = None) -> str:
                 status_text += f" — {p['reason']}"
             status_text += "\n"
 
-    # Read notes.md if it exists
     notes_path = proto_dir / "notes.md"
     if notes_path.exists():
         notes_content = notes_path.read_text(encoding="utf-8").strip()
@@ -171,99 +170,81 @@ def run_clarity(project_dir: str | None = None) -> str:
         if action.get("reason"):
             status_text += f": {action['reason']}"
         if action.get("process"):
-            status_text += (
-                f"\n\nUse `read_process_guide` with process_name="
-                f'"{action["process"]}" to get the full process guide.'
-            )
+            agent_dir = _resolve_agent_dir()
+            guide_path = agent_dir / "processes" / f"{action['process']}.md"
+            if guide_path.exists():
+                guide_content = guide_path.read_text(encoding="utf-8")
+                status_text += (
+                    f"\n\n---\n\n"
+                    f"## Process Guide: {action['process']}\n\n"
+                    f"{guide_content}"
+                )
+            else:
+                status_text += (
+                    f"\n\nProcess: {action['process']}"
+                )
 
     return status_text
 
 
-# ===================================================================
-# SUPPORT TOOLS — Protocol I/O
-# ===================================================================
-
-
 @mcp.tool()
-def init_protocol(project_dir: str | None = None) -> str:
-    """Initialize a .clarity-protocol/ directory for a project.
+def check_decision(
+    description: str,
+    project_dir: str | None = None,
+) -> str:
+    """Check whether a proposed change conflicts with existing decisions or requirements.
 
-    Creates directory structure, config.json, and template files.
-    Safe to run on partially-initialized projects.
+    Call this BEFORE making choices that would be expensive to reverse:
+    new services, auth/trust models, data schemas, external integrations,
+    significant API contracts. Returns any relevant existing decisions and
+    requirements so you can check for conflicts before proceeding.
+
+    Args:
+        description: What you plan to do or change.
+        project_dir: Project directory (default: CLARITY_PROJECT_DIR or cwd).
     """
-    from clarity_agent.protocol.initialize import init_protocol as _init
-
-    proj = _resolve_project_dir(project_dir)
-    created = _init(proj)
-    if created:
-        return f"Initialized clarity protocol at {_resolve_protocol_dir(project_dir)}"
-    return f"Protocol directory already exists at {_resolve_protocol_dir(project_dir)}"
-
-
-@mcp.tool()
-def list_protocol_documents(project_dir: str | None = None) -> str:
-    """List all files in the project's .clarity-protocol/ directory tree."""
     proto_dir = _resolve_protocol_dir(project_dir)
     if not proto_dir.exists():
-        return "No protocol directory found."
+        return "No protocol directory found. No existing decisions to check against."
 
-    files: list[str] = []
-    for root, dirs, filenames in os.walk(proto_dir):
-        dirs[:] = [d for d in dirs if not d.startswith((".", "__"))]
-        rel_root = Path(root).relative_to(proto_dir)
-        for f in sorted(filenames):
-            if f.startswith("."):
-                continue
-            rel_path = str(rel_root / f) if str(rel_root) != "." else f
-            files.append(rel_path)
+    sections: list[str] = []
 
-    if not files:
-        return "Protocol directory exists but is empty."
-    return "\n".join(files)
+    decisions_dir = proto_dir / "decisions"
+    if decisions_dir.exists():
+        decision_files = sorted(decisions_dir.glob("decision-*.md"))
+        if decision_files:
+            sections.append("## Existing Decisions\n")
+            for df in decision_files:
+                content = df.read_text(encoding="utf-8")
+                sections.append(f"### {df.stem}\n\n{content}\n")
 
+    req_path = proto_dir / "goal" / "requirements.md"
+    if req_path.exists():
+        from clarity_agent.protocol.packet_status import is_template
+        if not is_template(req_path):
+            content = req_path.read_text(encoding="utf-8")
+            sections.append(f"## Current Requirements\n\n{content}\n")
 
-@mcp.tool()
-def read_protocol_document(
-    document_path: str,
-    project_dir: str | None = None,
-) -> str:
-    """Read a document from the project's .clarity-protocol/ directory.
+    arch_path = proto_dir / "solution" / "architecture.md"
+    if arch_path.exists():
+        from clarity_agent.protocol.packet_status import is_template
+        if not is_template(arch_path):
+            content = arch_path.read_text(encoding="utf-8")
+            sections.append(f"## Current Architecture\n\n{content}\n")
 
-    Use list_protocol_documents to see available files.
-    """
-    proto_dir = _resolve_protocol_dir(project_dir)
-    file_path = (proto_dir / document_path).resolve()
+    if not sections:
+        return (
+            "No decisions, requirements, or architecture documents found. "
+            "Proceed, but consider recording this as a decision with "
+            "record_decision if it is significant."
+        )
 
-    # Path traversal protection
-    if not str(file_path).startswith(str(proto_dir.resolve())):
-        return "Error: path traversal not allowed."
-    if not file_path.exists():
-        return f"Error: document not found: {document_path}"
-
-    return file_path.read_text(encoding="utf-8")
-
-
-@mcp.tool()
-def write_protocol_document(
-    document_path: str,
-    content: str,
-    project_dir: str | None = None,
-) -> str:
-    """Write or update a document in the project's .clarity-protocol/ directory."""
-    proto_dir = _resolve_protocol_dir(project_dir)
-    file_path = (proto_dir / document_path).resolve()
-
-    if not str(file_path).startswith(str(proto_dir.resolve())):
-        return "Error: path traversal not allowed."
-
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    file_path.write_text(content, encoding="utf-8")
-    return f"Written: {document_path}"
-
-
-# ===================================================================
-# SUPPORT TOOLS — Status & Navigation
-# ===================================================================
+    header = (
+        f"## Proposed Change\n\n{description}\n\n"
+        "Review the following existing context for conflicts "
+        "before proceeding.\n\n"
+    )
+    return header + "\n".join(sections)
 
 
 @mcp.tool()
@@ -274,6 +255,8 @@ def get_packet_status(
     """Check the status of all protocol documents: staleness, dependencies,
     what needs updating.
 
+    Call this after completing significant implementation work (new features,
+    architectural changes) to see if protocol documents need updating.
     Returns a structured report showing which documents are current,
     stale, empty, or untracked.
     """
@@ -299,132 +282,52 @@ def get_packet_status(
 
 
 @mcp.tool()
-def record_packet_status(
-    documents: list[str] | None = None,
+def read_protocol_document(
+    document_path: str,
     project_dir: str | None = None,
 ) -> str:
-    """Record the current content hashes for protocol documents.
+    """Read a document from the project's .clarity-protocol/ directory.
 
-    Call this after writing or updating protocol documents so the
-    staleness tracker knows they are current. If no documents are
-    specified, records all tracked documents that have real content.
-
-    Args:
-        documents: List of document paths relative to .clarity-protocol/
-                   (e.g. ["goal/problem.md", "goal/stakeholders.md"]).
-                   If omitted, records all documents with content.
-        project_dir: Project directory (default: CLARITY_PROJECT_DIR or cwd).
+    Use forward slashes for nested paths (e.g., 'goal/problem.md').
     """
-    from clarity_agent.protocol.packet_status import record_hashes
-
     proto_dir = _resolve_protocol_dir(project_dir)
-    if not proto_dir.exists():
-        return "No protocol directory found. Run init_protocol first."
+    file_path = (proto_dir / document_path).resolve()
+
+    if not str(file_path).startswith(str(proto_dir.resolve())):
+        return "Error: path traversal not allowed."
+    if not file_path.exists():
+        return f"Error: document not found: {document_path}"
+
+    return file_path.read_text(encoding="utf-8")
+
+
+@mcp.tool()
+def write_protocol_document(
+    document_path: str,
+    content: str,
+    project_dir: str | None = None,
+) -> str:
+    """Write or update a document in the project's .clarity-protocol/ directory.
+
+    Automatically records the content hash so the staleness tracker
+    knows the document is current.
+    """
+    proto_dir = _resolve_protocol_dir(project_dir)
+    file_path = (proto_dir / document_path).resolve()
+
+    if not str(file_path).startswith(str(proto_dir.resolve())):
+        return "Error: path traversal not allowed."
+
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(content, encoding="utf-8")
 
     try:
-        recorded = record_hashes(proto_dir, documents)
-    except (json.JSONDecodeError, OSError) as exc:
-        return f"Error recording packet status: {exc}"
+        from clarity_agent.protocol.packet_status import record_hashes
+        record_hashes(proto_dir, [document_path])
+    except Exception:
+        pass
 
-    if not recorded:
-        return "No documents to record (all empty or untracked)."
-    _MAX_LISTED = 5
-    if len(recorded) <= _MAX_LISTED:
-        names = ", ".join(recorded)
-    else:
-        names = ", ".join(recorded[:_MAX_LISTED]) + f" + {len(recorded) - _MAX_LISTED} more"
-    return f"Recorded baselines for {len(recorded)} document(s): {names}"
-
-
-@mcp.tool()
-def get_next_action(project_dir: str | None = None) -> str:
-    """Determine what clarity process should be run next based on the
-    current state of the protocol documents.
-
-    Returns the recommended next step with rationale.
-    """
-    from clarity_agent.protocol.packet_status import (
-        check_packet_status as _check,
-    )
-    from clarity_agent.protocol.packet_status import (
-        next_action as _next,
-    )
-
-    proto_dir = _resolve_protocol_dir(project_dir)
-    if not proto_dir.exists():
-        return "No protocol directory found. Run init_protocol first."
-
-    report = _check(proto_dir)
-    action = _next(report)
-    if action is None:
-        return "All documents are current. No immediate action needed."
-
-    result = f"**{action.get('document', 'unknown')}**"
-    if action.get("reason"):
-        result += f"\n\n{action['reason']}"
-    if action.get("process"):
-        result += f"\n\nProcess: {action['process']}"
-    return result
-
-
-# ===================================================================
-# SUPPORT TOOLS — Recording
-# ===================================================================
-
-
-@mcp.tool()
-def record_failure(
-    title: str,
-    description: str,
-    additional_context: str = "",
-    pre_existing: bool | None = None,
-    project_dir: str | None = None,
-) -> str:
-    """Record a potential failure mode during brainstorming.
-
-    Writes to the failure-brainstorm mailbox in the protocol directory.
-    """
-    from clarity_agent.ai_actions.brainstorm import record_failure as _record
-
-    proto_dir = _resolve_protocol_dir(project_dir)
-    _, msg = _record(
-        proto_dir,
-        title=title,
-        description=description,
-        source="mcp",
-        additional_context=additional_context,
-        pre_existing=pre_existing,
-    )
-    return msg
-
-
-@mcp.tool()
-def record_suggestion(
-    title: str,
-    target_document: str,
-    suggestion: str,
-    rationale: str = "",
-    project_dir: str | None = None,
-) -> str:
-    """Record a suggestion to update a project document.
-
-    Writes to the suggestions mailbox so the suggestion can be
-    reviewed and applied later.
-    """
-    from clarity_agent.ai_actions.suggestion import (
-        record_suggestion as _record,
-    )
-
-    proto_dir = _resolve_protocol_dir(project_dir)
-    _, msg = _record(
-        proto_dir,
-        title=title,
-        target_document=target_document,
-        suggestion=suggestion,
-        source="mcp",
-        rationale=rationale,
-    )
-    return msg
+    return f"Written: {document_path}"
 
 
 @mcp.tool()
@@ -439,7 +342,9 @@ def record_decision(
 ) -> str:
     """Record a project decision with structured analysis.
 
-    Creates a decision document in the protocol's decisions/ directory.
+    Call this after making a significant architectural or design choice
+    to create a permanent record. Creates a decision document in the
+    protocol's decisions/ directory.
     """
     from clarity_agent.protocol.packet_status import (
         record_decision as _record_decision,
@@ -488,16 +393,157 @@ def record_decision(
     return f"Recorded decision: {title} → decisions/{filename}"
 
 
-# ===================================================================
-# SUPPORT TOOLS — Process & Thinker Access
-# ===================================================================
+@mcp.tool()
+def record_failure(
+    title: str,
+    description: str,
+    additional_context: str = "",
+    pre_existing: bool | None = None,
+    project_dir: str | None = None,
+) -> str:
+    """Record a potential failure mode during brainstorming.
+
+    Call this during failure brainstorming sessions when you identify
+    a way the system could fail. Writes to the failure-brainstorm
+    mailbox in the protocol directory.
+    """
+    from clarity_agent.ai_actions.brainstorm import record_failure as _record
+
+    proto_dir = _resolve_protocol_dir(project_dir)
+    _, msg = _record(
+        proto_dir,
+        title=title,
+        description=description,
+        source="mcp",
+        additional_context=additional_context,
+        pre_existing=pre_existing,
+    )
+    return msg
 
 
 @mcp.tool()
-def list_processes() -> str:
-    """List all available clarity-agent processes with their descriptions,
-    tiers, and categories.
+def record_suggestion(
+    title: str,
+    target_document: str,
+    suggestion: str,
+    rationale: str = "",
+    project_dir: str | None = None,
+) -> str:
+    """Record a suggestion to update a project document.
+
+    Writes to the suggestions mailbox so the suggestion can be
+    reviewed and applied later.
     """
+    from clarity_agent.ai_actions.suggestion import (
+        record_suggestion as _record,
+    )
+
+    proto_dir = _resolve_protocol_dir(project_dir)
+    _, msg = _record(
+        proto_dir,
+        title=title,
+        target_document=target_document,
+        suggestion=suggestion,
+        source="mcp",
+        rationale=rationale,
+    )
+    return msg
+
+
+# ===================================================================
+# INTERNAL FUNCTIONS (not exposed as MCP tools)
+#
+# These remain importable for desktop/web/CLI modes and for tests,
+# but coding agents don't need them as separate tools.
+# ===================================================================
+
+
+def init_protocol(project_dir: str | None = None) -> str:
+    """Initialize a .clarity-protocol/ directory for a project."""
+    from clarity_agent.protocol.initialize import init_protocol as _init
+
+    proj = _resolve_project_dir(project_dir)
+    created = _init(proj)
+    if created:
+        return f"Initialized clarity protocol at {_resolve_protocol_dir(project_dir)}"
+    return f"Protocol directory already exists at {_resolve_protocol_dir(project_dir)}"
+
+
+def list_protocol_documents(project_dir: str | None = None) -> str:
+    """List all files in the project's .clarity-protocol/ directory tree."""
+    proto_dir = _resolve_protocol_dir(project_dir)
+    if not proto_dir.exists():
+        return "No protocol directory found."
+
+    files: list[str] = []
+    for root, dirs, filenames in os.walk(proto_dir):
+        dirs[:] = [d for d in dirs if not d.startswith((".", "__"))]
+        rel_root = Path(root).relative_to(proto_dir)
+        for f in sorted(filenames):
+            if f.startswith("."):
+                continue
+            rel_path = str(rel_root / f) if str(rel_root) != "." else f
+            files.append(rel_path)
+
+    if not files:
+        return "Protocol directory exists but is empty."
+    return "\n".join(files)
+
+
+def record_packet_status(
+    documents: list[str] | None = None,
+    project_dir: str | None = None,
+) -> str:
+    """Record the current content hashes for protocol documents."""
+    from clarity_agent.protocol.packet_status import record_hashes
+
+    proto_dir = _resolve_protocol_dir(project_dir)
+    if not proto_dir.exists():
+        return "No protocol directory found. Run init_protocol first."
+
+    try:
+        recorded = record_hashes(proto_dir, documents)
+    except (json.JSONDecodeError, OSError) as exc:
+        return f"Error recording packet status: {exc}"
+
+    if not recorded:
+        return "No documents to record (all empty or untracked)."
+    _MAX_LISTED = 5
+    if len(recorded) <= _MAX_LISTED:
+        names = ", ".join(recorded)
+    else:
+        names = ", ".join(recorded[:_MAX_LISTED]) + f" + {len(recorded) - _MAX_LISTED} more"
+    return f"Recorded baselines for {len(recorded)} document(s): {names}"
+
+
+def get_next_action(project_dir: str | None = None) -> str:
+    """Determine what clarity process should be run next."""
+    from clarity_agent.protocol.packet_status import (
+        check_packet_status as _check,
+    )
+    from clarity_agent.protocol.packet_status import (
+        next_action as _next,
+    )
+
+    proto_dir = _resolve_protocol_dir(project_dir)
+    if not proto_dir.exists():
+        return "No protocol directory found. Run init_protocol first."
+
+    report = _check(proto_dir)
+    action = _next(report)
+    if action is None:
+        return "All documents are current. No immediate action needed."
+
+    result = f"**{action.get('document', 'unknown')}**"
+    if action.get("reason"):
+        result += f"\n\n{action['reason']}"
+    if action.get("process"):
+        result += f"\n\nProcess: {action['process']}"
+    return result
+
+
+def list_processes() -> str:
+    """List all available clarity-agent processes."""
     from clarity_agent.process_registry import PROCESS_METADATA
 
     lines: list[str] = []
@@ -509,17 +555,11 @@ def list_processes() -> str:
     return "\n".join(lines)
 
 
-@mcp.tool()
 def read_process_guide(process_name: str) -> str:
-    """Read the full markdown guide for a specific clarity-agent process.
-
-    This contains the step-by-step instructions the AI follows when
-    running the process.
-    """
+    """Read the full markdown guide for a specific clarity-agent process."""
     agent_dir = _resolve_agent_dir()
     guide_path = agent_dir / "processes" / f"{process_name}.md"
     if not guide_path.exists():
-        # Check without .md extension
         if not process_name.endswith(".md"):
             guide_path = agent_dir / "processes" / process_name
         if not guide_path.exists():
@@ -534,13 +574,8 @@ def read_process_guide(process_name: str) -> str:
     return guide_path.read_text(encoding="utf-8")
 
 
-@mcp.tool()
 def list_thinkers() -> str:
-    """List all available specialist thinkers for failure brainstorming.
-
-    Each thinker brings a specific analytical perspective (security,
-    human factors, adversarial, etc.).
-    """
+    """List all available specialist thinkers for failure brainstorming."""
     from clarity_agent.protocol.thinker_registry import discover_thinkers
 
     agent_dir = _resolve_agent_dir()
@@ -555,13 +590,8 @@ def list_thinkers() -> str:
     return "\n".join(lines) if lines else "No thinkers found."
 
 
-@mcp.tool()
 def read_thinker_guide(thinker_name: str) -> str:
-    """Read the full methodology guide for a specialist thinker.
-
-    Use this to apply their analytical framework when brainstorming
-    failures.
-    """
+    """Read the full methodology guide for a specialist thinker."""
     from clarity_agent.ai_actions.brainstorm import (
         read_thinker_guide as _read,
     )
@@ -570,12 +600,8 @@ def read_thinker_guide(thinker_name: str) -> str:
     return _read(agent_dir, thinker_name)
 
 
-@mcp.tool()
 def read_behaviors() -> str:
-    """Read the cross-cutting behavioral guidelines from AGENTS.md.
-
-    These apply to all clarity processes.
-    """
+    """Read the cross-cutting behavioral guidelines from AGENTS.md."""
     agent_dir = _resolve_agent_dir()
     agents_path = agent_dir / "AGENTS.md"
     if not agents_path.exists():
@@ -583,23 +609,13 @@ def read_behaviors() -> str:
     return agents_path.read_text(encoding="utf-8")
 
 
-# ===================================================================
-# SUPPORT TOOLS — Output
-# ===================================================================
-
-
-@mcp.tool()
 def generate_packet(
     output_format: str = "markdown",
     sections: str | None = None,
     view: str | None = None,
     project_dir: str | None = None,
 ) -> str:
-    """Generate a review packet document from protocol content.
-
-    Assembles problem statement, solution, failures, decisions, etc.
-    into a readable document for human reviewers.
-    """
+    """Generate a review packet document from protocol content."""
     from clarity_agent.packet import generate_packet as _generate
 
     proto_dir = _resolve_protocol_dir(project_dir)
@@ -622,11 +638,8 @@ def generate_packet(
         return f"Error generating packet: {e}"
 
 
-@mcp.tool()
 def get_mailbox_status(project_dir: str | None = None) -> str:
-    """Check the status of async operation mailboxes (failure brainstorming
-    results, suggestions, etc.).
-    """
+    """Check the status of async operation mailboxes."""
     from clarity_agent.protocol.packet_status import check_mailbox_status
 
     proto_dir = _resolve_protocol_dir(project_dir)
@@ -646,12 +659,8 @@ def get_mailbox_status(project_dir: str | None = None) -> str:
     return "\n".join(lines)
 
 
-@mcp.tool()
 def check_failure_state(project_dir: str | None = None) -> str:
-    """Check the current state of failure analysis: what phase the project
-    is in (brainstorming, analysis, management) and what the next
-    failure-related step should be.
-    """
+    """Check the current state of failure analysis."""
     from clarity_agent.protocol.failure_state import (
         check_failure_state as _check,
     )
@@ -676,24 +685,11 @@ def check_failure_state(project_dir: str | None = None) -> str:
     return "\n".join(lines)
 
 
-# ===================================================================
-# SUPPORT TOOLS — Mailbox Operations
-# ===================================================================
-
-
-@mcp.tool()
 def snapshot_mailbox(
     name: str,
     project_dir: str | None = None,
 ) -> str:
-    """Freeze a mailbox by moving all items into a timestamped archive snapshot.
-
-    Used at the start of failure-analysis to lock in brainstorming results.
-
-    Args:
-        name: Mailbox name (e.g. "failure-brainstorm").
-        project_dir: Project directory (default: CLARITY_PROJECT_DIR or cwd).
-    """
+    """Freeze a mailbox by moving all items into a timestamped archive snapshot."""
     from clarity_agent.protocol.mailbox import Mailbox, MailboxError
 
     proto_dir = _resolve_protocol_dir(project_dir)
@@ -712,19 +708,11 @@ def snapshot_mailbox(
     return f"Snapshot created: {snapshot_path.name}"
 
 
-@mcp.tool()
 def list_mailbox_items(
     name: str,
     project_dir: str | None = None,
 ) -> str:
-    """List all item filenames in a mailbox.
-
-    Returns one filename per line, suitable for passing to read_mailbox_item.
-
-    Args:
-        name: Mailbox name (e.g. "failure-brainstorm").
-        project_dir: Project directory (default: CLARITY_PROJECT_DIR or cwd).
-    """
+    """List all item filenames in a mailbox."""
     from clarity_agent.protocol.mailbox import Mailbox, MailboxError
 
     proto_dir = _resolve_protocol_dir(project_dir)
@@ -745,22 +733,12 @@ def list_mailbox_items(
     return "\n".join(item.name for item in items)
 
 
-@mcp.tool()
 def read_mailbox_item(
     name: str,
     filename: str,
     project_dir: str | None = None,
 ) -> str:
-    """Read the content of a single mailbox item.
-
-    Also checks the archive snapshot directories if the item is not
-    in the active mailbox.
-
-    Args:
-        name: Mailbox name (e.g. "failure-brainstorm").
-        filename: Item filename (from list_mailbox_items).
-        project_dir: Project directory (default: CLARITY_PROJECT_DIR or cwd).
-    """
+    """Read the content of a single mailbox item."""
     from clarity_agent.protocol.mailbox import Mailbox
 
     proto_dir = _resolve_protocol_dir(project_dir)
@@ -769,12 +747,10 @@ def read_mailbox_item(
 
     mailbox = Mailbox(proto_dir, name)
 
-    # Check active mailbox
     item_path = mailbox.mailbox_dir / filename
     if item_path.is_file():
         return item_path.read_text(encoding="utf-8")
 
-    # Check archive snapshots
     if mailbox.archive_dir.exists():
         for snapshot in sorted(mailbox.archive_dir.iterdir(), reverse=True):
             if snapshot.is_dir():
@@ -785,21 +761,12 @@ def read_mailbox_item(
     return f"Item '{filename}' not found in mailbox '{name}' or its archive."
 
 
-@mcp.tool()
 def archive_mailbox_item(
     name: str,
     filename: str,
     project_dir: str | None = None,
 ) -> str:
-    """Move a single item from the active mailbox to the archive.
-
-    Marks the item as processed so it no longer appears in list_mailbox_items.
-
-    Args:
-        name: Mailbox name (e.g. "failure-brainstorm").
-        filename: Item filename to archive.
-        project_dir: Project directory (default: CLARITY_PROJECT_DIR or cwd).
-    """
+    """Move a single item from the active mailbox to the archive."""
     from clarity_agent.protocol.mailbox import Mailbox, MailboxError
 
     proto_dir = _resolve_protocol_dir(project_dir)
@@ -831,6 +798,23 @@ def project_summary() -> str:
     if not summary_path.exists():
         return "No project summary found."
     return summary_path.read_text(encoding="utf-8")
+
+
+@mcp.resource("clarity://decisions")
+def decisions_resource() -> str:
+    """Read all project decision records concatenated into one document."""
+    proto_dir = _resolve_protocol_dir()
+    decisions_dir = proto_dir / "decisions"
+    if not decisions_dir.exists():
+        return "No decisions directory found."
+
+    parts: list[str] = []
+    for df in sorted(decisions_dir.glob("decision-*.md")):
+        parts.append(df.read_text(encoding="utf-8"))
+
+    if not parts:
+        return "No decision records found."
+    return "\n\n---\n\n".join(parts)
 
 
 @mcp.resource("clarity://behaviors")
@@ -871,7 +855,6 @@ def protocol_document_resource(path: str) -> str:
     """
     proto_dir = _resolve_protocol_dir()
     file_path = (proto_dir / path).resolve()
-    # Path traversal protection
     if not str(file_path).startswith(str(proto_dir.resolve())):
         return "Error: path traversal not allowed."
     if not file_path.exists():

--- a/src/clarity_agent/mcp/server.py
+++ b/src/clarity_agent/mcp/server.py
@@ -28,13 +28,11 @@ from __future__ import annotations
 
 import json
 import os
-import re
 from datetime import datetime, timezone
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
-SLUG_MAX_LENGTH = 40
 DEFAULT_SSE_PORT = 8421
 
 mcp = FastMCP(
@@ -348,6 +346,7 @@ def record_decision(
     """
     from clarity_agent.protocol.packet_status import (
         record_decision as _record_decision,
+        write_decision_file,
     )
 
     proto_dir = _resolve_protocol_dir(project_dir)
@@ -367,24 +366,17 @@ def record_decision(
 
     content = "\n".join(content_parts)
 
-    decisions_dir = proto_dir / "decisions"
-    decisions_dir.mkdir(parents=True, exist_ok=True)
-    existing = sorted(decisions_dir.glob("decision-*.md"))
-    next_num = 1
-    if existing:
-        match = re.search(r"decision-(\d+)", existing[-1].name)
-        if match:
-            next_num = int(match.group(1)) + 1
+    filename, _ = write_decision_file(proto_dir, title, content)
 
-    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:SLUG_MAX_LENGTH]
-    filename = f"decision-{next_num:02d}-{slug}.md"
-    file_path = decisions_dir / filename
-    file_path.write_text(content, encoding="utf-8")
+    # Extract the number prefix for config.json tracking.
+    import re
+    match = re.search(r"decision-(\d+)", filename)
+    decision_id = match.group(1) if match else "01"
 
     try:
         _record_decision(
             proto_dir,
-            decision_id=f"{next_num:02d}",
+            decision_id=decision_id,
             status="decided",
         )
     except Exception as exc:

--- a/src/clarity_agent/mcp/server.py
+++ b/src/clarity_agent/mcp/server.py
@@ -346,6 +346,8 @@ def record_decision(
     """
     from clarity_agent.protocol.packet_status import (
         record_decision as _record_decision,
+    )
+    from clarity_agent.protocol.packet_status import (
         write_decision_file,
     )
 

--- a/src/clarity_agent/protocol/packet_status.py
+++ b/src/clarity_agent/protocol/packet_status.py
@@ -735,6 +735,44 @@ def record_decision(
     save_config(protocol_dir, config)
 
 
+def write_decision_file(
+    protocol_dir: Path,
+    title: str,
+    content: str,
+    slug_max_length: int = 40,
+) -> tuple[str, Path]:
+    """Create a numbered decision file in the decisions/ directory.
+
+    Handles filename generation (numbering, slug) so all UI surfaces
+    get consistent behavior.
+
+    Args:
+        protocol_dir: Path to the .clarity-protocol/ directory.
+        title: Human-readable decision title (used for slug).
+        content: Full markdown content to write.
+        slug_max_length: Maximum length of the slug portion.
+
+    Returns:
+        Tuple of (filename, full_path) for the created file.
+    """
+    import re
+
+    decisions_dir = protocol_dir / "decisions"
+    decisions_dir.mkdir(parents=True, exist_ok=True)
+    existing = sorted(decisions_dir.glob("decision-*.md"))
+    next_num = 1
+    if existing:
+        match = re.search(r"decision-(\d+)", existing[-1].name)
+        if match:
+            next_num = int(match.group(1)) + 1
+
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:slug_max_length]
+    filename = f"decision-{next_num:02d}-{slug}.md"
+    file_path = decisions_dir / filename
+    file_path.write_text(content, encoding="utf-8")
+    return filename, file_path
+
+
 def next_action(report: PacketStatusReport) -> NextAction | None:
     """Walk the dependency graph and return the first document needing attention.
 

--- a/src/clarity_agent/setup/project.py
+++ b/src/clarity_agent/setup/project.py
@@ -247,6 +247,7 @@ def run_project_embed(
 
     _record(insert_agent_snippet(project_dir, agent_dir))
     _record(create_project_wrapper(project_dir, agent_dir))
+    _record(create_mcp_json(project_dir, agent_dir))
     for r in update_gitignore(project_dir):
         _record(r)
 

--- a/src/clarity_agent/setup/snippet.md
+++ b/src/clarity_agent/setup/snippet.md
@@ -27,5 +27,5 @@ documents are stale, read them with `read_protocol_document`, update with
 `write_protocol_document`.
 
 Record significant architectural choices with `record_decision`.
-Drop risks you notice with `record_failure`.
+Add risks you notice with `record_failure`.
 <!-- clarity-end -->

--- a/src/clarity_agent/setup/snippet.md
+++ b/src/clarity_agent/setup/snippet.md
@@ -7,28 +7,25 @@ thinking about problems, solutions, and failure modes.
 **Before building — think when it matters.** Two triggers:
 
 1. *The user asks.* When they want to explore what to build, clarify
-   requirements, brainstorm risks, or work through a decision — read and
-   follow `{{PROCESSES_DIR}}/clarity-agent.md`.
+   requirements, brainstorm risks, or work through a decision, call
+   `run_clarity` to assess project state and get the relevant process guide.
 
 2. *You recognize an inflection point.* Before making choices that would be
    expensive to reverse — new services, auth/trust models, data schemas,
-   external integrations, significant API contracts — check
-   `.clarity-protocol/` for existing decisions and context. If a relevant
-   decision exists, follow it. If the choice contradicts existing requirements
-   or architecture, surface the conflict before proceeding. If nothing exists
-   and the choice is consequential, offer to think it through:
-   "This is a significant architectural choice — want to spend a minute
-   thinking through alternatives and risks before I build it?"
+   external integrations, significant API contracts — call `check_decision`
+   with a description of what you plan to do. It returns existing decisions,
+   requirements, and architecture so you can check for conflicts.
 
    Don't interrupt for routine implementation. The test: "If this turns out
    wrong, is it a 5-minute fix or a multi-day rework?" Interrupt for the
    latter.
 
 **After building — keep the record current.** After completing significant
-implementation work (new features, architectural changes), check whether
-protocol documents need updating:
+implementation work (new features, architectural changes), call
+`get_packet_status` to check if protocol documents need updating. If
+documents are stale, read them with `read_protocol_document`, update with
+`write_protocol_document`.
 
-1. Run: `python -m clarity_agent.protocol.packet_status . --agent`
-2. Update documents the tool identifies as stale or inaccurate
-3. Record: `python -m clarity_agent.protocol.packet_status . --record <docs>`
+Record significant architectural choices with `record_decision`.
+Drop risks you notice with `record_failure`.
 <!-- clarity-end -->

--- a/tests/test_init_protocol.py
+++ b/tests/test_init_protocol.py
@@ -195,17 +195,18 @@ class TestSnippetInsertion:
         assert "# Custom agents config" in content
         assert BEGIN_DELIMITER in content
 
-    def test_substitutes_processes_dir(self, tmp_path: Path) -> None:
+    def test_snippet_references_mcp_tools(self, tmp_path: Path) -> None:
+        """The snippet should reference MCP tool names, not CLI commands."""
         project = tmp_path / "project"
         project.mkdir()
-        # Simulate embedded install.
         (project / ".clarity-agent").mkdir()
 
         init_protocol(project, clarity_agent_dir=Path(__file__).resolve().parent.parent)
 
         from clarity_agent.setup.snippet import find_target
         content = find_target(project).read_text()
-        assert ".clarity-agent/processes/clarity-agent.md" in content
+        assert "run_clarity" in content
+        assert "check_decision" in content
         assert "{{PROCESSES_DIR}}" not in content
 
     def test_no_snippet_without_clarity_agent_dir(self, tmp_path: Path) -> None:

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -819,12 +819,14 @@ class TestInsertAgentSnippet:
         assert "already" in r.message.lower()
         assert (tmp_path / "AGENTS.md").read_text() == first
 
-    def test_substitutes_processes_dir(self, tmp_path: Path) -> None:
+    def test_snippet_references_mcp_tools(self, tmp_path: Path) -> None:
+        """The snippet should reference MCP tool names, not CLI commands."""
         agent = tmp_path / CLARITY_DIR
         agent.mkdir()
         insert_agent_snippet(tmp_path, agent)
         content = (tmp_path / "AGENTS.md").read_text()
-        assert f"{CLARITY_DIR}/processes/clarity-agent.md" in content
+        assert "run_clarity" in content
+        assert "check_decision" in content
         assert "{{PROCESSES_DIR}}" not in content
 
     def test_skip_when_no_template(self, tmp_path: Path) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -46,22 +46,36 @@ def _set_project_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 # ---------------------------------------------------------------------------
 
 def test_all_tools_registered() -> None:
-    """All expected tools should be registered in the MCP server."""
+    """All expected MCP tools should be registered."""
     from clarity_agent.mcp.server import mcp
 
     tool_names = {t.name for t in mcp._tool_manager.list_tools()}
     expected = {
         "run_clarity",
-        "init_protocol",
-        "list_protocol_documents",
+        "check_decision",
+        "get_packet_status",
         "read_protocol_document",
         "write_protocol_document",
-        "get_packet_status",
-        "record_packet_status",
-        "get_next_action",
+        "record_decision",
         "record_failure",
         "record_suggestion",
-        "record_decision",
+    }
+    assert expected == tool_names, (
+        f"Missing tools: {expected - tool_names}\n"
+        f"Extra tools: {tool_names - expected}"
+    )
+
+
+def test_no_internal_tools_exposed() -> None:
+    """Internal functions should NOT be registered as MCP tools."""
+    from clarity_agent.mcp.server import mcp
+
+    tool_names = {t.name for t in mcp._tool_manager.list_tools()}
+    internal = {
+        "init_protocol",
+        "list_protocol_documents",
+        "record_packet_status",
+        "get_next_action",
         "list_processes",
         "read_process_guide",
         "list_thinkers",
@@ -75,7 +89,8 @@ def test_all_tools_registered() -> None:
         "read_mailbox_item",
         "archive_mailbox_item",
     }
-    assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"
+    leaked = internal & tool_names
+    assert not leaked, f"Internal functions leaked as MCP tools: {leaked}"
 
 
 def test_resources_registered() -> None:
@@ -84,6 +99,7 @@ def test_resources_registered() -> None:
 
     resource_names = {r.name for r in mcp._resource_manager.list_resources()}
     assert "project_summary" in resource_names
+    assert "decisions_resource" in resource_names
     assert "behaviors_resource" in resource_names
 
     template_names = {t.name for t in mcp._resource_manager.list_templates()}
@@ -93,39 +109,84 @@ def test_resources_registered() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Tool function tests (direct calls, no MCP transport)
+# MCP Tool function tests
 # ---------------------------------------------------------------------------
 
-class TestInitProtocol:
-    def test_creates_protocol_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(tmp_path))
-        from clarity_agent.mcp.server import init_protocol
-        result = init_protocol()
-        assert "Initialized" in result or "already exists" in result
-        # Protocol directory should exist
-        from clarity_agent.app_paths import protocol_dir
-        assert protocol_dir(tmp_path).exists()
+class TestRunClarity:
+    def test_new_project(self, empty_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(empty_project))
+        from clarity_agent.mcp.server import run_clarity
+        result = run_clarity()
+        assert "New Project" in result
 
-    def test_idempotent(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_existing_project(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
-        from clarity_agent.mcp.server import init_protocol
-        result = init_protocol()
-        # Second init should succeed (idempotent) — may say "Initialized" or "already exists"
-        assert "Initialized" in result or "already exists" in result
+        from clarity_agent.mcp.server import run_clarity
+        result = run_clarity()
+        assert "New Project" not in result
+
+    def test_inlines_process_guide(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When a next action has a process, the guide content is inlined."""
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
+        from clarity_agent.mcp.server import run_clarity
+        result = run_clarity()
+        if "Process Guide:" in result:
+            assert "##" in result
 
 
-class TestListProtocolDocuments:
+class TestCheckDecision:
     def test_no_protocol(self, empty_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(empty_project))
-        from clarity_agent.mcp.server import list_protocol_documents
-        result = list_protocol_documents()
+        from clarity_agent.mcp.server import check_decision
+        result = check_decision("Add a new database")
         assert "No protocol" in result
 
-    def test_lists_files(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_context(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
-        from clarity_agent.mcp.server import list_protocol_documents
-        result = list_protocol_documents()
-        assert "config.json" in result
+        from clarity_agent.mcp.server import check_decision, write_protocol_document
+        write_protocol_document("goal/requirements.md", "# Requirements\n\nMust be fast.")
+        result = check_decision("Switch to a slow database")
+        assert "Requirements" in result
+        assert "Proposed Change" in result
+
+    def test_with_decisions(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
+        from clarity_agent.mcp.server import check_decision, record_decision
+        record_decision(
+            title="Use PostgreSQL",
+            context="Need a database.",
+            decision="Use PostgreSQL.",
+            rationale="Battle-tested.",
+        )
+        result = check_decision("Switch to MongoDB")
+        assert "Existing Decisions" in result
+
+    def test_empty_protocol(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
+        from clarity_agent.mcp.server import check_decision
+        result = check_decision("Add a cache layer")
+        assert "No decisions" in result or "Proceed" in result
+
+
+class TestGetPacketStatus:
+    def test_no_protocol(self, empty_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(empty_project))
+        from clarity_agent.mcp.server import get_packet_status
+        result = get_packet_status()
+        assert "No protocol" in result
+
+    def test_returns_report(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
+        from clarity_agent.mcp.server import get_packet_status
+        result = get_packet_status()
+        assert "Packet Status" in result or "empty" in result.lower() or "missing" in result.lower()
+
+    def test_json_format(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
+        from clarity_agent.mcp.server import get_packet_status
+        result = get_packet_status(output_format="json")
+        parsed = json.loads(result)
+        assert "documents" in parsed
 
 
 class TestReadWriteProtocolDocument:
@@ -151,82 +212,30 @@ class TestReadWriteProtocolDocument:
         result = read_protocol_document("../../etc/passwd")
         assert "traversal" in result.lower()
 
-
-class TestGetPacketStatus:
-    def test_no_protocol(self, empty_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(empty_project))
-        from clarity_agent.mcp.server import get_packet_status
-        result = get_packet_status()
-        assert "No protocol" in result
-
-    def test_returns_report(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_write_auto_records_hashes(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Writing a protocol document should auto-record its content hash."""
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
-        from clarity_agent.mcp.server import get_packet_status
-        result = get_packet_status()
-        assert "Packet Status" in result or "empty" in result.lower() or "missing" in result.lower()
+        from clarity_agent.mcp.server import write_protocol_document
+        write_protocol_document("goal/problem.md", "# Real Problem\n\nA real problem statement.")
+        from clarity_agent.app_paths import protocol_dir
+        from clarity_agent.protocol.packet_status import load_config
+        config = load_config(protocol_dir(initialized_project))
+        state = config.get("documentState", {})
+        assert "goal/problem.md" in state
 
-    def test_json_format(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+
+class TestRecordDecision:
+    def test_records_decision(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
-        from clarity_agent.mcp.server import get_packet_status
-        result = get_packet_status(output_format="json")
-        parsed = json.loads(result)
-        assert "documents" in parsed
-
-
-class TestRunClarity:
-    def test_new_project(self, empty_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(empty_project))
-        from clarity_agent.mcp.server import run_clarity
-        result = run_clarity()
-        assert "New Project" in result
-
-    def test_existing_project(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
-        from clarity_agent.mcp.server import run_clarity
-        result = run_clarity()
-        # Should contain status information, not "New Project"
-        assert "New Project" not in result
-
-
-class TestListProcesses:
-    def test_returns_processes(self) -> None:
-        from clarity_agent.mcp.server import list_processes
-        result = list_processes()
-        assert "problem-clarification" in result
-        assert "failure-brainstorming" in result
-
-
-class TestReadProcessGuide:
-    def test_existing_process(self) -> None:
-        from clarity_agent.mcp.server import read_process_guide
-        result = read_process_guide("clarity-agent")
-        assert "Clarity Agent" in result
-
-    def test_nonexistent_process(self) -> None:
-        from clarity_agent.mcp.server import read_process_guide
-        result = read_process_guide("nonexistent-process")
-        assert "not found" in result.lower()
-
-
-class TestListThinkers:
-    def test_returns_thinkers(self, agent_dir: Path) -> None:
-        """Thinkers should be discoverable when agent_dir resolves correctly."""
-        from clarity_agent.mcp.server import list_thinkers
-        result = list_thinkers()
-        # Thinkers may not be found if get_bundle_dir doesn't resolve to repo root
-        # in the test environment — accept either outcome
-        assert (
-            "general" in result.lower()
-            or "security" in result.lower()
-            or "No thinkers" in result
+        from clarity_agent.mcp.server import record_decision
+        result = record_decision(
+            title="Use Python for MCP server",
+            context="Need to choose implementation language.",
+            decision="Use Python with FastMCP.",
+            rationale="Existing codebase is Python.",
         )
-
-
-class TestReadBehaviors:
-    def test_returns_agents_md(self) -> None:
-        from clarity_agent.mcp.server import read_behaviors
-        result = read_behaviors()
-        assert "Behaviors" in result
+        assert "Recorded decision" in result
+        assert "decisions/" in result
 
 
 class TestRecordFailure:
@@ -252,18 +261,76 @@ class TestRecordSuggestion:
         assert "Recorded suggestion" in result
 
 
-class TestRecordDecision:
-    def test_records_decision(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+# ---------------------------------------------------------------------------
+# Internal function tests (not MCP tools, but still callable)
+# ---------------------------------------------------------------------------
+
+class TestInitProtocol:
+    def test_creates_protocol_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(tmp_path))
+        from clarity_agent.mcp.server import init_protocol
+        result = init_protocol()
+        assert "Initialized" in result or "already exists" in result
+        from clarity_agent.app_paths import protocol_dir
+        assert protocol_dir(tmp_path).exists()
+
+    def test_idempotent(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
-        from clarity_agent.mcp.server import record_decision
-        result = record_decision(
-            title="Use Python for MCP server",
-            context="Need to choose implementation language.",
-            decision="Use Python with FastMCP.",
-            rationale="Existing codebase is Python.",
+        from clarity_agent.mcp.server import init_protocol
+        result = init_protocol()
+        assert "Initialized" in result or "already exists" in result
+
+
+class TestListProtocolDocuments:
+    def test_no_protocol(self, empty_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(empty_project))
+        from clarity_agent.mcp.server import list_protocol_documents
+        result = list_protocol_documents()
+        assert "No protocol" in result
+
+    def test_lists_files(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
+        from clarity_agent.mcp.server import list_protocol_documents
+        result = list_protocol_documents()
+        assert "config.json" in result
+
+
+class TestListProcesses:
+    def test_returns_processes(self) -> None:
+        from clarity_agent.mcp.server import list_processes
+        result = list_processes()
+        assert "problem-clarification" in result
+        assert "failure-brainstorming" in result
+
+
+class TestReadProcessGuide:
+    def test_existing_process(self) -> None:
+        from clarity_agent.mcp.server import read_process_guide
+        result = read_process_guide("clarity-agent")
+        assert "Clarity Agent" in result
+
+    def test_nonexistent_process(self) -> None:
+        from clarity_agent.mcp.server import read_process_guide
+        result = read_process_guide("nonexistent-process")
+        assert "not found" in result.lower()
+
+
+class TestListThinkers:
+    def test_returns_thinkers(self, agent_dir: Path) -> None:
+        from clarity_agent.mcp.server import list_thinkers
+        result = list_thinkers()
+        assert (
+            "general" in result.lower()
+            or "security" in result.lower()
+            or "No thinkers" in result
         )
-        assert "Recorded decision" in result
-        assert "decisions/" in result
+
+
+class TestReadBehaviors:
+    def test_returns_agents_md(self) -> None:
+        from clarity_agent.mcp.server import read_behaviors
+        result = read_behaviors()
+        assert "Behaviors" in result
 
 
 class TestGeneratePacket:
@@ -275,11 +342,9 @@ class TestGeneratePacket:
 
     def test_generates_markdown(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
-        # Write some content first
         from clarity_agent.mcp.server import generate_packet, write_protocol_document
         write_protocol_document("goal/problem.md", "# Test Problem\n\nA real problem.")
         result = generate_packet()
-        # Should return markdown content or indicate empty packet
         assert isinstance(result, str)
 
 
@@ -328,21 +393,18 @@ class TestRecordPacketStatus:
 
 class TestSnapshotMailbox:
     def test_no_protocol(self, empty_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Returns error when no protocol directory exists."""
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(empty_project))
         from clarity_agent.mcp.server import snapshot_mailbox
         result = snapshot_mailbox("failure-brainstorm")
         assert "No protocol" in result
 
     def test_nonexistent_mailbox(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Returns error for a mailbox that does not exist."""
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
         from clarity_agent.mcp.server import snapshot_mailbox
         result = snapshot_mailbox("nonexistent")
         assert "does not exist" in result
 
     def test_snapshots_mailbox(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Creates a snapshot and empties the mailbox."""
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
         from clarity_agent.mcp.server import record_failure, snapshot_mailbox
         record_failure(title="Test fail", description="desc")
@@ -352,14 +414,12 @@ class TestSnapshotMailbox:
 
 class TestListMailboxItems:
     def test_no_protocol(self, empty_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Returns error when no protocol directory exists."""
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(empty_project))
         from clarity_agent.mcp.server import list_mailbox_items
         result = list_mailbox_items("failure-brainstorm")
         assert "No protocol" in result
 
     def test_empty_mailbox(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Returns empty message for a mailbox with no items."""
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
         from clarity_agent.app_paths import protocol_dir
         from clarity_agent.protocol.mailbox import Mailbox
@@ -370,7 +430,6 @@ class TestListMailboxItems:
         assert "empty" in result.lower()
 
     def test_lists_items(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Lists item filenames after recording failures."""
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
         from clarity_agent.mcp.server import list_mailbox_items, record_failure
         record_failure(title="Fail one", description="desc")
@@ -380,14 +439,12 @@ class TestListMailboxItems:
 
 class TestReadMailboxItem:
     def test_no_protocol(self, empty_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Returns error when no protocol directory exists."""
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(empty_project))
         from clarity_agent.mcp.server import read_mailbox_item
         result = read_mailbox_item("failure-brainstorm", "nonexistent.md")
         assert "No protocol" in result
 
     def test_reads_item(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Reads the content of a mailbox item."""
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
         from clarity_agent.mcp.server import list_mailbox_items, read_mailbox_item, record_failure
         record_failure(title="Read test", description="readable content")
@@ -397,7 +454,6 @@ class TestReadMailboxItem:
         assert "readable content" in content
 
     def test_reads_from_archive(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Reads items from archive snapshots."""
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
         from clarity_agent.mcp.server import (
             list_mailbox_items,
@@ -413,7 +469,6 @@ class TestReadMailboxItem:
         assert "archived content" in content
 
     def test_not_found(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Returns error for nonexistent item."""
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
         from clarity_agent.mcp.server import read_mailbox_item, record_failure
         record_failure(title="x", description="y")
@@ -423,14 +478,12 @@ class TestReadMailboxItem:
 
 class TestArchiveMailboxItem:
     def test_no_protocol(self, empty_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Returns error when no protocol directory exists."""
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(empty_project))
         from clarity_agent.mcp.server import archive_mailbox_item
         result = archive_mailbox_item("failure-brainstorm", "x.md")
         assert "No protocol" in result
 
     def test_archives_item(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Archives an item and removes it from the active mailbox."""
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
         from clarity_agent.mcp.server import (
             archive_mailbox_item,

--- a/tests/test_snippet.py
+++ b/tests/test_snippet.py
@@ -23,9 +23,11 @@ class TestSnippetPath:
 
 
 class TestRenderSnippet:
-    def test_substitutes_processes_dir(self) -> None:
+    def test_render_produces_valid_snippet(self) -> None:
+        """render_snippet returns the snippet content with delimiters."""
         result = render_snippet(".clarity-agent/processes")
-        assert ".clarity-agent/processes/clarity-agent.md" in result
+        assert "run_clarity" in result
+        assert "check_decision" in result
         assert "{{PROCESSES_DIR}}" not in result
 
     def test_preserves_delimiters(self) -> None:


### PR DESCRIPTION
## Summary

Simplifies the Clarity MCP server tool surface from broad internal API exposure to a focused set of agent-facing protocol tools.

## Changes

- Exposes 8 MCP tools centered on agent workflow:
  - `run_clarity`
  - `check_decision`
  - `get_packet_status`
  - `read_protocol_document`
  - `write_protocol_document`
  - `record_decision`
  - `record_failure`
  - `record_suggestion`
- Keeps internal helpers callable in Python but no longer exposes them as MCP tools.
- Adds `check_decision` for pre-implementation conflict checks against requirements, architecture, and existing decisions.
- Wires MCP config creation into project embed setup.
- Updates the embedded Clarity snippet so agents know when to call MCP tools.
- Updates MCP README and tests to match the slimmer surface.

## Why

Coding agents need a small, clear set of tools that guide when to think, check decisions, record meaningful context, and keep protocol docs current. Exposing internal protocol utilities as MCP tools makes the server harder to understand and easier to misuse.

## Validation

- `tests/test_mcp_server.py` verifies the exposed tool set, resource registration, and core tool behavior.
- Using on projects at work and ran through test invocations on a test project.
