### PR TITLE
Handle stale projects gracefully and add remove-from-list UX

### DIFF
--- a/web/src/__tests__/ProjectSwitcher.test.tsx
+++ b/web/src/__tests__/ProjectSwitcher.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import ProjectSwitcher from "../components/ProjectSwitcher";
+import type { ProjectEntry } from "../types";
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(),
+  save: vi.fn(),
+}));
+
+vi.mock("../components/Layout", () => ({
+  refreshRecentMenu: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { getProjectsMock, removeProjectMock, activateProjectMock } = vi.hoisted(() => ({
+  getProjectsMock: vi.fn(),
+  removeProjectMock: vi.fn(),
+  activateProjectMock: vi.fn(),
+}));
+
+vi.mock("../api/client", () => ({
+  getProjects: getProjectsMock,
+  removeProject: removeProjectMock,
+  activateProject: activateProjectMock,
+  createProject: vi.fn(),
+}));
+
+function makeProject(overrides: Partial<ProjectEntry> = {}): ProjectEntry {
+  return {
+    id: "abc12345",
+    name: "alpha",
+    path: "/home/u/alpha",
+    last_opened: Date.now() / 1000,
+    has_protocol: true,
+    running: false,
+    active: false,
+    ...overrides,
+  };
+}
+
+function renderSwitcher() {
+  return render(
+    <MemoryRouter>
+      <ProjectSwitcher currentProject={undefined} />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  getProjectsMock.mockReset();
+  removeProjectMock.mockReset();
+  activateProjectMock.mockReset();
+});
+
+describe("ProjectSwitcher remove flow", () => {
+  it("shows a confirm strip when the trash button is clicked", async () => {
+    getProjectsMock.mockResolvedValue({
+      projects: [makeProject({ name: "alpha" }), makeProject({ name: "beta", id: "def67890", path: "/home/u/beta" })],
+    });
+
+    renderSwitcher();
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    const trash = screen.getByRole("button", { name: /remove alpha from list/i });
+    await userEvent.click(trash);
+
+    expect(
+      screen.getByText((_, el) => el?.textContent === "Remove alpha from list?"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+  });
+
+  it("calls removeProject and refreshes the list when confirmed", async () => {
+    getProjectsMock
+      .mockResolvedValueOnce({
+        projects: [makeProject({ name: "alpha" }), makeProject({ name: "beta", id: "def67890", path: "/home/u/beta" })],
+      })
+      .mockResolvedValueOnce({
+        projects: [makeProject({ name: "beta", id: "def67890", path: "/home/u/beta" })],
+      });
+    removeProjectMock.mockResolvedValue({ status: "removed" });
+
+    renderSwitcher();
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /remove alpha from list/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    await waitFor(() => {
+      expect(removeProjectMock).toHaveBeenCalledWith("alpha");
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("alpha")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("beta")).toBeInTheDocument();
+  });
+
+  it("dismisses the confirm strip when Cancel is clicked", async () => {
+    getProjectsMock.mockResolvedValue({
+      projects: [makeProject({ name: "alpha" })],
+    });
+
+    renderSwitcher();
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: /remove alpha from list/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(removeProjectMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: /remove alpha from list/i })).toBeInTheDocument();
+  });
+});
+
+describe("ProjectSwitcher activation error handling", () => {
+  it("shows a friendly message and refreshes the list when activation returns 410", async () => {
+    getProjectsMock
+      .mockResolvedValueOnce({
+        projects: [makeProject({ name: "alpha" })],
+      })
+      .mockResolvedValueOnce({ projects: [] });
+    activateProjectMock.mockRejectedValue(new Error("410: gone"));
+
+    renderSwitcher();
+    await waitFor(() => expect(screen.getByText("alpha")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByTitle("/home/u/alpha"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/folder no longer exists/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/__tests__/apiClient.test.ts
+++ b/web/src/__tests__/apiClient.test.ts
@@ -10,6 +10,7 @@ import {
   getSession,
   getModelProfile,
   setModelOverride,
+  removeProject,
 } from "../api/client";
 
 // ---------------------------------------------------------------------------
@@ -199,6 +200,17 @@ describe("API client", () => {
       const result = await getModelProfile();
       expect(mockFetch).toHaveBeenCalledWith("/api/model-profile", undefined);
       expect(result).toEqual(data);
+    });
+
+    it("removeProject sends DELETE with url-encoded name", async () => {
+      mockFetch.mockReturnValue(jsonResponse({ status: "removed" }));
+
+      const result = await removeProject("my project/with space");
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/projects/my%20project%2Fwith%20space",
+        { method: "DELETE" },
+      );
+      expect(result).toEqual({ status: "removed" });
     });
 
     it("setModelOverride sends PUT with tier", async () => {

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -41,6 +41,7 @@ export default function Layout() {
   const [showFeedback, setShowFeedback] = useState(false);
   const [session, setSession] = useState<SessionInfo | null>(null);
   const [sessionLoading, setSessionLoading] = useState(true);
+  const [activationError, setActivationError] = useState<string | null>(null);
   const navigate = useNavigate();
   const location = useLocation();
   const projectId = useProjectId();
@@ -80,9 +81,19 @@ export default function Layout() {
     setSessionLoading(true);
     activateProjectById(projectId)
       .then(() => fetchSession())
-      .catch(() => {
-        // Project ID doesn't exist — go to root
+      .catch((err: unknown) => {
+        // The launcher returns 410 when a project's directory no longer
+        // exists; refresh the recent menu so the stale entry drops out,
+        // surface a banner, and route the user back to the picker.
+        const msg = err instanceof Error ? err.message : String(err);
+        setActivationError(
+          msg.startsWith("410")
+            ? "That project's folder no longer exists. It has been removed from your recent list."
+            : "Couldn't open that project."
+        );
+        void refreshRecentMenu();
         navigate("/", { replace: true });
+        setSessionLoading(false);
       })
       .finally(() => {
         activatingRef.current = null;
@@ -142,9 +153,19 @@ export default function Layout() {
       openProjectPath((e as CustomEvent).detail, "create_new");
     const onActivate = async (e: Event) => {
       const projectId = (e as CustomEvent).detail;
-      await activateProjectById(projectId);
-      await refreshRecentMenu();
-      navigate(`/p/${projectId}/`);
+      try {
+        await activateProjectById(projectId);
+        await refreshRecentMenu();
+        navigate(`/p/${projectId}/`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setActivationError(
+          msg.startsWith("410")
+            ? "That project's folder no longer exists. It has been removed from your recent list."
+            : "Couldn't open that project."
+        );
+        await refreshRecentMenu();
+      }
     };
     // Print is handled natively by Tauri (WebviewWindow::print()),
     // not via JS — window.print() is a no-op in WKWebView.
@@ -264,6 +285,21 @@ export default function Layout() {
         // `onShowFeedback={() => setShowFeedback(true)}`.
       />
       <main id="main-content" className="flex-1 overflow-auto animate-fade-in">
+        {activationError && (
+          <div
+            role="alert"
+            className="mx-4 mt-3 px-3 py-2 rounded text-xs
+              text-status-error-text bg-status-error-bg flex items-center gap-2"
+          >
+            <span className="flex-1">{activationError}</span>
+            <button
+              onClick={() => setActivationError(null)}
+              className="underline hover:no-underline"
+            >
+              dismiss
+            </button>
+          </div>
+        )}
         {noActiveProject ? (
           <div className="h-full flex items-center justify-center text-body-faint text-sm select-none">
             Select or create a project to get started.

--- a/web/src/components/ProjectSwitcher.tsx
+++ b/web/src/components/ProjectSwitcher.tsx
@@ -4,6 +4,7 @@ import {
   activateProject,
   createProject,
   getProjects,
+  removeProject,
   type CreateProjectResult,
 } from "../api/client";
 import type { ProjectEntry } from "../types";
@@ -60,6 +61,8 @@ export default function ProjectSwitcher({ currentProject }: ProjectSwitcherProps
   const [projects, setProjects] = useState<ProjectEntry[]>([]);
   const [loading, setLoading] = useState(false);
   const [activating, setActivating] = useState<string | null>(null);
+  const [removing, setRemoving] = useState<string | null>(null);
+  const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   // New-project inline form (browser-mode fallback only).
@@ -120,8 +123,32 @@ export default function ProjectSwitcher({ currentProject }: ProjectSwitcherProps
       refreshRecentMenu();
       navigate(`/p/${project.id}/`);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(
+        msg.startsWith("410")
+          ? "That project's folder no longer exists. It has been removed from your list."
+          : msg
+      );
       setActivating(null);
+      if (msg.startsWith("410")) {
+        void refreshRecentMenu();
+        refresh();
+      }
+    }
+  };
+
+  const handleRemove = async (project: ProjectEntry) => {
+    setRemoving(project.name);
+    setError(null);
+    try {
+      await removeProject(project.name);
+      setConfirmRemove(null);
+      refresh();
+      void refreshRecentMenu();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRemoving(null);
     }
   };
 
@@ -307,6 +334,7 @@ export default function ProjectSwitcher({ currentProject }: ProjectSwitcherProps
     setNewName("");
     setShowOpenForm(false);
     setOpenPath("");
+    setConfirmRemove(null);
     setError(null);
   };
 
@@ -359,34 +387,86 @@ export default function ProjectSwitcher({ currentProject }: ProjectSwitcherProps
           ) : (
             projects.map((project) => {
               const isCurrent = project.path === currentProject;
+              if (confirmRemove === project.name) {
+                return (
+                  <div
+                    key={project.name}
+                    className="flex items-center gap-1.5 pl-4 pr-3 py-1.5 text-xs
+                      bg-sidebar-active/40 border-l-2 border-status-error/60 -ml-px"
+                  >
+                    <span className="flex-1 min-w-0 truncate text-sidebar-text">
+                      Remove <span className="font-medium">{project.name}</span> from list?
+                    </span>
+                    <button
+                      onClick={() => handleRemove(project)}
+                      disabled={removing === project.name}
+                      className="px-2 py-0.5 rounded text-[11px] bg-status-error/80 text-white
+                        hover:bg-status-error disabled:opacity-50 transition-colors"
+                    >
+                      {removing === project.name ? "Removing…" : "Remove"}
+                    </button>
+                    <button
+                      onClick={() => setConfirmRemove(null)}
+                      disabled={removing === project.name}
+                      className="px-2 py-0.5 rounded text-[11px] text-sidebar-text-muted
+                        hover:text-sidebar-text hover:bg-sidebar-active/60 transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                );
+              }
               return (
-                <button
+                <div
                   key={project.name}
-                  onClick={() => !isCurrent && !activating && handleActivate(project)}
-                  disabled={isCurrent || activating !== null}
-                  title={project.path}
-                  className={`w-full text-left flex items-center gap-2 pl-4 pr-3 py-1.5 text-sm
-                    transition-all duration-150 disabled:cursor-default ${
+                  className={`group flex items-center w-full transition-all duration-150 ${
                     isCurrent
-                      ? "text-sidebar-text bg-sidebar-active/80 border-l-2 border-accent-focus -ml-px"
-                      : "text-sidebar-text-muted hover:text-sidebar-text hover:pl-5"
+                      ? "bg-sidebar-active/80 border-l-2 border-accent-focus -ml-px"
+                      : ""
                   }`}
                 >
-                  <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${
-                    project.running
-                      ? isCurrent ? "bg-accent-focus" : "bg-status-ok"
-                      : "bg-sidebar-line/60"
-                  }`} />
-                  <span className="truncate flex-1 min-w-0">{project.name}</span>
-                  {activating === project.name ? (
-                    <svg className="w-3 h-3 animate-spin shrink-0 text-accent" viewBox="0 0 24 24" fill="none">
-                      <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" opacity="0.3" />
-                      <path d="M12 2a10 10 0 019.95 9" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                  <button
+                    onClick={() => !isCurrent && !activating && handleActivate(project)}
+                    disabled={isCurrent || activating !== null}
+                    title={project.path}
+                    className={`flex-1 min-w-0 text-left flex items-center gap-2 pl-4 pr-2 py-1.5 text-sm
+                      transition-all duration-150 disabled:cursor-default ${
+                      isCurrent
+                        ? "text-sidebar-text"
+                        : "text-sidebar-text-muted hover:text-sidebar-text hover:pl-5"
+                    }`}
+                  >
+                    <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${
+                      project.running
+                        ? isCurrent ? "bg-accent-focus" : "bg-status-ok"
+                        : "bg-sidebar-line/60"
+                    }`} />
+                    <span className="truncate flex-1 min-w-0">{project.name}</span>
+                    {activating === project.name ? (
+                      <svg className="w-3 h-3 animate-spin shrink-0 text-accent" viewBox="0 0 24 24" fill="none">
+                        <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" opacity="0.3" />
+                        <path d="M12 2a10 10 0 019.95 9" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                      </svg>
+                    ) : (
+                      <span className="text-[10px] text-sidebar-text-faint shrink-0 group-hover:opacity-0 transition-opacity">
+                        {timeAgo(project.last_opened)}
+                      </span>
+                    )}
+                  </button>
+                  <button
+                    onClick={() => setConfirmRemove(project.name)}
+                    disabled={activating !== null}
+                    aria-label={`Remove ${project.name} from list`}
+                    title="Remove from list"
+                    className="shrink-0 mr-2 p-1 rounded opacity-0 group-hover:opacity-100
+                      focus:opacity-100 text-sidebar-text-faint hover:text-status-error
+                      hover:bg-sidebar-active/60 transition-opacity disabled:cursor-default"
+                  >
+                    <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.75}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
                     </svg>
-                  ) : (
-                    <span className="text-[10px] text-sidebar-text-faint shrink-0">{timeAgo(project.last_opened)}</span>
-                  )}
-                </button>
+                  </button>
+                </div>
               );
             })
           )}


### PR DESCRIPTION
Fixes #38.

## Bug

The launcher's `GET /api/projects` and `_do_activate` already prune stale-directory entries, but two frontend paths weren't catching the 410 that follows:

- Tauri "Open Recent" menu (`Layout.tsx` `onActivate`) — no try/catch, so the click did nothing and the menu kept showing the dead entry.
- URL-driven activation (`Layout.tsx` URL effect) — silently redirected to `/` with no indication of what happened.

Both now refresh the native Recent menu (so the stale entry drops out on next open) and surface a dismissable banner in `<main>` explaining what happened. `ProjectSwitcher.handleActivate` got the same treatment for the race window where a directory disappears between list and click.

## Enhancement

The backend `DELETE /api/projects/:name` and the `removeProject` API client already existed (used only by the Clear Recent menu). This PR wires them into `ProjectSwitcher`: each row gets a trash icon visible on hover, with an inline "Remove X from list?" confirm strip that matches the existing inline-form pattern in the component. Archive is not included since there's no backend story for it yet.

## Tests

- `apiClient.test.ts`: covers `removeProject` (DELETE + URL encoding).
- `ProjectSwitcher.test.tsx` (new): confirm strip render, successful removal + list refresh, cancel, and 410-on-activate surfacing.

All 107 tests pass. `tsc -b` clean. `vite build` clean. ESLint shows two pre-existing warnings unchanged.