### PR TITLE
Include AGENTS.md in PyInstaller bundle

### DIFF
--- a/clarity-server.spec
+++ b/clarity-server.spec
@@ -102,6 +102,7 @@ if not _copilot_bin.exists():
     _copilot_bin = Path(".venv", "Lib", "site-packages", "copilot", "bin")
 
 datas = [
+    ("AGENTS.md", "."),
     ("processes", "processes"),
     ("thinkers", "thinkers"),
     ("web/dist", "web/dist"),


### PR DESCRIPTION
The desktop bundle was missing AGENTS.md. In dev mode, get_bundle_dir() returns the repo root where AGENTS.md exists naturally, so this was never noticed. In frozen (PyInstaller) builds, it returns sys._MEIPASS, and since AGENTS.md was not listed in the spec's datas, load_behaviors() silently returned an empty string. The LLM never received the Behaviors section that governs how all Clarity processes run.

Fix: add AGENTS.md to the datas list in clarity-server.spec so it is bundled at the root of the PyInstaller output.