### PR TITLE
Issue 41: protocol tree shows flat list on Windows

### DIFF
--- a/src/clarity_agent/web/app.py
+++ b/src/clarity_agent/web/app.py
@@ -397,7 +397,7 @@ def create_app(
             for f in sorted(files):
                 if f.startswith("."):
                     continue
-                rel_path = str(rel_root / f) if str(rel_root) != "." else f
+                rel_path = (rel_root / f).as_posix() if str(rel_root) != "." else f
                 tree.append({"path": rel_path, "name": f})
         tree.sort(key=lambda item: _dir_sort_key(item["path"]))
         return {"exists": True, "tree": tree}


### PR DESCRIPTION
Path.relative_to() / filename produces backslash separators on Windows (e.g. 'failures\failure-01-foo.md'). The frontend splits on '/' only, so every file falls into the root group and the tree renders as a flat list instead of folders.

Use .as_posix() to always emit forward slashes in the JSON response.

<img width="376" height="1145" alt="Screenshot 2026-05-15 134556" src="https://github.com/user-attachments/assets/b62bfea3-b826-4225-8688-701faf8db725" />
