### PR TITLE
fix: move default projects dir to ~/clarity-projects

### DIFF
--- a/src/clarity_agent/app_paths.py
+++ b/src/clarity_agent/app_paths.py
@@ -90,13 +90,14 @@ def clarity_env_path() -> Path:
 def clarity_projects_dir() -> Path:
     """Return the default directory for user project workspaces.
 
-    Always ``~/Clarity Projects/`` — project directories are the user's
-    documents and survive uninstall on all platforms.
+    Uses ``~/clarity-projects/`` on all platforms.  This lives directly
+    under the home directory rather than inside ``~/Documents/`` to
+    avoid triggering macOS TCC prompts for Documents folder access —
+    the app should request only the permissions it actually needs.
+
+    Project directories are the user's documents and survive uninstall.
     """
-    if sys.platform == "darwin" or sys.platform == "win32":
-        return Path.home() / "Documents" / "Clarity Projects"
-    else:
-        return Path.home() / "Clarity Projects"
+    return Path.home() / "clarity-projects"
 
 
 # The two possible names for the protocol directory.


### PR DESCRIPTION
On macOS, ~/Documents/Clarity Projects triggers a TCC prompt for full Documents folder access. Moving to ~/clarity-projects avoids the overpermissioning — the app only needs access to its own directory, not all of Documents.

Consistent path on all platforms now (was platform-conditional).

This will cause existing Windows installation to change new projects from ~/documents/Clarity Projects to ~/Clarity Projects. Any existing projects (recorded in projects.json) will continue to be accessible, but now new projects will go to /~Clarity Projects unless explicitly pointed elsewhere. 