### PR TITLE
fix: capture traceback to clarity-crash.log on startup failure

### DIFF
--- a/clarity.py
+++ b/clarity.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import traceback
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -387,6 +389,33 @@ def _transcript_dir(args: argparse.Namespace, project_dir: Path):
 
 
 # ---------------------------------------------------------------------------
+# Crash logging
+# ---------------------------------------------------------------------------
+
+def _write_crash_log(exc: BaseException) -> Path | None:
+    """Append *exc*'s traceback to the per-user crash log.
+
+    The Tauri sidecar runs without an attached console on Windows, so a
+    bare ``print(Error: ...)`` leaves users (and us) blind to startup
+    failures.  Writing the traceback to a known on-disk location turns
+    silent exit codes into something we can ask users to read back.
+
+    Best-effort: any failure during logging is swallowed so a broken
+    logger never masks the real exception.
+    """
+    try:
+        from clarity_agent.app_paths import clarity_data_dir
+        log_path = clarity_data_dir() / "clarity-crash.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("a", encoding="utf-8") as f:
+            f.write(f"\n=== {datetime.now().isoformat(timespec='seconds')} ===\n")
+            f.write("".join(traceback.format_exception(exc)))
+        return log_path
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Subcommand registry
 # ---------------------------------------------------------------------------
 
@@ -642,7 +671,10 @@ def main() -> None:
     except KeyboardInterrupt:
         pass
     except Exception as e:
-        print(f"Error: {e}")
+        crash_log = _write_crash_log(e)
+        print(f"Error: {e}", file=sys.stderr)
+        if crash_log is not None:
+            print(f"Full traceback written to: {crash_log}", file=sys.stderr)
         raise SystemExit(1) from e
 
 

--- a/tests/test_crash_log.py
+++ b/tests/test_crash_log.py
@@ -1,0 +1,92 @@
+"""Tests for the ``_write_crash_log`` helper in ``clarity.py``.
+
+The helper turns a silent ``SystemExit(1)`` (which is all the user sees
+when the Tauri sidecar dies on Windows) into a readable traceback on
+disk.  These tests pin down the file location, the contents, and the
+must-never-raise contract.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_clarity_module():
+    """Load ``clarity.py`` from the repo root without polluting ``sys.path``.
+
+    ``clarity.py`` lives at the repo root (not under ``src/``) and isn't
+    a package, so a plain ``import clarity`` would depend on pytest's
+    rootdir behavior.  Loading by path is explicit and order-independent.
+    """
+    spec = importlib.util.spec_from_file_location("clarity", _REPO_ROOT / "clarity.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def clarity_module():
+    return _load_clarity_module()
+
+
+def test_writes_traceback_to_data_dir(clarity_module, tmp_path: Path) -> None:
+    # conftest already points CLARITY_DATA_DIR at a per-test tmp dir.
+    try:
+        raise ValueError("synthetic boom")
+    except ValueError as exc:
+        log_path = clarity_module._write_crash_log(exc)
+
+    assert log_path is not None
+    assert log_path.exists()
+    assert log_path.name == "clarity-crash.log"
+    assert log_path.parent == Path(os.environ["CLARITY_DATA_DIR"])
+
+    content = log_path.read_text(encoding="utf-8")
+    assert "ValueError" in content
+    assert "synthetic boom" in content
+    assert "===" in content  # timestamp header marker
+
+
+def test_appends_across_invocations(clarity_module) -> None:
+    """A second crash adds to the file rather than overwriting it."""
+    try:
+        raise RuntimeError("first")
+    except RuntimeError as exc:
+        clarity_module._write_crash_log(exc)
+    try:
+        raise RuntimeError("second")
+    except RuntimeError as exc:
+        log_path = clarity_module._write_crash_log(exc)
+
+    assert log_path is not None
+    content = log_path.read_text(encoding="utf-8")
+    assert "first" in content
+    assert "second" in content
+
+
+def test_swallows_failure(monkeypatch: pytest.MonkeyPatch, clarity_module) -> None:
+    """An unwritable data dir must return ``None``, never raise.
+
+    Otherwise the crash logger would mask the very exception we're
+    trying to surface in ``main()``.
+    """
+    from clarity_agent import app_paths
+
+    def _broken() -> Path:
+        raise OSError("disk on fire")
+
+    monkeypatch.setattr(app_paths, "clarity_data_dir", _broken)
+
+    try:
+        raise ValueError("boom")
+    except ValueError as exc:
+        result = clarity_module._write_crash_log(exc)
+
+    assert result is None


### PR DESCRIPTION
Fixes #54.

`main()` was catching exceptions and printing only `Error: <msg>`, no traceback. The Tauri sidecar on Windows has no attached console, so this shows up as a silent exit 1.

Now writes the full traceback to `clarity_data_dir() / "clarity-crash.log"` on any unhandled exception, and prints the path to stderr. 

Path lands at `%LOCALAPPDATA%\Clarity\data\clarity-crash.log` on Windows (plus the macOS/Linux equivalents)