### PR TITLE
fix: use 127.0.0.1 instead of localhost for sidecar health check

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -551,7 +551,7 @@ fn main() {
 
                 // ---- Wait for server, then navigate ----
                 let window = app.get_webview_window("main").expect("no main window");
-                let server_url = format!("http://localhost:{}", port);
+                let server_url = format!("http://127.0.0.1:{}", port);
 
                 std::thread::spawn(move || {
                     let mut log_poll = open_startup_log();


### PR DESCRIPTION
My first beta tester (Toby) for the properly signed Windows installer found a real bug! Check this out:

<img width="677" height="158" alt="Screenshot 2026-05-13 121838" src="https://github.com/user-attachments/assets/fb6a38b7-4fdf-4826-9543-55bd9139d5dd" />

On Windows machines where localhost resolves to ::1 (IPv6), the Tauri health check connects via IPv6 while uvicorn binds only to 127.0.0.1 (IPv4). The TCP handshake succeeds through Windows dual-stack networking but no HTTP response arrives, causing the app to spin on 'getting things ready' until the 30s timeout.

Use the explicit IPv4 address to match what uvicorn actually binds to.