### PR TITLE
Update README.md and CONTRIBUTING.md to prep for the release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Clarity Agent: Developer Guide
 
+Join the [Clarity Agent Discord](https://aka.ms/clarity-agent-community) to talk with the team, share feedback, and connect with the community.
+
 This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
 
 When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repositories using our CLA.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ cd clarity-agent
 uv sync --all-extras
 ```
 
-Prerequisites: **Python 3.10+**, **Node.js 18+** (for frontend development only), **git**, and credentials for at least one supported LLM backend (see "LLM backends" below).
+Prerequisites: **uv** (install with `curl -LsSf https://astral.sh/uv/install.sh | sh` or see [uv docs](https://docs.astral.sh/uv/getting-started/installation/)), **Node.js 18+** (for frontend development only), **git**, and credentials for at least one supported LLM backend (see "LLM backends" below). uv manages Python itself — no separate Python install required.
 
 ```bash
 # Authenticate (see "LLM backends" below for all options)
@@ -117,24 +117,28 @@ The web UI (`--web` flag) is a FastAPI server that exposes the same `ClaritySess
 
 ### LLM backends are pluggable
 
-The `src/clarity_agent/llm/` package abstracts all LLM interaction behind two interfaces: `LLMClient` (low-level completions) and `ChatBackend` (multi-turn conversations with tool use). Four providers are supported:
+The `src/clarity_agent/llm/` package abstracts all LLM interaction behind two interfaces: `LLMClient` (low-level completions) and `ChatBackend` (multi-turn conversations with tool use). Five providers are supported:
 
 | Provider | `--provider` flag | API key env var | Notes |
 | --- | --- | --- | --- |
-| **Anthropic API** | `anthropic` | `ANTHROPIC_API_KEY` | Direct API access with tool use. |
+| **Anthropic** | `anthropic` | `ANTHROPIC_API_KEY` | Default auth uses `claude login` (`--auth-mode claude_sdk`); use `--auth-mode api_key` for direct API access. |
 | **Azure AI Inference** | `azure` | `AZURE_AI_API_KEY` | Also requires `--endpoint` or `AZURE_AI_ENDPOINT`. |
 | **OpenAI** | `openai` | `OPENAI_API_KEY` | Tool definitions translated from Anthropic format. |
-| **Claude SDK** | `claude-sdk` (default) | None — uses `claude login` | Uses the Claude CLI for authentication. |
+| **GitHub Copilot** | `github` | `GITHUB_TOKEN` | Also supports zero-config via `gh auth login` (`--auth-mode gh_cli`). |
+| **Google Gemini** | `gemini` | `GEMINI_API_KEY` | API key from [Google AI Studio](https://aistudio.google.com/apikey). |
 
 Select a provider with `--provider`:
 
 ```bash
 ./clarity ./my-project --provider anthropic
+./clarity ./my-project --provider anthropic --auth-mode api_key  # use API key instead of claude login
 ./clarity ./my-project --provider openai --model gpt-4o
 ./clarity ./my-project --provider azure --endpoint https://your-deployment.inference.ai.azure.com
+./clarity ./my-project --provider github
+./clarity ./my-project --provider gemini
 ```
 
-The default model for all providers is `claude-sonnet-4-5-20250929`; override with `--model`.
+Each provider resolves its default model from provider-specific tier defaults (defined as `*_TIER_DEFAULTS` in `llm/impl/`), which can be overridden via settings, environment variables, or the `--model` flag.
 
 **Architecture:** `LLMConfig` (in `llm/config.py`) resolves provider, API key, model, and endpoint from CLI flags and environment variables. `create_chat_backend()` (in `llm/factory.py`) instantiates the correct backend. `ClaritySession` accepts any `ChatBackend` and doesn't know which provider is behind it.
 
@@ -214,7 +218,7 @@ The "standard library." Called by process guides and by clarity CLI.
 | `llm/chat.py` | `ChatBackend` abstract interface for multi-turn LLM conversations with tool use. |
 | `llm/client.py` | `LLMClient` abstract interface for low-level completions. |
 | `llm/types.py` | Shared type definitions (tool schemas, message types). |
-| `llm/impl/` | Provider implementations: `anthropic.py`, `claude_sdk.py`, `openai.py`, `azure_inference.py`. |
+| `llm/impl/` | Provider implementations: `anthropic.py`, `claude_sdk.py`, `openai.py`, `azure_inference.py`, `github_copilot.py`, `gemini.py`. |
 | `packet/` | Review packet generation — assembles protocol content into Markdown or Word documents. |
 | `web/app.py` | FastAPI application — WebSocket chat endpoint and REST API for protocol data. |
 | `web/session_manager.py` | Bridges sync `ClaritySession` to async WebSocket via `ThreadPoolExecutor`. |

--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ Clarity was designed with the following principles in mind.
 **Tool-agnostic core.** Process guides are plain markdown that any LLM can follow. Swapping tools doesn't mean starting over.
 
 
+## Community
+
+Join the [Clarity Agent Discord](https://aka.ms/clarity-agent-community) to share feedback, ask questions, and connect with the team and other users.
+
 ## Contributing
 
 Contributions are welcome, especially:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can also join the [Clarity Agent Discord](https://aka.ms/clarity-agent-commu
 
 **Download the desktop app** (no terminal required):
 
-Download the latest `.dmg` (macOS), `.exe` installer (Windows), or `.AppImage` (Linux) from the [GitHub Releases page](https://github.com/microsoft/clarity-agent/releases/latest) and install it directly. No prerequisites.
+Download the latest `.dmg` (macOS) or `.exe` installer (Windows) from the [GitHub Releases page](https://github.com/microsoft/clarity-agent/releases/latest) and install it directly. No prerequisites.
 
 **Or install via script** (adds the `clarity` CLI and embeds Clarity into git repos):
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ bash scripts/install.sh        # macOS / Linux
 
 ### Launch and connect an LLM
 
-**macOS:** Open `~/Applications/Clarity.app` (downloaded installer) or `Clarity.app` from wherever you installed it.
+**macOS:** Open `Clarity.app` from `~/Applications`.
 
 **Windows:** Run the installed app from the Start Menu, or run `clarity` from your terminal if you used the script installer.
 
-**Linux:** Run the `.AppImage` directly, or run `clarity` from your terminal if you used the script installer.
+**Linux:** Run `clarity` from your terminal.
 
 On first launch, the setup wizard walks you through connecting an LLM provider.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Clarity runs as a desktop app, a web UI, or embedded in your coding agent. It pr
 
 Read more about the philosophy behind clarity agent [in this blog post](https://medium.com/@yonatanzunger/are-we-building-the-right-ai-203cfc7effdc).
 
+You can also join the [Clarity Agent Discord](https://aka.ms/clarity-agent-community) to talk with the team, share feedback, and connect with the community.
+
 ## Getting Started
 
 ### Install
@@ -176,10 +178,6 @@ Clarity was designed with the following principles in mind.
 
 **Tool-agnostic core.** Process guides are plain markdown that any LLM can follow. Swapping tools doesn't mean starting over.
 
-
-## Community
-
-Join the [Clarity Agent Discord](https://aka.ms/clarity-agent-community) to share feedback, ask questions, and connect with the team and other users.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,19 @@ Read more about the philosophy behind clarity agent [in this blog post](https://
 
 ### Install
 
-**macOS / Linux:**
+**Download the desktop app** (no terminal required):
+
+Download the latest `.dmg` (macOS), `.exe` installer (Windows), or `.AppImage` (Linux) from the [GitHub Releases page](https://github.com/microsoft/clarity-agent/releases/latest) and install it directly. No prerequisites.
+
+**Or install via script** (adds the `clarity` CLI and embeds Clarity into git repos):
+
+*macOS / Linux:*
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/microsoft/clarity-agent/main/scripts/install.sh | bash
 ```
 
-**Windows (PowerShell):**
+*Windows (PowerShell):*
 
 ```powershell
 irm https://raw.githubusercontent.com/microsoft/clarity-agent/main/scripts/install.ps1 | iex
@@ -46,9 +52,11 @@ bash scripts/install.sh        # macOS / Linux
 
 ### Launch and connect an LLM
 
-**macOS:** Open `~/Applications/Clarity.app`
+**macOS:** Open `~/Applications/Clarity.app` (downloaded installer) or `Clarity.app` from wherever you installed it.
 
-**Linux / Windows:** Run `clarity` from your terminal or Start Menu.
+**Windows:** Run the installed app from the Start Menu, or run `clarity` from your terminal if you used the script installer.
+
+**Linux:** Run the `.AppImage` directly, or run `clarity` from your terminal if you used the script installer.
 
 On first launch, the setup wizard walks you through connecting an LLM provider.
 
@@ -102,13 +110,17 @@ A `.clarity-protocol/` directory:
 .clarity-protocol/
 ├── summary.md              # Brief summary of what this project is
 ├── notes.md                # Principles and cross-cutting observations
+├── observations.md         # Patterns and coverage notes from analysis
 ├── goal/
 │   ├── problem.md          # What you're trying to achieve and why
 │   ├── stakeholders.md     # Who cares about the outcome
-│   └── requirements.md     # Criteria any solution must satisfy
+│   ├── requirements.md     # Criteria any solution must satisfy
+│   ├── open-questions.md   # Unknowns that could change the approach
+│   └── resolved-questions.md # Questions answered, with findings
 ├── solution/
 │   ├── solution.md         # What you plan to build
-│   └── architecture.md     # How you plan to build it
+│   ├── architecture.md     # How you plan to build it
+│   └── solution-summary.md # Concise overview for stakeholders
 ├── failures/
 │   └── failures.md         # Failure modes, chains, and management plans
 ├── decisions/
@@ -137,9 +149,9 @@ See [Responsible AI FAQ](AIFAQ.md) for detailed information about intended uses,
 ## CLI Reference
 
 ```text
-clarity                            Launch desktop app
-clarity app                        Same, explicit
+clarity                            Launch web UI (default)
 clarity web [project_dir]          Headless web server
+clarity app                        Launch desktop app
 clarity cli [project_dir]          Interactive terminal session
 clarity process NAME [project_dir] Run a single process by name
 clarity packet [project_dir]       Generate a review packet


### PR DESCRIPTION
README — 
1. Added GitHub releases download as the primary install path for the desktop app (no terminal required), ahead of the curl/script install. 
2. Expanded per-platform launch instructions to distinguish app-download users from script-install users.
3. Added links to the discord.

CONTRIBUTING.md — 
1. LLM backends table and llm/impl/ file listing both updated from 4 providers to 6 (added GitHub Copilot and Gemini). 
2. Added uv install instructions (previously assumed uv was already present). Removed hardcoded default model string — each provider now resolves its own default at runtime.
3. Added links to the discord.