### PR TITLE
Fix max_tokens vs max_completion_tokens for OAI backend

### DIFF
--- a/src/clarity_agent/llm/impl/_openai_compat.py
+++ b/src/clarity_agent/llm/impl/_openai_compat.py
@@ -1,0 +1,52 @@
+"""Shared helpers for the OpenAI-format backends.
+
+Used by both :mod:`clarity_agent.llm.impl.openai` (the direct
+OpenAI API) and :mod:`clarity_agent.llm.impl.azure_inference`
+(Azure-hosted models, which use the OpenAI request shape).  Add to
+this module when a new helper needs to behave identically across
+both backends; backend-specific behavior stays in the per-backend
+file.
+"""
+
+from __future__ import annotations
+
+# Models that still take the legacy ``max_tokens`` kwarg.
+#
+# Maintained as a *denylist* on purpose: ``max_completion_tokens``
+# is the forward-compatible default for every model OpenAI has
+# released since the o1 series in late 2024, and continues to be
+# the way new models accept token-limit hints.  Treating it as the
+# default means future / unknown models work out of the box —
+# only the shrinking set of pre-o1 chat models needs special
+# handling.
+#
+# Matched by prefix via :func:`uses_legacy_max_tokens` so that
+# date-stamped variants (``gpt-4o-2024-08-06``, ``gpt-3.5-turbo-1106``,
+# etc.) are covered without enumerating every snapshot.
+#
+# **Maintenance**: if a vendor ships a new release in the legacy
+# families that still requires ``max_tokens`` — unlikely — add its
+# prefix here.  If a legacy model gains support for
+# ``max_completion_tokens`` and you want to silently migrate, drop
+# its prefix.  See issue #59 for the bug that motivated the
+# inversion.
+_LEGACY_MAX_TOKENS_PREFIXES: tuple[str, ...] = (
+    "gpt-3.5",  # gpt-3.5-turbo and all -turbo-* snapshots
+    "gpt-4",    # gpt-4, gpt-4-turbo, gpt-4o, gpt-4-32k, gpt-4o-mini,
+                # gpt-4-vision-preview, and date-stamped snapshots.
+                # The gpt-4 family appears frozen; if OpenAI ever
+                # ships a "gpt-4.5"-style name we'll need to make
+                # this matcher smarter.
+)
+
+
+def uses_legacy_max_tokens(model: str) -> bool:
+    """Return True if *model* needs ``max_tokens`` instead of
+    ``max_completion_tokens``.
+
+    Any model name that doesn't match the legacy prefix list is
+    assumed to want the modern kwarg — that's the safe default for
+    every currently-supported OpenAI model and for unknown /
+    future / fine-tuned model names.
+    """
+    return model.startswith(_LEGACY_MAX_TOKENS_PREFIXES)

--- a/src/clarity_agent/llm/impl/azure_inference.py
+++ b/src/clarity_agent/llm/impl/azure_inference.py
@@ -16,6 +16,7 @@ from azure.core.credentials import AzureKeyCredential as _AzureKeyCredential
 from azure.identity import DefaultAzureCredential as _DefaultAzureCredential
 
 from clarity_agent.llm.client import LLMClient
+from clarity_agent.llm.impl._openai_compat import uses_legacy_max_tokens
 from clarity_agent.llm.types import (
     LLMAuthExpiredError,
     LLMResponse,
@@ -133,9 +134,6 @@ class AzureInferenceClient(LLMClient):
     TIER_DEFAULTS = _AZURE_TIER_DEFAULTS
     MODEL_CONTEXT_WINDOWS = _AZURE_MODEL_CONTEXT_WINDOWS
 
-    # Models that require max_completion_tokens instead of max_tokens.
-    _MODERN_MODELS = {"gpt-5", "gpt-5.2", "gpt-5.3", "gpt-5.4", "gpt-5-mini", "o3", "o3-mini", "o4-mini"}
-
     def __init__(
         self,
         *,
@@ -220,10 +218,6 @@ class AzureInferenceClient(LLMClient):
             self._clients[model] = _azure_aio_mod.ChatCompletionsClient(**kwargs)
         return self._clients[model]
 
-    def _needs_modern_tokens(self, model: str) -> bool:
-        """Return True if the model requires max_completion_tokens."""
-        return any(model.startswith(m) for m in self._MODERN_MODELS)
-
     async def _create_message(
         self,
         *,
@@ -240,11 +234,16 @@ class AzureInferenceClient(LLMClient):
             "model": model,
         }
 
-        # GPT-5 family and reasoning models require max_completion_tokens.
-        if self._needs_modern_tokens(model):
-            kwargs["model_extras"] = {"max_completion_tokens": max_tokens}
-        else:
+        # ``max_completion_tokens`` is the forward-compatible kwarg
+        # name — only pre-o1 chat models still take ``max_tokens``.
+        # See ``_openai_compat`` for the prefix list and rationale.
+        # The Azure inference SDK doesn't accept ``max_completion_tokens``
+        # as a first-class argument, so we route it through
+        # ``model_extras`` (which forwards to the underlying HTTP body).
+        if uses_legacy_max_tokens(model):
             kwargs["max_tokens"] = max_tokens
+        else:
+            kwargs["model_extras"] = {"max_completion_tokens": max_tokens}
 
         if tools:
             kwargs["tools"] = _translate_tools(tools)

--- a/src/clarity_agent/llm/impl/openai.py
+++ b/src/clarity_agent/llm/impl/openai.py
@@ -13,6 +13,7 @@ from typing import Any
 import openai as _openai_mod
 
 from clarity_agent.llm.client import LLMClient
+from clarity_agent.llm.impl._openai_compat import uses_legacy_max_tokens
 from clarity_agent.llm.types import (
     LLMResponse,
     TextBlock,
@@ -128,10 +129,19 @@ class OpenAIClient(LLMClient):
         kwargs: dict[str, Any] = {
             "messages": _translate_messages(messages, system),
             "model": model,
-            "max_tokens": max_tokens,
             "stream": True,
             "stream_options": {"include_usage": True},
         }
+        # ``max_completion_tokens`` is the forward-compatible kwarg
+        # (required by gpt-5 family + reasoning models, accepted by
+        # everything since o1).  ``uses_legacy_max_tokens`` picks
+        # out the dwindling set of pre-o1 chat models that still
+        # need the legacy name.  See ``_openai_compat`` for the
+        # rationale and the maintenance note on the prefix list.
+        if uses_legacy_max_tokens(model):
+            kwargs["max_tokens"] = max_tokens
+        else:
+            kwargs["max_completion_tokens"] = max_tokens
         if tools:
             kwargs["tools"] = _translate_tools(tools)
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -980,6 +980,51 @@ class TestAzureInferenceClient:
 
         assert deltas == ["Hello", " world"]
 
+    def _capture_azure_complete_kwargs(
+        self, model: str, max_tokens: int,
+    ) -> dict[str, Any]:
+        # Same shape as the OpenAI helper above: drive a one-shot
+        # create_message against a mock Azure client and return the
+        # kwargs that landed on the inference SDK's ``complete()``.
+        chunks = [_make_stream_chunk(content="hi"), _make_stream_chunk(finish_reason="stop")]
+        with \
+             patch("clarity_agent.llm.impl.azure_inference._azure_aio_mod") as mock_aio, \
+             patch("clarity_agent.llm.impl.azure_inference._AzureKeyCredential"), \
+             patch("clarity_agent.llm.impl.azure_inference._azure_models"):
+            mock_client = AsyncMock()
+            mock_client.complete = AsyncMock(return_value=self._make_stream(chunks))
+            mock_aio.ChatCompletionsClient.return_value = mock_client
+
+            from clarity_agent.llm.impl.azure_inference import AzureInferenceClient
+            client = AzureInferenceClient(
+                api_key="fake", endpoint="https://example.com",
+            )
+            asyncio.run(client.create_message(
+                messages=[{"role": "user", "content": "hi"}],
+                model=model,
+                max_tokens=max_tokens,
+            ))
+        return mock_client.complete.await_args.kwargs
+
+    def test_default_routes_through_model_extras(self) -> None:
+        # Azure mirrors the OpenAI inversion (see test_default_picks_
+        # max_completion_tokens above), but routes via ``model_extras``
+        # because the inference SDK doesn't surface
+        # ``max_completion_tokens`` as a first-class kwarg.  Unknown /
+        # future model names must take this branch by default.
+        for model in ("gpt-5.4", "o3-mini", "ft:gpt-7-future"):
+            kw = self._capture_azure_complete_kwargs(model, 1234)
+            assert kw.get("model_extras") == {"max_completion_tokens": 1234}, model
+            assert "max_tokens" not in kw, model
+
+    def test_legacy_models_use_max_tokens(self) -> None:
+        # Pre-o1 deployments take the legacy first-class kwarg
+        # rather than the ``model_extras`` route.
+        for model in ("gpt-4", "gpt-4o", "gpt-3.5-turbo-1106"):
+            kw = self._capture_azure_complete_kwargs(model, 2048)
+            assert kw.get("max_tokens") == 2048, model
+            assert "model_extras" not in kw, model
+
 
 # ---------------------------------------------------------------------------
 # AzureInferenceClient — auth modes
@@ -1221,6 +1266,51 @@ class TestOpenAIClient:
             ))
 
         assert deltas == ["Hello", " ", "world"]
+
+    def _capture_create_kwargs(self, model: str, max_tokens: int) -> dict[str, Any]:
+        # Run a one-shot create_message against a mock and return
+        # the kwargs the OpenAI SDK was called with — the assertion
+        # surface for the legacy / modern token-kwarg routing tests.
+        chunks = [_make_stream_chunk(content="hi"), _make_stream_chunk(finish_reason="stop")]
+        with patch("clarity_agent.llm.impl.openai._openai_mod") as mock_mod:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create = AsyncMock(
+                return_value=self._make_stream(chunks),
+            )
+            mock_mod.AsyncOpenAI.return_value = mock_client
+
+            from clarity_agent.llm.impl.openai import OpenAIClient
+            client = OpenAIClient(api_key="fake")
+            asyncio.run(client.create_message(
+                messages=[{"role": "user", "content": "hi"}],
+                model=model,
+                max_tokens=max_tokens,
+            ))
+        return mock_client.chat.completions.create.await_args.kwargs
+
+    def test_default_picks_max_completion_tokens(self) -> None:
+        # Regression for issue #59 and forward-default guarantee:
+        # any model not in the legacy prefix list (the dwindling
+        # set of pre-o1 chat models) gets ``max_completion_tokens``.
+        # This covers the named gpt-5 family models, reasoning
+        # models (o3/o4), AND unknown future / fine-tuned model
+        # names — the inversion's whole point is that new model
+        # IDs work without a code change.
+        for model in ("gpt-5.4", "o3-mini", "o4-mini", "ft:gpt-7-future"):
+            kw = self._capture_create_kwargs(model, 1234)
+            assert kw.get("max_completion_tokens") == 1234, model
+            assert "max_tokens" not in kw, model
+
+    def test_legacy_models_use_max_tokens(self) -> None:
+        # The flip side: pre-o1 chat models still take the legacy
+        # kwarg.  These date-stamped names exercise the prefix
+        # match — bare ``gpt-4``, ``gpt-4o-2024-08-06``, and
+        # ``gpt-3.5-turbo-1106`` must all be recognised as legacy
+        # rather than getting the new kwarg.
+        for model in ("gpt-4", "gpt-4o", "gpt-4o-2024-08-06", "gpt-3.5-turbo-1106"):
+            kw = self._capture_create_kwargs(model, 2048)
+            assert kw.get("max_tokens") == 2048, model
+            assert "max_completion_tokens" not in kw, model
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This was working right for AOAI but not OAI. Also changed the logic to (a) share the list of models that need different flags between the two and (b) only have to maintain the list of *legacy* models that use the old max_tokens, not every conceivable new model that uses max_completion_tokens.

Resolves #59.