### PR TITLE
Fix document-open flow

### DIFF
--- a/src/clarity_agent/projects.py
+++ b/src/clarity_agent/projects.py
@@ -73,14 +73,44 @@ class ProjectRegistry:
         return sorted(entries, key=lambda e: e.last_opened, reverse=True)
 
     def add(self, name: str, path: str | Path) -> ProjectEntry:
-        """Register a new project.  Raises ``ValueError`` if the name is taken."""
-        path = str(Path(path).resolve())
+        """Register (or re-open) a project.
+
+        Path is the primary identity — a project directory is the
+        thing that uniquely identifies a project.  Re-adding the
+        same path is idempotent: returns the existing entry without
+        touching disk, so "open project" is safe to call against an
+        already-registered directory.
+
+        The display ``name`` is *not* a uniqueness constraint.  Two
+        projects in different directories can share the same name —
+        the launcher disambiguates by ``id`` (a stable hash of the
+        path) for activation and process-table lookups.  A caller
+        re-registering an existing path with a *different* name
+        wins: the entry is renamed.
+
+        The launcher's runtime state is id-keyed throughout —
+        ``active_project["id"]``, the ``processes`` table, and the
+        proxy-routing path all dispatch on id.  The legacy
+        name-keyed routes (``activate_project``,
+        ``deactivate_project``, ``remove_project``) resolve via
+        registry first and then dispatch by id; with duplicate
+        names they still fall back to first-match.  Frontends with
+        a known id should prefer the id-keyed variants
+        (``activate-by-id``, ``getActiveProject``-returned ids).
+        """
+        path_str = str(Path(path).resolve())
         entries = self._read()
 
-        if any(e.name == name for e in entries):
-            raise ValueError(f"Project name already exists: {name!r}")
+        for e in entries:
+            if e.path == path_str:
+                # Idempotent reopen.  Honor a name change if the
+                # caller supplied a different one.
+                if e.name != name:
+                    e.name = name
+                    self._write(entries)
+                return e
 
-        entry = ProjectEntry(name=name, path=path)
+        entry = ProjectEntry(name=name, path=path_str)
         entry.refresh()
         entries.append(entry)
         self._write(entries)
@@ -161,19 +191,39 @@ class ProjectRegistry:
     # -- Active project persistence ----------------------------------------
 
     def get_active(self) -> str | None:
-        """Return the name of the last-active project, or ``None``."""
-        data = self._read_raw()
-        return data.get("active")
+        """Return the *id* of the last-active project, or ``None``.
 
-    def set_active(self, name: str) -> None:
-        """Persist *name* as the active project."""
+        Persisted under the ``"active_id"`` key.  Legacy registries
+        stored ``"active"`` as a project *name*; we read both forms
+        for compat (preferring id when present) and migrate to id on
+        the next :meth:`set_active`.  The migration is silent so
+        startup never blocks on a registry rewrite.
+        """
         data = self._read_raw()
-        data["active"] = name
+        active_id = data.get("active_id")
+        if active_id:
+            return active_id
+        # Legacy name-keyed value — try to resolve to an id so
+        # consumers don't have to know about the format change.
+        legacy_name = data.get("active")
+        if legacy_name:
+            existing = self.get(legacy_name)
+            if existing is not None:
+                return existing.id
+        return None
+
+    def set_active(self, project_id: str) -> None:
+        """Persist *project_id* as the active project.  Clears any
+        legacy ``"active"`` name field so it doesn't drift."""
+        data = self._read_raw()
+        data["active_id"] = project_id
+        data.pop("active", None)
         self._write_raw(data)
 
     def clear_active(self) -> None:
-        """Clear the persisted active project."""
+        """Clear the persisted active project (both id and legacy name)."""
         data = self._read_raw()
+        data.pop("active_id", None)
         data.pop("active", None)
         self._write_raw(data)
 

--- a/src/clarity_agent/projects.py
+++ b/src/clarity_agent/projects.py
@@ -40,11 +40,14 @@ class ProjectEntry:
         if not self.id:
             self.id = _make_project_id(self.path)
 
-    def refresh(self) -> None:
-        """Update ``has_protocol`` from the filesystem."""
-        from clarity_agent.app_paths import _PROTOCOL_DIR_DOT, _PROTOCOL_DIR_VISIBLE
+    def refresh(self) -> bool:
+        """Update ``has_protocol`` from the filesystem. Returns False if the entire entry is now bogus."""
         p = Path(self.path)
+        if not p.is_dir():
+            return False
+        from clarity_agent.app_paths import _PROTOCOL_DIR_DOT, _PROTOCOL_DIR_VISIBLE
         self.has_protocol = (p / _PROTOCOL_DIR_DOT).is_dir() or (p / _PROTOCOL_DIR_VISIBLE).is_dir()
+        return True
 
 
 class ProjectRegistry:
@@ -67,38 +70,49 @@ class ProjectRegistry:
         """
         entries = self._read()
         if refresh:
-            for e in entries:
-                e.refresh()
+            entries = [e for e in entries if e.refresh()]
+        entries = sorted(entries, key=lambda e: e.last_opened, reverse=True)
+        if refresh:
             self._write(entries)
-        return sorted(entries, key=lambda e: e.last_opened, reverse=True)
+        return entries
 
-    def add(self, name: str, path: str | Path) -> ProjectEntry:
-        """Register (or re-open) a project.
+    def add(
+        self, path: str | Path, *, name: str | None = None,
+    ) -> ProjectEntry:
+        """Register (or re-open) a project at *path*.
 
-        Path is the primary identity — a project directory is the
-        thing that uniquely identifies a project.  Re-adding the
-        same path is idempotent: returns the existing entry without
-        touching disk, so "open project" is safe to call against an
-        already-registered directory.
+        Path is the primary identity — a project directory is what
+        uniquely identifies a project.  Re-adding the same path is
+        idempotent: returns the existing entry, so "open project"
+        is safe to call against an already-registered directory.
+        Re-registering an existing path with a *different* name
+        renames the entry — the user is just relabeling.
 
-        The display ``name`` is *not* a uniqueness constraint.  Two
-        projects in different directories can share the same name —
-        the launcher disambiguates by ``id`` (a stable hash of the
-        path) for activation and process-table lookups.  A caller
-        re-registering an existing path with a *different* name
-        wins: the entry is renamed.
+        The display ``name`` defaults to the basename of *path*
+        as supplied by the caller (computed *before* resolving
+        symlinks, so a path like ``~/Documents/Projects/my-thing``
+        gives "my-thing" rather than whatever the canonical
+        target's basename happens to be).  Pass ``name=`` to
+        override.
 
-        The launcher's runtime state is id-keyed throughout —
-        ``active_project["id"]``, the ``processes`` table, and the
-        proxy-routing path all dispatch on id.  The legacy
-        name-keyed routes (``activate_project``,
-        ``deactivate_project``, ``remove_project``) resolve via
-        registry first and then dispatch by id; with duplicate
-        names they still fall back to first-match.  Frontends with
-        a known id should prefer the id-keyed variants
-        (``activate-by-id``, ``getActiveProject``-returned ids).
+        Display names are not a uniqueness constraint — two
+        projects in different directories can share a label.  Look
+        a name up via :meth:`find_by_name`, which returns a list
+        rather than pretending it's a key.
+
+        Raises :class:`FileNotFoundError` if *path* doesn't exist
+        on disk — the registry never holds entries for directories
+        that aren't there.
         """
-        path_str = str(Path(path).resolve())
+        raw = Path(path)
+        if name is None:
+            # Pre-resolve basename keeps the user's chosen label
+            # (e.g. the symlink they picked).  Fall back to the
+            # resolved basename for edge cases like ``"."`` or
+            # ``"/"``, then to a generic label so an entry always
+            # has a non-empty name.
+            name = raw.name or raw.resolve().name or "project"
+        path_str = str(raw.resolve())
         entries = self._read()
 
         for e in entries:
@@ -111,47 +125,30 @@ class ProjectRegistry:
                 return e
 
         entry = ProjectEntry(name=name, path=path_str)
-        entry.refresh()
+        if not entry.refresh():
+            raise FileNotFoundError(f"No project directory at {path_str}")
         entries.append(entry)
         self._write(entries)
         return entry
 
-    def remove(self, name: str) -> None:
-        """Remove a project from the registry (does not touch the filesystem)."""
-        entries = self._read()
-        entries = [e for e in entries if e.name != name]
-        self._write(entries)
+    # -- Identity-keyed action verbs (id is the primary key) ---------------
 
-    def get(self, name: str) -> ProjectEntry | None:
-        """Look up a project by name."""
-        for e in self._read():
-            if e.name == name:
-                return e
-        return None
-
-    def get_by_id(self, project_id: str) -> ProjectEntry | None:
-        """Look up a project by its short hash ID."""
+    def get(self, project_id: str) -> ProjectEntry | None:
+        """Look up a project by its short hash id.  ``None`` if
+        unknown.  Id is the registry's primary key — prefer it for
+        any action that has to be unambiguous."""
         for e in self._read():
             if e.id == project_id:
                 return e
         return None
 
-    def find_by_path(self, path: str | Path) -> ProjectEntry | None:
-        """Look up a project by its directory path."""
-        resolved = str(Path(path).resolve())
-        for e in self._read():
-            if e.path == resolved:
-                return e
-        return None
-
-    def update(self, name: str, **fields: object) -> ProjectEntry:
-        """Update fields on an existing entry.  Returns the updated entry.
-
-        Raises ``KeyError`` if the project is not found.
-        """
+    def update(self, project_id: str, **fields: object) -> ProjectEntry:
+        """Update fields on the entry with this id.  Returns the
+        updated entry.  Raises :class:`KeyError` if the id isn't
+        in the registry."""
         entries = self._read()
         for e in entries:
-            if e.name == name:
+            if e.id == project_id:
                 for k, v in fields.items():
                     if not hasattr(e, k):
                         raise AttributeError(
@@ -160,17 +157,49 @@ class ProjectRegistry:
                     setattr(e, k, v)
                 self._write(entries)
                 return e
-        raise KeyError(f"Project not found: {name!r}")
+        raise KeyError(f"Project not found: id={project_id!r}")
 
-    def touch(self, name: str) -> None:
-        """Update ``last_opened`` to now."""
-        self.update(name, last_opened=time.time())
+    def touch(self, project_id: str) -> None:
+        """Update ``last_opened`` on this id to now.  Raises
+        :class:`KeyError` if the id isn't in the registry."""
+        self.update(project_id, last_opened=time.time())
+
+    def remove(self, project_id: str) -> None:
+        """Drop the entry with this id from the registry.  No-op
+        if the id isn't present (don't raise — callers commonly
+        invoke this defensively during cleanup)."""
+        entries = self._read()
+        entries = [e for e in entries if e.id != project_id]
+        self._write(entries)
+
+    # -- Alternate-key lookups ---------------------------------------------
+
+    def find_by_name(self, name: str) -> list[ProjectEntry]:
+        """All registered projects with this display label.
+
+        Returns a list because display names aren't unique — two
+        projects in different directories may share a label.
+        Caller decides what to do with 0/1/N matches.
+        """
+        return [e for e in self._read() if e.name == name]
+
+    def get_by_path(self, path: str | Path) -> ProjectEntry | None:
+        """Look up the project at this directory path.  Single
+        result because paths are unique by construction (they're
+        what derives the id)."""
+        resolved = str(Path(path).resolve())
+        for e in self._read():
+            if e.path == resolved:
+                return e
+        return None
+
+    # -- Collection management ---------------------------------------------
 
     def discover(self, base: Path | None = None) -> list[ProjectEntry]:
-        """Scan a directory for project subdirectories and register any new ones.
-
-        Returns the list of newly added entries.  Directories that are already
-        registered (by path) are skipped.
+        """Scan a directory for project subdirectories and register
+        any new ones.  Returns the list of newly added entries.
+        Directories that are already registered (by path) are
+        skipped.
         """
         base = base or clarity_projects_dir()
         if not base.is_dir():
@@ -180,11 +209,14 @@ class ProjectRegistry:
         for child in sorted(base.iterdir()):
             if not child.is_dir() or child.name.startswith("."):
                 continue
-            if self.find_by_path(child) is not None:
+            if self.get_by_path(child) is not None:
                 continue
-            # Derive a name, deduplicating if needed.
+            # Derive a name, deduplicating if needed.  ``add`` would
+            # default it to ``child.name`` anyway, but we want the
+            # de-duplicating suffix when a label is already taken so
+            # the project list stays readable.
             name = self._unique_name(child.name)
-            entry = self.add(name, child)
+            entry = self.add(child, name=name)
             added.append(entry)
         return added
 

--- a/src/clarity_agent/web/launcher.py
+++ b/src/clarity_agent/web/launcher.py
@@ -110,8 +110,14 @@ from clarity_agent.projects import ProjectEntry, ProjectRegistry
 
 @dataclass
 class ProcessEntry:
-    """A running per-project server subprocess."""
+    """A running per-project server subprocess.
 
+    Keyed by ``project_id`` (the registry's path-derived hash) so
+    that two projects sharing a display ``project_name`` can coexist
+    without overwriting each other in the process table.
+    """
+
+    project_id: str
     project_name: str
     pid: int
     port: int
@@ -120,32 +126,36 @@ class ProcessEntry:
 
 
 class ProcessTable:
-    """In-memory table of running project server subprocesses."""
+    """In-memory table of running project server subprocesses, keyed
+    by project id.  Display names are not unique (the registry
+    allows duplicate labels at different paths) — keying by id
+    means two same-named projects can run side-by-side without
+    overwriting each other's entries."""
 
     def __init__(self) -> None:
         self._entries: dict[str, ProcessEntry] = {}
 
-    def get(self, name: str) -> ProcessEntry | None:
-        entry = self._entries.get(name)
+    def get(self, project_id: str) -> ProcessEntry | None:
+        entry = self._entries.get(project_id)
         if entry is not None and not self._is_alive(entry):
-            del self._entries[name]
+            del self._entries[project_id]
             return None
         return entry
 
     def add(self, entry: ProcessEntry) -> None:
-        self._entries[entry.project_name] = entry
+        self._entries[entry.project_id] = entry
 
-    def remove(self, name: str) -> ProcessEntry | None:
-        return self._entries.pop(name, None)
+    def remove(self, project_id: str) -> ProcessEntry | None:
+        return self._entries.pop(project_id, None)
 
     def all(self) -> list[ProcessEntry]:
         self.prune_dead()
         return list(self._entries.values())
 
     def prune_dead(self) -> None:
-        dead = [n for n, e in self._entries.items() if not self._is_alive(e)]
-        for n in dead:
-            del self._entries[n]
+        dead = [pid for pid, e in self._entries.items() if not self._is_alive(e)]
+        for pid in dead:
+            del self._entries[pid]
 
     def kill_all(self) -> None:
         for entry in self._entries.values():
@@ -155,8 +165,8 @@ class ProcessTable:
                 pass
         self._entries.clear()
 
-    def touch(self, name: str) -> None:
-        entry = self._entries.get(name)
+    def touch(self, project_id: str) -> None:
+        entry = self._entries.get(project_id)
         if entry is not None:
             entry.last_activity = time.time()
 
@@ -220,15 +230,20 @@ def create_launcher(
     """
     registry = ProjectRegistry()
     processes = ProcessTable()
-    active_project: dict[str, str | None] = {"name": None}
+    # ``id`` (the registry's stable path-derived hash) — unique
+    # even when two projects share a display name.  See the
+    # ProcessEntry docstring for why this matters.
+    active_project: dict[str, str | None] = {"id": None}
 
     # Discover projects in the default workspace on startup.
     registry.discover()
 
-    # Restore last-active project name from the persistent registry.
-    _persisted_active = registry.get_active()
-    if _persisted_active and registry.get(_persisted_active) is not None:
-        active_project["name"] = _persisted_active
+    # Restore last-active project id from the persistent registry.
+    # ``get_active`` reads the new ``active_id`` key with a legacy
+    # fallback to the old name-keyed ``active`` field.
+    _persisted_active_id = registry.get_active()
+    if _persisted_active_id and registry.get_by_id(_persisted_active_id) is not None:
+        active_project["id"] = _persisted_active_id
 
     from clarity_agent.app_paths import clarity_env_path
     _env_path = env_path or clarity_env_path()
@@ -248,10 +263,10 @@ def create_launcher(
             await asyncio.sleep(60)
             for entry in processes.idle_entries(_IDLE_TIMEOUT_SECONDS):
                 # Don't reap the active project
-                if entry.project_name == active_project["name"]:
+                if entry.project_id == active_project["id"]:
                     continue
                 entry.process.terminate()
-                processes.remove(entry.project_name)
+                processes.remove(entry.project_id)
 
     app = FastAPI(title="Clarity Launcher", lifespan=lifespan)
 
@@ -341,6 +356,7 @@ def create_launcher(
             t.start()
 
         entry = ProcessEntry(
+            project_id=project.id,
             project_name=project.name,
             pid=proc.pid,
             port=port,
@@ -351,16 +367,16 @@ def create_launcher(
 
     async def _ensure_running(project: ProjectEntry) -> ProcessEntry:
         """Return a running ProcessEntry, spawning if needed."""
-        entry = processes.get(project.name)
+        entry = processes.get(project.id)
         if entry is not None:
-            processes.touch(project.name)
+            processes.touch(project.id)
             return entry
 
         entry = await asyncio.to_thread(_spawn_server, project)
         ok = await _wait_for_server(entry.port)
         if not ok:
             entry.process.terminate()
-            processes.remove(project.name)
+            processes.remove(project.id)
             raise RuntimeError(
                 f"Project server for {project.name!r} failed to start"
             )
@@ -371,22 +387,22 @@ def create_launcher(
 
         Returns the ProcessEntry if the server is (now) running, or None
         if there's no active project.  This handles the common case of a
-        launcher restart: the active project name is persisted but the
+        launcher restart: the active project id is persisted but the
         subprocess is gone.
         """
-        name = active_project["name"]
-        if name is None:
+        project_id = active_project["id"]
+        if project_id is None:
             return None
-        entry = processes.get(name)
+        entry = processes.get(project_id)
         if entry is not None:
-            processes.touch(name)
+            processes.touch(project_id)
             return entry
         # Server not running — try to (re)start it.
-        project = registry.get(name)
+        project = registry.get_by_id(project_id)
         if project is None or not Path(project.path).is_dir():
             if project is not None:
                 registry.remove(project.name)
-            active_project["name"] = None
+            active_project["id"] = None
             registry.clear_active()
             return None
         try:
@@ -425,12 +441,12 @@ def create_launcher(
         gone = [p for p in projects if not Path(p.path).is_dir()]
         for p in gone:
             registry.remove(p.name)
-            if p.name == active_project["name"]:
-                active_project["name"] = None
+            if p.id == active_project["id"]:
+                active_project["id"] = None
                 registry.clear_active()
         if gone:
             projects = [p for p in projects if Path(p.path).is_dir()]
-        running_names = {e.project_name for e in processes.all()}
+        running_ids = {e.project_id for e in processes.all()}
         return {
             "projects": [
                 {
@@ -439,8 +455,8 @@ def create_launcher(
                     "path": p.path,
                     "last_opened": p.last_opened,
                     "has_protocol": p.has_protocol,
-                    "running": p.name in running_names,
-                    "active": p.name == active_project["name"],
+                    "running": p.id in running_ids,
+                    "active": p.id == active_project["id"],
                 }
                 for p in projects
             ],
@@ -571,10 +587,12 @@ def create_launcher(
                         "path": str(project_path),
                     }
 
-        try:
-            entry = registry.add(name, project_path)
-        except ValueError as e:
-            raise HTTPException(status_code=409, detail=str(e)) from e
+        # ``registry.add`` is now path-keyed and idempotent — same
+        # path returns the existing entry, duplicate display names
+        # are allowed (two projects in different directories are
+        # genuinely different projects).  The old name-conflict 409
+        # path is unreachable.
+        entry = registry.add(name, project_path)
 
         return {
             "status": "ok",
@@ -587,12 +605,16 @@ def create_launcher(
 
     @app.delete("/api/projects/{name}")
     async def remove_project(name: str) -> dict[str, str]:
-        # Stop the server if running
-        proc = processes.remove(name)
-        if proc is not None:
-            proc.process.terminate()
-        if active_project["name"] == name:
-            active_project["name"] = None
+        # Resolve via registry so we can stop the right subprocess
+        # and clear active state when there are duplicate names.
+        project = registry.get(name)
+        if project is not None:
+            proc = processes.remove(project.id)
+            if proc is not None:
+                proc.process.terminate()
+            if active_project["id"] == project.id:
+                active_project["id"] = None
+                registry.clear_active()
         registry.remove(name)
         return {"status": "removed"}
 
@@ -600,17 +622,17 @@ def create_launcher(
         """Activate a project: start its server and mark it active."""
         if not Path(project.path).is_dir():
             registry.remove(project.name)
-            if active_project["name"] == project.name:
-                active_project["name"] = None
+            if active_project["id"] == project.id:
+                active_project["id"] = None
                 registry.clear_active()
             raise HTTPException(
                 status_code=410,
                 detail=f"Project directory no longer exists: {project.path}",
             )
         entry = await _ensure_running(project)
-        active_project["name"] = project.name
+        active_project["id"] = project.id
         registry.touch(project.name)
-        registry.set_active(project.name)
+        registry.set_active(project.id)
 
         # Fetch session info from the project server
         async with httpx.AsyncClient() as client:
@@ -633,6 +655,9 @@ def create_launcher(
 
     @app.post("/api/projects/{name}/activate")
     async def activate_project(name: str) -> dict[str, Any]:
+        # Name-keyed activation is first-match across duplicates;
+        # frontends with a known id should prefer
+        # ``activate-by-id`` to disambiguate.
         project = registry.get(name)
         if project is None:
             raise HTTPException(status_code=404, detail=f"Project not found: {name}")
@@ -647,24 +672,27 @@ def create_launcher(
 
     @app.post("/api/projects/{name}/deactivate")
     async def deactivate_project(name: str) -> dict[str, str]:
-        proc = processes.remove(name)
-        if proc is not None:
-            proc.process.terminate()
-        if active_project["name"] == name:
-            active_project["name"] = None
-            registry.clear_active()
+        project = registry.get(name)
+        if project is not None:
+            proc = processes.remove(project.id)
+            if proc is not None:
+                proc.process.terminate()
+            if active_project["id"] == project.id:
+                active_project["id"] = None
+                registry.clear_active()
         return {"status": "deactivated"}
 
     @app.get("/api/projects/active")
     async def get_active_project() -> dict[str, Any]:
-        name = active_project["name"]
-        if name is None:
+        project_id = active_project["id"]
+        if project_id is None:
             return {"active": False}
-        project = registry.get(name)
-        entry = processes.get(name) if name else None
+        project = registry.get_by_id(project_id)
+        entry = processes.get(project_id)
         return {
             "active": True,
-            "name": name,
+            "id": project_id,
+            "name": project.name if project else None,
             "path": project.path if project else None,
             "running": entry is not None,
         }
@@ -720,22 +748,28 @@ def create_launcher(
                         # if we got here.  Preserve the chat-session
                         # flag separately so the UI can distinguish.
                         data["active"] = True
-                        # Include project ID so the frontend can build
-                        # project-scoped URLs.
-                        name = active_project["name"]
-                        if name:
-                            proj = registry.get(name)
-                            if proj:
-                                data["project_id"] = proj.id
+                        # Include project id + path so the frontend
+                        # can build project-scoped URLs and so the
+                        # ProjectSwitcher's ``isCurrent`` comparison
+                        # matches the right entry even when display
+                        # names collide.  Resolve via id so duplicates
+                        # don't fall back to first-match.
+                        project_id = active_project["id"]
+                        proj = (
+                            registry.get_by_id(project_id)
+                            if project_id else None
+                        )
+                        if proj:
+                            data["project_id"] = proj.id
+                            data["project_dir"] = proj.path
                         # Persist SDK session ID so we can resume after
                         # a launcher restart.
                         new_sid = data.get("llm_session_id")
-                        name = active_project["name"]
-                        if new_sid and name:
+                        if new_sid and proj and proj.llm_session_id != new_sid:
                             try:
-                                proj = registry.get(name)
-                                if proj and proj.llm_session_id != new_sid:
-                                    registry.update(name, llm_session_id=new_sid)
+                                registry.update(
+                                    proj.name, llm_session_id=new_sid,
+                                )
                             except Exception:
                                 pass  # don't break the proxy
                         return data
@@ -775,10 +809,10 @@ def create_launcher(
             await ws.close()
             return
 
-        name = active_project["name"]
-        assert name is not None  # guaranteed by _ensure_active_running success
+        project_id = active_project["id"]
+        assert project_id is not None  # guaranteed by _ensure_active_running success
 
-        processes.touch(name)
+        processes.touch(project_id)
 
         # Connect to the project server's WebSocket.
         # websockets 13+ uses websockets.asyncio.client.

--- a/src/clarity_agent/web/launcher.py
+++ b/src/clarity_agent/web/launcher.py
@@ -242,7 +242,7 @@ def create_launcher(
     # ``get_active`` reads the new ``active_id`` key with a legacy
     # fallback to the old name-keyed ``active`` field.
     _persisted_active_id = registry.get_active()
-    if _persisted_active_id and registry.get_by_id(_persisted_active_id) is not None:
+    if _persisted_active_id and registry.get(_persisted_active_id) is not None:
         active_project["id"] = _persisted_active_id
 
     from clarity_agent.app_paths import clarity_env_path
@@ -398,10 +398,10 @@ def create_launcher(
             processes.touch(project_id)
             return entry
         # Server not running — try to (re)start it.
-        project = registry.get_by_id(project_id)
+        project = registry.get(project_id)
         if project is None or not Path(project.path).is_dir():
             if project is not None:
-                registry.remove(project.name)
+                registry.remove(project.id)
             active_project["id"] = None
             registry.clear_active()
             return None
@@ -436,16 +436,20 @@ def create_launcher(
 
     @app.get("/api/projects")
     async def list_projects() -> dict[str, Any]:
+        # ``registry.list()`` drops entries whose directories no
+        # longer exist on disk and writes the cleaned registry
+        # back, so callers see a current view.  We still have to
+        # sync the launcher's in-memory ``active_project["id"]``
+        # if the pruning happened to drop the active one — the
+        # registry can't reach into runtime state.
         projects = registry.list()
-        # Prune projects whose directories no longer exist.
-        gone = [p for p in projects if not Path(p.path).is_dir()]
-        for p in gone:
-            registry.remove(p.name)
-            if p.id == active_project["id"]:
-                active_project["id"] = None
-                registry.clear_active()
-        if gone:
-            projects = [p for p in projects if Path(p.path).is_dir()]
+        live_ids = {p.id for p in projects}
+        if (
+            active_project["id"] is not None
+            and active_project["id"] not in live_ids
+        ):
+            active_project["id"] = None
+            registry.clear_active()
         running_ids = {e.project_id for e in processes.all()}
         return {
             "projects": [
@@ -587,12 +591,19 @@ def create_launcher(
                         "path": str(project_path),
                     }
 
-        # ``registry.add`` is now path-keyed and idempotent — same
-        # path returns the existing entry, duplicate display names
-        # are allowed (two projects in different directories are
-        # genuinely different projects).  The old name-conflict 409
-        # path is unreachable.
-        entry = registry.add(name, project_path)
+        # ``registry.add`` is path-keyed and idempotent — same path
+        # returns the existing entry, duplicate display names are
+        # allowed (two projects in different directories are
+        # genuinely different projects).  The name from the request
+        # body is supplied as a keyword so the auto-derived default
+        # doesn't shadow what the user actually typed.
+        try:
+            entry = registry.add(project_path, name=name)
+        except FileNotFoundError as e:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Directory not found: {project_path}",
+            ) from e
 
         return {
             "status": "ok",
@@ -603,11 +614,23 @@ def create_launcher(
             "has_protocol": entry.has_protocol,
         }
 
-    @app.delete("/api/projects/{name}")
-    async def remove_project(name: str) -> dict[str, str]:
-        # Resolve via registry so we can stop the right subprocess
-        # and clear active state when there are duplicate names.
-        project = registry.get(name)
+    def _get_project_or_404(project_id: str) -> ProjectEntry:
+        """Look up a project by id; raise 404 if unknown.  Used by
+        every id-keyed route so the not-found response is uniform."""
+        project = registry.get(project_id)
+        if project is None:
+            raise HTTPException(
+                status_code=404, detail=f"Project not found: {project_id}",
+            )
+        return project
+
+    @app.delete("/api/projects/{project_id}")
+    async def remove_project(project_id: str) -> dict[str, str]:
+        # Idempotent: a 404 here means the caller's view was
+        # already stale (project disappeared between list and
+        # delete) — treat as success rather than surfacing an
+        # error the user has no way to act on.
+        project = registry.get(project_id)
         if project is not None:
             proc = processes.remove(project.id)
             if proc is not None:
@@ -615,13 +638,13 @@ def create_launcher(
             if active_project["id"] == project.id:
                 active_project["id"] = None
                 registry.clear_active()
-        registry.remove(name)
+            registry.remove(project.id)
         return {"status": "removed"}
 
     async def _do_activate(project: ProjectEntry) -> dict[str, Any]:
         """Activate a project: start its server and mark it active."""
         if not Path(project.path).is_dir():
-            registry.remove(project.name)
+            registry.remove(project.id)
             if active_project["id"] == project.id:
                 active_project["id"] = None
                 registry.clear_active()
@@ -631,7 +654,7 @@ def create_launcher(
             )
         entry = await _ensure_running(project)
         active_project["id"] = project.id
-        registry.touch(project.name)
+        registry.touch(project.id)
         registry.set_active(project.id)
 
         # Fetch session info from the project server
@@ -653,26 +676,17 @@ def create_launcher(
             "session": session_info,
         }
 
-    @app.post("/api/projects/{name}/activate")
-    async def activate_project(name: str) -> dict[str, Any]:
-        # Name-keyed activation is first-match across duplicates;
-        # frontends with a known id should prefer
-        # ``activate-by-id`` to disambiguate.
-        project = registry.get(name)
-        if project is None:
-            raise HTTPException(status_code=404, detail=f"Project not found: {name}")
-        return await _do_activate(project)
+    @app.post("/api/projects/{project_id}/activate")
+    async def activate_project(project_id: str) -> dict[str, Any]:
+        return await _do_activate(_get_project_or_404(project_id))
 
-    @app.post("/api/projects/activate-by-id/{project_id}")
-    async def activate_project_by_id(project_id: str) -> dict[str, Any]:
-        project = registry.get_by_id(project_id)
-        if project is None:
-            raise HTTPException(status_code=404, detail=f"Project not found: {project_id}")
-        return await _do_activate(project)
-
-    @app.post("/api/projects/{name}/deactivate")
-    async def deactivate_project(name: str) -> dict[str, str]:
-        project = registry.get(name)
+    @app.post("/api/projects/{project_id}/deactivate")
+    async def deactivate_project(project_id: str) -> dict[str, str]:
+        # Idempotent: a 404 here would just confuse the caller.
+        # If the project's already gone we treat the deactivate as
+        # already-applied; if it's there we tear down its server
+        # and clear the active state.
+        project = registry.get(project_id)
         if project is not None:
             proc = processes.remove(project.id)
             if proc is not None:
@@ -687,7 +701,7 @@ def create_launcher(
         project_id = active_project["id"]
         if project_id is None:
             return {"active": False}
-        project = registry.get_by_id(project_id)
+        project = registry.get(project_id)
         entry = processes.get(project_id)
         return {
             "active": True,
@@ -756,7 +770,7 @@ def create_launcher(
                         # don't fall back to first-match.
                         project_id = active_project["id"]
                         proj = (
-                            registry.get_by_id(project_id)
+                            registry.get(project_id)
                             if project_id else None
                         )
                         if proj:
@@ -768,7 +782,7 @@ def create_launcher(
                         if new_sid and proj and proj.llm_session_id != new_sid:
                             try:
                                 registry.update(
-                                    proj.name, llm_session_id=new_sid,
+                                    proj.id, llm_session_id=new_sid,
                                 )
                             except Exception:
                                 pass  # don't break the proxy

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -13,13 +13,21 @@ from clarity_agent.web.launcher import ProcessEntry, ProcessTable, _find_free_po
 # ProcessTable tests
 # ---------------------------------------------------------------------------
 
-def _make_entry(name: str, alive: bool = True) -> ProcessEntry:
-    """Create a ProcessEntry with a mocked subprocess."""
+def _make_entry(
+    id_: str, name: str | None = None, alive: bool = True,
+) -> ProcessEntry:
+    """Create a ProcessEntry with a mocked subprocess.
+
+    The table is keyed by ``project_id``; ``project_name`` is kept
+    around as metadata for display.  Tests default ``name`` to the
+    id so collision-free cases stay terse.
+    """
     proc = MagicMock(spec=subprocess.Popen)
     proc.poll.return_value = None if alive else 1
     proc.pid = 12345
     return ProcessEntry(
-        project_name=name,
+        project_id=id_,
+        project_name=name if name is not None else id_,
         pid=proc.pid,
         port=9000,
         process=proc,
@@ -61,7 +69,7 @@ class TestProcessTable:
         table.add(_make_entry("dead", alive=False))
         entries = table.all()
         assert len(entries) == 1
-        assert entries[0].project_name == "alive"
+        assert entries[0].project_id == "alive"
 
     def test_kill_all(self) -> None:
         table = ProcessTable()
@@ -95,7 +103,20 @@ class TestProcessTable:
         table.add(new)
         idle = table.idle_entries(1800)
         assert len(idle) == 1
-        assert idle[0].project_name == "old"
+        assert idle[0].project_id == "old"
+
+    def test_duplicate_names_at_different_ids_coexist(self) -> None:
+        # The whole reason for keying by id: two projects sharing
+        # a display name shouldn't overwrite each other in the
+        # process table.
+        table = ProcessTable()
+        a = _make_entry("id-a", name="raas2")
+        b = _make_entry("id-b", name="raas2")
+        table.add(a)
+        table.add(b)
+        assert table.get("id-a") is a
+        assert table.get("id-b") is b
+        assert len(table.all()) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_launcher_create_project_endpoint.py
+++ b/tests/test_launcher_create_project_endpoint.py
@@ -317,3 +317,97 @@ class TestValidation:
         })
         assert r.status_code == 400
         assert "not found" in r.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Registry is path-keyed: same path → idempotent ok, same name OK at
+# different paths.
+# ---------------------------------------------------------------------------
+
+
+class TestAlreadyRegistered:
+    """Regression for the silent-409 bug.  Path is the registry's
+    primary key; the display ``name`` is not a uniqueness constraint
+    (two projects in different directories are genuinely different
+    projects, even if a user wants to call them the same thing)."""
+
+    def test_same_path_is_idempotent_ok(
+        self, client: TestClient, tmp_path: Path,
+    ) -> None:
+        project = tmp_path / "raas2"
+        project.mkdir()
+        (project / PROTOCOL_DIR_VISIBLE).mkdir()
+
+        # First open registers it.
+        first = client.post("/api/projects", json={
+            "name": "raas2", "path": str(project),
+            "intent": "open_existing",
+        })
+        assert first.status_code == 200
+        first_id = first.json()["id"]
+
+        # Second open (same path) — used to silently 409.  Now an
+        # idempotent ok returning the same registry entry.
+        second = client.post("/api/projects", json={
+            "name": "raas2", "path": str(project),
+            "intent": "open_existing",
+        })
+        assert second.status_code == 200, second.text
+        assert second.json()["status"] == "ok"
+        assert second.json()["id"] == first_id
+
+    def test_same_name_different_path_both_register(
+        self, client: TestClient, tmp_path: Path,
+    ) -> None:
+        # Two clean projects at different paths, same display name —
+        # both should register successfully.  The launcher
+        # disambiguates by ``id`` for activation.
+        first_path = tmp_path / "alpha"
+        first_path.mkdir()
+        (first_path / PROTOCOL_DIR_VISIBLE).mkdir()
+        second_path = tmp_path / "beta"
+        second_path.mkdir()
+        (second_path / PROTOCOL_DIR_VISIBLE).mkdir()
+
+        first = client.post("/api/projects", json={
+            "name": "ws", "path": str(first_path),
+            "intent": "open_existing",
+        })
+        assert first.status_code == 200
+        first_id = first.json()["id"]
+
+        second = client.post("/api/projects", json={
+            "name": "ws", "path": str(second_path),
+            "intent": "open_existing",
+        })
+        assert second.status_code == 200, second.text
+        assert second.json()["status"] == "ok"
+        # Different paths produce different ids — they're genuinely
+        # different entries despite the shared display name.
+        assert second.json()["id"] != first_id
+        assert second.json()["path"] == str(second_path)
+
+    def test_same_path_different_name_renames(
+        self, client: TestClient, tmp_path: Path,
+    ) -> None:
+        # Re-opening the same path with a new name should update
+        # the display label rather than refusing — same project,
+        # the user is just relabeling it.
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / PROTOCOL_DIR_VISIBLE).mkdir()
+
+        first = client.post("/api/projects", json={
+            "name": "old-name", "path": str(project),
+            "intent": "open_existing",
+        })
+        assert first.status_code == 200
+
+        second = client.post("/api/projects", json={
+            "name": "new-name", "path": str(project),
+            "intent": "open_existing",
+        })
+        assert second.status_code == 200, second.text
+        assert second.json()["name"] == "new-name"
+        # Same path means same id — it's the same project entry.
+        assert second.json()["id"] == first.json()["id"]

--- a/tests/test_launcher_create_project_endpoint.py
+++ b/tests/test_launcher_create_project_endpoint.py
@@ -411,3 +411,74 @@ class TestAlreadyRegistered:
         assert second.json()["name"] == "new-name"
         # Same path means same id — it's the same project entry.
         assert second.json()["id"] == first.json()["id"]
+
+
+# ---------------------------------------------------------------------------
+# Id-keyed routes: 404 on unknown id; idempotent delete/deactivate
+# ---------------------------------------------------------------------------
+
+
+class TestIdKeyedRoutes:
+    """All routes that take a project identifier in the URL use the
+    stable id (path-derived hash), never the display name.  These
+    tests pin down both the 404 contract for activate (where the
+    caller really does need to know the project exists) and the
+    idempotent succeed-on-missing contract for delete/deactivate
+    (where surfacing a 404 would just race with stale UI views)."""
+
+    def test_activate_404_when_unknown_id(
+        self, client: TestClient,
+    ) -> None:
+        # The activate route needs to look the project up to spawn
+        # its server — there's no sensible "proceed anyway" when
+        # the id doesn't exist, so 404 is the right answer.
+        r = client.post("/api/projects/bogus-id-123/activate")
+        assert r.status_code == 404
+        assert "not found" in r.json()["detail"].lower()
+
+    def test_delete_unknown_id_is_idempotent(
+        self, client: TestClient,
+    ) -> None:
+        # The frontend issues DELETE during cleanup paths (e.g.
+        # confirming removal of a project the user picked from the
+        # list).  By the time the request lands the user's view
+        # may already be stale — a 404 here would force the
+        # frontend to special-case "the project went away while I
+        # was deleting it", which is the same outcome as success.
+        # Always 200; remove() is silent on unknown ids by design.
+        r = client.delete("/api/projects/bogus-id-123")
+        assert r.status_code == 200
+        assert r.json()["status"] == "removed"
+
+    def test_deactivate_unknown_id_is_idempotent(
+        self, client: TestClient,
+    ) -> None:
+        # Same logic as delete — deactivate is fundamentally a
+        # "ensure not running" operation; an unknown id is
+        # trivially "already not running."
+        r = client.post("/api/projects/bogus-id-123/deactivate")
+        assert r.status_code == 200
+        assert r.json()["status"] == "deactivated"
+
+    def test_delete_actual_id_works(
+        self, client: TestClient, tmp_path: Path,
+    ) -> None:
+        # Round-trip: create → delete by id → confirm it's gone.
+        # Pins down that the id from the create response is what
+        # the DELETE route expects.
+        project = tmp_path / "doomed"
+        project.mkdir()
+        (project / PROTOCOL_DIR_VISIBLE).mkdir()
+
+        created = client.post("/api/projects", json={
+            "name": "doomed", "path": str(project),
+            "intent": "open_existing",
+        })
+        assert created.status_code == 200
+        project_id = created.json()["id"]
+
+        r = client.delete(f"/api/projects/{project_id}")
+        assert r.status_code == 200
+
+        listed = client.get("/api/projects").json()["projects"]
+        assert project_id not in {p["id"] for p in listed}

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,4 +1,11 @@
-"""Tests for the clarity_agent.projects module."""
+"""Tests for the clarity_agent.projects module.
+
+The registry is path-keyed with an id derived from the path; the
+action verbs (``get``, ``update``, ``touch``, ``remove``) all take
+that id.  Name lookups go through :meth:`find_by_name`, which
+returns a list because names aren't unique.  These tests pin all
+of that down so future drifts get caught.
+"""
 
 from __future__ import annotations
 
@@ -25,54 +32,104 @@ def sample_project(tmp_path: Path) -> Path:
     return d
 
 
+# ---------------------------------------------------------------------------
+# ProjectEntry — refresh semantics
+# ---------------------------------------------------------------------------
+
+
 class TestProjectEntry:
     def test_refresh_detects_protocol(self, sample_project: Path) -> None:
         entry = ProjectEntry(name="test", path=str(sample_project))
         assert not entry.has_protocol
-        entry.refresh()
+        assert entry.refresh() is True
         assert entry.has_protocol
 
     def test_refresh_no_protocol(self, tmp_path: Path) -> None:
         d = tmp_path / "bare"
         d.mkdir()
         entry = ProjectEntry(name="bare", path=str(d))
-        entry.refresh()
+        assert entry.refresh() is True
         assert not entry.has_protocol
 
+    def test_refresh_returns_false_when_path_gone(
+        self, tmp_path: Path,
+    ) -> None:
+        # The refresh-returns-bool contract is what lets the
+        # registry filter vanished entries on read.
+        d = tmp_path / "transient"
+        d.mkdir()
+        entry = ProjectEntry(name="t", path=str(d))
+        assert entry.refresh() is True
+        d.rmdir()
+        assert entry.refresh() is False
 
-class TestRegistryBasics:
-    def test_empty_list(self, registry: ProjectRegistry) -> None:
-        assert registry.list() == []
 
-    def test_add_and_list(
+# ---------------------------------------------------------------------------
+# add() — path-keyed, default name from basename, idempotent reopens
+# ---------------------------------------------------------------------------
+
+
+class TestAdd:
+    def test_basic_add(
         self, registry: ProjectRegistry, sample_project: Path,
     ) -> None:
-        entry = registry.add("proj", sample_project)
+        entry = registry.add(sample_project, name="proj")
         assert entry.name == "proj"
         assert entry.path == str(sample_project.resolve())
         assert entry.has_protocol is True
 
         entries = registry.list()
         assert len(entries) == 1
-        assert entries[0].name == "proj"
+        assert entries[0].id == entry.id
 
-    def test_add_duplicate_name_at_different_paths_both_register(
+    def test_default_name_from_basename(
         self, registry: ProjectRegistry, tmp_path: Path,
     ) -> None:
-        # Path is the registry's primary key — display ``name`` is
-        # not a uniqueness constraint.  Two genuinely-different
-        # projects in different directories can share a display
-        # label; the entries are still distinguishable by ``id``.
+        # Without an explicit name=, the entry's display label is
+        # the basename of the path the caller supplied — the natural
+        # default for menu-driven "Open Project…" flows that have
+        # nothing better to suggest.
+        d = tmp_path / "my-thing"
+        d.mkdir()
+        entry = registry.add(d)
+        assert entry.name == "my-thing"
+
+    def test_default_name_from_unresolved_basename(
+        self, tmp_path: Path,
+    ) -> None:
+        # When the caller hands us a symlinked path, the default
+        # name should come from the symlink itself (what they
+        # picked), not from the resolved target's basename.
+        target = tmp_path / "actual-name"
+        target.mkdir()
+        link = tmp_path / "user-picked-name"
+        link.symlink_to(target)
+
+        reg = ProjectRegistry(path=tmp_path / "projects.json")
+        entry = reg.add(link)
+        # The user picked "user-picked-name" — that's what should
+        # appear in the project list, not "actual-name".
+        assert entry.name == "user-picked-name"
+        # But the stored path is resolved so identity is canonical.
+        assert entry.path == str(target.resolve())
+
+    def test_duplicate_name_different_paths_both_register(
+        self, registry: ProjectRegistry, tmp_path: Path,
+    ) -> None:
+        # Path is the registry's primary key — display names aren't
+        # unique.  Two genuinely-different projects in different
+        # directories can share a label; the entries are still
+        # distinguishable by id.
         d1 = tmp_path / "a"
         d1.mkdir()
         d2 = tmp_path / "b"
         d2.mkdir()
-        e1 = registry.add("same", d1)
-        e2 = registry.add("same", d2)
+        e1 = registry.add(d1, name="same")
+        e2 = registry.add(d2, name="same")
         assert e1.id != e2.id
         assert {e.path for e in registry.list()} == {str(d1), str(d2)}
 
-    def test_add_same_path_is_idempotent(
+    def test_same_path_is_idempotent(
         self, registry: ProjectRegistry, tmp_path: Path,
     ) -> None:
         # Re-adding the same path returns the existing entry — no
@@ -80,65 +137,97 @@ class TestRegistryBasics:
         # project" safe to call against an already-registered dir.
         d = tmp_path / "proj"
         d.mkdir()
-        first = registry.add("proj", d)
-        second = registry.add("proj", d)
+        first = registry.add(d, name="proj")
+        second = registry.add(d, name="proj")
         assert first.id == second.id
         assert len(registry.list()) == 1
 
-    def test_add_same_path_different_name_renames(
+    def test_same_path_different_name_renames(
         self, registry: ProjectRegistry, tmp_path: Path,
     ) -> None:
         # User re-opening the same path with a new label: relabel
         # the existing entry rather than creating a duplicate.
         d = tmp_path / "proj"
         d.mkdir()
-        registry.add("old-label", d)
-        updated = registry.add("new-label", d)
+        registry.add(d, name="old-label")
+        updated = registry.add(d, name="new-label")
         assert updated.name == "new-label"
         assert len(registry.list()) == 1
 
-    def test_remove(
+    def test_missing_path_raises(
+        self, registry: ProjectRegistry, tmp_path: Path,
+    ) -> None:
+        # The registry holds entries for directories that actually
+        # exist; an attempt to add a vanished path should refuse
+        # rather than poisoning the registry with a phantom.
+        with pytest.raises(FileNotFoundError):
+            registry.add(tmp_path / "nope", name="ghost")
+
+
+# ---------------------------------------------------------------------------
+# Lookups — id is the default (no suffix); name + path get explicit suffixes
+# ---------------------------------------------------------------------------
+
+
+class TestLookups:
+    def test_get_by_id(
         self, registry: ProjectRegistry, sample_project: Path,
     ) -> None:
-        registry.add("proj", sample_project)
-        registry.remove("proj")
-        assert registry.list() == []
+        entry = registry.add(sample_project, name="proj")
+        assert registry.get(entry.id) == entry
+        assert registry.get("nope-not-an-id") is None
 
-    def test_remove_nonexistent_is_silent(
-        self, registry: ProjectRegistry,
+    def test_find_by_name_returns_list(
+        self, registry: ProjectRegistry, tmp_path: Path,
     ) -> None:
-        registry.remove("ghost")  # should not raise
+        # Names aren't unique → ``find_by_name`` returns every
+        # match, not just the first.  Callers handle 0/1/N.
+        d1 = tmp_path / "a"
+        d1.mkdir()
+        d2 = tmp_path / "b"
+        d2.mkdir()
+        d3 = tmp_path / "c"
+        d3.mkdir()
+        registry.add(d1, name="dup")
+        registry.add(d2, name="dup")
+        registry.add(d3, name="solo")
 
+        dups = registry.find_by_name("dup")
+        assert len(dups) == 2
+        assert {e.path for e in dups} == {str(d1), str(d2)}
 
-class TestRegistryLookup:
-    def test_get_by_name(
+        solo = registry.find_by_name("solo")
+        assert len(solo) == 1
+
+        none = registry.find_by_name("ghost")
+        assert none == []
+
+    def test_get_by_path(
         self, registry: ProjectRegistry, sample_project: Path,
     ) -> None:
-        registry.add("proj", sample_project)
-        proj = registry.get("proj")
-        assert proj is not None
-        assert proj.name == "proj"
-        assert registry.get("nope") is None
-
-    def test_find_by_path(
-        self, registry: ProjectRegistry, sample_project: Path,
-    ) -> None:
-        registry.add("proj", sample_project)
-        found = registry.find_by_path(sample_project)
+        # Paths are unique by construction so ``get_by_path`` is
+        # single-result (matches the ``get_*`` naming convention).
+        registry.add(sample_project, name="proj")
+        found = registry.get_by_path(sample_project)
         assert found is not None
-        assert found.name == "proj"
-        assert registry.find_by_path("/nonexistent") is None
+        assert found.path == str(sample_project.resolve())
+        assert registry.get_by_path("/nonexistent") is None
 
 
-class TestRegistryUpdate:
+# ---------------------------------------------------------------------------
+# Mutators — all id-keyed
+# ---------------------------------------------------------------------------
+
+
+class TestUpdate:
     def test_update_fields(
         self, registry: ProjectRegistry, sample_project: Path,
     ) -> None:
-        registry.add("proj", sample_project)
-        updated = registry.update("proj", has_protocol=False)
+        entry = registry.add(sample_project, name="proj")
+        updated = registry.update(entry.id, has_protocol=False)
         assert updated.has_protocol is False
-        # Persisted
-        loaded = registry.get("proj")
+        # Persisted across re-read.
+        loaded = registry.get(entry.id)
         assert loaded is not None
         assert loaded.has_protocol is False
 
@@ -146,37 +235,66 @@ class TestRegistryUpdate:
         self, registry: ProjectRegistry,
     ) -> None:
         with pytest.raises(KeyError, match="not found"):
-            registry.update("ghost", has_protocol=True)
+            registry.update("bogus-id", has_protocol=True)
 
     def test_update_bad_field_raises(
         self, registry: ProjectRegistry, sample_project: Path,
     ) -> None:
-        registry.add("proj", sample_project)
+        entry = registry.add(sample_project, name="proj")
         with pytest.raises(AttributeError, match="no field"):
-            registry.update("proj", bogus=42)
+            registry.update(entry.id, bogus=42)
 
-    def test_touch(
+
+class TestTouch:
+    def test_touch_updates_last_opened(
         self, registry: ProjectRegistry, sample_project: Path,
     ) -> None:
-        registry.add("proj", sample_project)
-        before = registry.get("proj")
-        assert before is not None
-        old_time = before.last_opened
+        entry = registry.add(sample_project, name="proj")
+        old_time = entry.last_opened
         time.sleep(0.01)
-        registry.touch("proj")
-        after = registry.get("proj")
+        registry.touch(entry.id)
+        after = registry.get(entry.id)
         assert after is not None
         assert after.last_opened > old_time
 
+    def test_touch_nonexistent_raises(
+        self, registry: ProjectRegistry,
+    ) -> None:
+        with pytest.raises(KeyError):
+            registry.touch("bogus-id")
 
-class TestRegistryOrdering:
-    def test_list_sorted_by_last_opened(
+
+class TestRemove:
+    def test_remove_by_id(
+        self, registry: ProjectRegistry, sample_project: Path,
+    ) -> None:
+        entry = registry.add(sample_project, name="proj")
+        registry.remove(entry.id)
+        assert registry.list() == []
+
+    def test_remove_nonexistent_is_silent(
+        self, registry: ProjectRegistry,
+    ) -> None:
+        # Defensive: remove() is commonly invoked during cleanup
+        # paths that don't already know whether the entry is still
+        # present, so it shouldn't raise.
+        registry.remove("ghost-id")
+
+
+# ---------------------------------------------------------------------------
+# list() — sorted by last_opened; prunes vanished paths
+# ---------------------------------------------------------------------------
+
+
+class TestList:
+    def test_sorted_by_last_opened(
         self, registry: ProjectRegistry, tmp_path: Path,
     ) -> None:
+        ids: list[str] = []
         for name in ("old", "mid", "new"):
             d = tmp_path / name
             d.mkdir()
-            registry.add(name, d)
+            ids.append(registry.add(d, name=name).id)
             time.sleep(0.01)
 
         entries = registry.list()
@@ -185,19 +303,61 @@ class TestRegistryOrdering:
     def test_touch_reorders(
         self, registry: ProjectRegistry, tmp_path: Path,
     ) -> None:
+        ids: list[str] = []
         for name in ("a", "b", "c"):
             d = tmp_path / name
             d.mkdir()
-            registry.add(name, d)
+            ids.append(registry.add(d, name=name).id)
             time.sleep(0.01)
 
-        registry.touch("a")
+        # Touch the oldest — it should move to the front of the list.
+        registry.touch(ids[0])
         entries = registry.list()
         assert entries[0].name == "a"
 
+    def test_prunes_vanished_paths(
+        self, registry: ProjectRegistry, tmp_path: Path,
+    ) -> None:
+        # ``refresh=True`` (the default) drops entries whose
+        # directories no longer exist and writes the cleaned
+        # registry back, so callers always see a current view.
+        d = tmp_path / "transient"
+        d.mkdir()
+        entry = registry.add(d, name="t")
+        assert len(registry.list()) == 1
+
+        d.rmdir()
+        assert registry.list() == []
+
+        # And the prune is persistent — the next read confirms
+        # the entry is gone from disk too.
+        fresh = ProjectRegistry(path=registry._path)
+        assert fresh.list(refresh=False) == []
+        # Pin down that we're really exercising the persistence —
+        # otherwise this test could pass via a stale in-memory list.
+        assert entry.id not in {e.id for e in fresh.list(refresh=False)}
+
+    def test_refresh_false_keeps_vanished_entries(
+        self, registry: ProjectRegistry, tmp_path: Path,
+    ) -> None:
+        # ``refresh=False`` is the "I just want the raw registry,
+        # don't touch disk" mode used by tests + persistence
+        # round-trips.  Vanished entries stay until a refreshing
+        # read prunes them.
+        d = tmp_path / "transient"
+        d.mkdir()
+        registry.add(d, name="t")
+        d.rmdir()
+        assert len(registry.list(refresh=False)) == 1
+
+
+# ---------------------------------------------------------------------------
+# discover() — auto-register a workspace's subdirectories
+# ---------------------------------------------------------------------------
+
 
 class TestDiscover:
-    def test_discover_finds_subdirectories(
+    def test_finds_subdirectories(
         self, registry: ProjectRegistry, tmp_path: Path,
     ) -> None:
         base = tmp_path / "Clarity Projects"
@@ -212,35 +372,37 @@ class TestDiscover:
         names = {e.name for e in added}
         assert names == {"alpha", "beta"}
 
-        # beta has protocol
-        beta = registry.get("beta")
-        assert beta is not None
-        assert beta.has_protocol is True
+        # beta has the protocol marker.
+        beta_matches = registry.find_by_name("beta")
+        assert len(beta_matches) == 1
+        assert beta_matches[0].has_protocol is True
 
-    def test_discover_skips_already_registered(
+    def test_skips_already_registered(
         self, registry: ProjectRegistry, tmp_path: Path,
     ) -> None:
         base = tmp_path / "Clarity Projects"
         base.mkdir()
         d = base / "existing"
         d.mkdir()
-        registry.add("existing", d)
+        registry.add(d, name="existing")
 
         added = registry.discover(base)
-        assert len(added) == 0
+        assert added == []
 
-    def test_discover_nonexistent_base(
+    def test_nonexistent_base_returns_empty(
         self, registry: ProjectRegistry, tmp_path: Path,
     ) -> None:
         assert registry.discover(tmp_path / "nope") == []
 
-    def test_discover_deduplicates_names(
+    def test_deduplicates_names(
         self, registry: ProjectRegistry, tmp_path: Path,
     ) -> None:
-        # Register a project with name "dup" at a different path.
+        # discover() auto-disambiguates display labels so the
+        # project list stays readable even when two scanned dirs
+        # would share a name with an existing entry.
         other = tmp_path / "other"
         other.mkdir()
-        registry.add("dup", other)
+        registry.add(other, name="dup")
 
         base = tmp_path / "Clarity Projects"
         base.mkdir()
@@ -251,6 +413,11 @@ class TestDiscover:
         assert added[0].name == "dup-2"
 
 
+# ---------------------------------------------------------------------------
+# Persistence — registry survives reload; corrupted file degrades cleanly
+# ---------------------------------------------------------------------------
+
+
 class TestPersistence:
     def test_survives_reload(self, tmp_path: Path) -> None:
         path = tmp_path / "projects.json"
@@ -258,12 +425,12 @@ class TestPersistence:
         d.mkdir()
 
         r1 = ProjectRegistry(path=path)
-        r1.add("proj", d)
+        entry = r1.add(d, name="proj")
 
         r2 = ProjectRegistry(path=path)
         entries = r2.list(refresh=False)
         assert len(entries) == 1
-        assert entries[0].name == "proj"
+        assert entries[0].id == entry.id
 
     def test_corrupt_file_returns_empty(self, tmp_path: Path) -> None:
         path = tmp_path / "projects.json"

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -56,16 +56,46 @@ class TestRegistryBasics:
         assert len(entries) == 1
         assert entries[0].name == "proj"
 
-    def test_add_duplicate_name_raises(
+    def test_add_duplicate_name_at_different_paths_both_register(
         self, registry: ProjectRegistry, tmp_path: Path,
     ) -> None:
+        # Path is the registry's primary key — display ``name`` is
+        # not a uniqueness constraint.  Two genuinely-different
+        # projects in different directories can share a display
+        # label; the entries are still distinguishable by ``id``.
         d1 = tmp_path / "a"
         d1.mkdir()
         d2 = tmp_path / "b"
         d2.mkdir()
-        registry.add("same", d1)
-        with pytest.raises(ValueError, match="already exists"):
-            registry.add("same", d2)
+        e1 = registry.add("same", d1)
+        e2 = registry.add("same", d2)
+        assert e1.id != e2.id
+        assert {e.path for e in registry.list()} == {str(d1), str(d2)}
+
+    def test_add_same_path_is_idempotent(
+        self, registry: ProjectRegistry, tmp_path: Path,
+    ) -> None:
+        # Re-adding the same path returns the existing entry — no
+        # duplicate row, no exception.  This is what makes "open
+        # project" safe to call against an already-registered dir.
+        d = tmp_path / "proj"
+        d.mkdir()
+        first = registry.add("proj", d)
+        second = registry.add("proj", d)
+        assert first.id == second.id
+        assert len(registry.list()) == 1
+
+    def test_add_same_path_different_name_renames(
+        self, registry: ProjectRegistry, tmp_path: Path,
+    ) -> None:
+        # User re-opening the same path with a new label: relabel
+        # the existing entry rather than creating a duplicate.
+        d = tmp_path / "proj"
+        d.mkdir()
+        registry.add("old-label", d)
+        updated = registry.add("new-label", d)
+        assert updated.name == "new-label"
+        assert len(registry.list()) == 1
 
     def test_remove(
         self, registry: ProjectRegistry, sample_project: Path,

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -162,6 +162,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -524,6 +525,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -564,6 +566,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -585,6 +588,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -2119,8 +2123,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2251,6 +2254,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2262,6 +2266,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2317,6 +2322,7 @@
       "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -2711,6 +2717,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2761,7 +2768,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2772,7 +2778,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3122,6 +3127,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3689,8 +3695,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3960,6 +3965,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5319,6 +5325,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5348,6 +5355,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -5571,7 +5579,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6890,6 +6897,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7049,7 +7057,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7105,6 +7112,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7117,6 +7125,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7130,8 +7139,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-markdown": {
       "version": "9.1.0",
@@ -7954,6 +7962,7 @@
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -8067,6 +8076,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8286,6 +8296,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8516,6 +8527,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -8609,6 +8621,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8930,6 +8943,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/src/__tests__/ProjectSwitcher.test.tsx
+++ b/web/src/__tests__/ProjectSwitcher.test.tsx
@@ -89,7 +89,10 @@ describe("ProjectSwitcher remove flow", () => {
     await userEvent.click(screen.getByRole("button", { name: "Remove" }));
 
     await waitFor(() => {
-      expect(removeProjectMock).toHaveBeenCalledWith("alpha");
+      // Routes are id-keyed now — name lookup would be ambiguous
+      // (the registry allows duplicate display labels).  The id
+      // comes from ``makeProject``'s default ("abc12345").
+      expect(removeProjectMock).toHaveBeenCalledWith("abc12345");
     });
     await waitFor(() => {
       expect(screen.queryByText("alpha")).not.toBeInTheDocument();

--- a/web/src/__tests__/apiClient.test.ts
+++ b/web/src/__tests__/apiClient.test.ts
@@ -202,12 +202,15 @@ describe("API client", () => {
       expect(result).toEqual(data);
     });
 
-    it("removeProject sends DELETE with url-encoded name", async () => {
+    it("removeProject sends DELETE to /api/projects/{id}", async () => {
       mockFetch.mockReturnValue(jsonResponse({ status: "removed" }));
 
-      const result = await removeProject("my project/with space");
+      // Real ids are 8-char hex hashes; encodeURIComponent is a no-op
+      // on those, but the wrapper still calls it defensively, so the
+      // test passes a synthetic value to exercise the encoding path.
+      const result = await removeProject("ab/cd ef");
       expect(mockFetch).toHaveBeenCalledWith(
-        "/api/projects/my%20project%2Fwith%20space",
+        "/api/projects/ab%2Fcd%20ef",
         { method: "DELETE" },
       );
       expect(result).toEqual({ status: "removed" });

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -270,26 +270,27 @@ export async function createProject(args: {
   throw new Error(`${res.status}: ${errorBody}`);
 }
 
-export const removeProject = (name: string) =>
-  fetchJson<{ status: string }>(`/api/projects/${encodeURIComponent(name)}`, {
-    method: "DELETE",
-  });
-
-export const activateProject = (name: string) =>
-  fetchJson<{ id: string; name: string; path: string; port: number; session: SessionInfo }>(
-    `/api/projects/${encodeURIComponent(name)}/activate`,
-    { method: "POST" },
-  );
-
-export const activateProjectById = (id: string) =>
-  fetchJson<{ id: string; name: string; path: string; port: number; session: SessionInfo }>(
-    `/api/projects/activate-by-id/${encodeURIComponent(id)}`,
-    { method: "POST" },
-  );
-
-export const deactivateProject = (name: string) =>
+// Project lifecycle routes are all id-keyed.  Display names aren't
+// unique (the registry deliberately allows two projects with the
+// same label in different directories), so routing by name would
+// produce ambiguous outcomes; the launcher dropped its name-keyed
+// routes when the registry switched to path-as-identity.  Always
+// pass the ``id`` from the project list / create-project response.
+export const removeProject = (projectId: string) =>
   fetchJson<{ status: string }>(
-    `/api/projects/${encodeURIComponent(name)}/deactivate`,
+    `/api/projects/${encodeURIComponent(projectId)}`,
+    { method: "DELETE" },
+  );
+
+export const activateProject = (projectId: string) =>
+  fetchJson<{ id: string; name: string; path: string; port: number; session: SessionInfo }>(
+    `/api/projects/${encodeURIComponent(projectId)}/activate`,
+    { method: "POST" },
+  );
+
+export const deactivateProject = (projectId: string) =>
+  fetchJson<{ status: string }>(
+    `/api/projects/${encodeURIComponent(projectId)}/deactivate`,
     { method: "POST" },
   );
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -210,6 +210,18 @@ export type CreateProjectResult =
   | { status: "broken_install"; brokenness: string; path: string }
   | { status: "embedded_install_required"; command: string; path: string };
 
+// Set of recognized status discriminators, kept next to the union
+// so the runtime guard below can't drift from the type.  Name
+// collisions are NOT a status — the registry is path-keyed and
+// allows duplicate display names; same-path reopens come back as
+// "ok".
+const KNOWN_CREATE_PROJECT_STATUSES = new Set([
+  "ok",
+  "needs_setup",
+  "broken_install",
+  "embedded_install_required",
+]);
+
 /**
  * Register / set up a project.  See the server-side docstring on
  * ``create_project`` for the per-(intent, mode, disk-state)
@@ -229,9 +241,12 @@ export async function createProject(args: {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(args),
   });
-  // The launcher returns 409 with structured bodies for the two
-  // setup-decision-needed cases; everything else is either a
-  // success (200) or a genuine error.
+  // The launcher returns 409 with structured bodies whose
+  // ``status`` field discriminates the case (broken_install,
+  // needs_setup, name_conflict, …).  Anything else — 4xx without
+  // a recognised status, 5xx, network — throws so the caller's
+  // catch block surfaces it instead of the UI silently swallowing
+  // a body it doesn't understand.
   if (res.status === 200 || res.status === 409) {
     const body = await res.json();
     if (res.status === 200 && !body.status) {
@@ -242,7 +257,14 @@ export async function createProject(args: {
       const { status: _s, ...entry } = body;
       return { status: "ok", entry: entry as ProjectEntry };
     }
-    return body as CreateProjectResult;
+    if (KNOWN_CREATE_PROJECT_STATUSES.has(body?.status)) {
+      return body as CreateProjectResult;
+    }
+    // Unrecognised body — most often FastAPI's ``{"detail": ...}``
+    // from a bare ``HTTPException``.  Throw with the most useful
+    // string we can pull out so the caller's catch surfaces it.
+    const reason = body?.detail || body?.message || JSON.stringify(body);
+    throw new Error(`${res.status}: ${reason}`);
   }
   const errorBody = await res.text();
   throw new Error(`${res.status}: ${errorBody}`);

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Outlet, useLocation, useNavigate, useParams } from "react-router-dom";
-import { activateProjectById, createProject, getProjects, removeProject, getSession, getSettings, getSetupStatus } from "../api/client";
+import { activateProject, createProject, getProjects, removeProject, getSession, getSettings, getSetupStatus } from "../api/client";
 import { ChatProvider } from "../hooks/useChat";
 import type { SessionInfo } from "../types";
 import FeedbackDialog from "./FeedbackDialog";
@@ -79,7 +79,7 @@ export default function Layout() {
     }
     activatingRef.current = projectId;
     setSessionLoading(true);
-    activateProjectById(projectId)
+    activateProject(projectId)
       .then(() => fetchSession())
       .catch((err: unknown) => {
         // The launcher returns 410 when a project's directory no longer
@@ -130,7 +130,7 @@ export default function Layout() {
           // collide across projects, and name-keyed activation
           // would first-match the wrong one.  Id is the stable
           // path-derived hash.
-          await activateProjectById(result.entry.id);
+          await activateProject(result.entry.id);
           id = result.entry.id;
         } else {
           // The directory needs a setup decision (needs_setup,
@@ -175,7 +175,7 @@ export default function Layout() {
     const onActivate = async (e: Event) => {
       const projectId = (e as CustomEvent).detail;
       try {
-        await activateProjectById(projectId);
+        await activateProject(projectId);
         await refreshRecentMenu();
         navigate(`/p/${projectId}/`);
       } catch (err) {
@@ -194,7 +194,7 @@ export default function Layout() {
       try {
         const data = await getProjects();
         for (const p of data.projects) {
-          await removeProject(p.name);
+          await removeProject(p.id);
         }
         await refreshRecentMenu();
       } catch {

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -133,31 +133,32 @@ export default function Layout() {
           await activateProjectById(result.entry.id);
           id = result.entry.id;
         } else {
-          // Menu-driven open hit a needs_setup / broken_install /
-          // embedded_install_required branch.  The native-menu
-          // path has no place to host the SetupPromptDialog (it
-          // lives inside ProjectSwitcher, not the routed app
-          // shell), so we surface a banner the user can act on
-          // instead of silently doing nothing.  This was the
-          // "no clear UI behavior" symptom when a perfectly fine-
-          // looking directory came back with broken_install or
-          // needs_setup.
-          const reason =
-            result.status === "needs_setup"
-              ? "directory needs setup — use \"New Project…\" in the picker"
-              : result.status === "broken_install"
-              ? `installation looks broken (${result.brokenness})`
-              : result.status === "embedded_install_required"
-              ? "needs an embedded install: " + result.command
-              : `couldn't open (${(result satisfies never as { status: string }).status})`;
-          setActivationError(`Couldn't open ${path}: ${reason}`);
+          // The directory needs a setup decision (needs_setup,
+          // broken_install) or an external action (embedded
+          // install).  Defer to ProjectSwitcher's existing setup
+          // dialog rather than rebuilding the prompt UI here:
+          // uncollapse the sidebar so ProjectSwitcher is mounted
+          // and the dialog overlay is visible, then dispatch a
+          // custom event on the next tick (so the re-render that
+          // mounts the listener completes first).  ProjectSwitcher
+          // calls its own ``handleCreateResult`` and the user gets
+          // the same userspace / embedded prompt they'd see from
+          // the in-app "Open Project" button.
+          setSidebarCollapsed(false);
+          setTimeout(() => {
+            window.dispatchEvent(
+              new CustomEvent("clarity-show-create-prompt", {
+                detail: { name, path, result },
+              }),
+            );
+          }, 0);
           return;
         }
       } catch (err) {
         // ``createProject`` throws on unknown 409 bodies and on
-        // other HTTP errors.  Surface the message and bail
-        // rather than guessing — silent failure was what got us
-        // here in the first place.
+        // other HTTP errors.  Surface the message and bail rather
+        // than guessing — silent failure was what got us here in
+        // the first place.
         setActivationError(
           err instanceof Error ? err.message : String(err),
         );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Outlet, useLocation, useNavigate, useParams } from "react-router-dom";
-import { activateProject, activateProjectById, createProject, getProjects, removeProject, getSession, getSettings, getSetupStatus } from "../api/client";
+import { activateProjectById, createProject, getProjects, removeProject, getSession, getSettings, getSetupStatus } from "../api/client";
 import { ChatProvider } from "../hooks/useChat";
 import type { SessionInfo } from "../types";
 import FeedbackDialog from "./FeedbackDialog";
@@ -126,22 +126,42 @@ export default function Layout() {
       try {
         const result = await createProject({ name, path, intent });
         if (result.status === "ok") {
-          await activateProject(result.entry.name);
+          // Activate by id rather than name — display names can
+          // collide across projects, and name-keyed activation
+          // would first-match the wrong one.  Id is the stable
+          // path-derived hash.
+          await activateProjectById(result.entry.id);
           id = result.entry.id;
         } else {
-          // Menu-driven open hit a needs_setup / broken / embedded-
-          // required branch; the menu UI has no place to host the
-          // SetupPromptDialog, so the user has to use the in-app
-          // ProjectSwitcher flow.  Surface nothing; the directory
-          // simply doesn't activate.
+          // Menu-driven open hit a needs_setup / broken_install /
+          // embedded_install_required branch.  The native-menu
+          // path has no place to host the SetupPromptDialog (it
+          // lives inside ProjectSwitcher, not the routed app
+          // shell), so we surface a banner the user can act on
+          // instead of silently doing nothing.  This was the
+          // "no clear UI behavior" symptom when a perfectly fine-
+          // looking directory came back with broken_install or
+          // needs_setup.
+          const reason =
+            result.status === "needs_setup"
+              ? "directory needs setup — use \"New Project…\" in the picker"
+              : result.status === "broken_install"
+              ? `installation looks broken (${result.brokenness})`
+              : result.status === "embedded_install_required"
+              ? "needs an embedded install: " + result.command
+              : `couldn't open (${(result satisfies never as { status: string }).status})`;
+          setActivationError(`Couldn't open ${path}: ${reason}`);
           return;
         }
-      } catch {
-        const data = await getProjects();
-        const existing = data.projects.find((p) => p.path === path);
-        if (!existing) return;
-        await activateProject(existing.name);
-        id = existing.id;
+      } catch (err) {
+        // ``createProject`` throws on unknown 409 bodies and on
+        // other HTTP errors.  Surface the message and bail
+        // rather than guessing — silent failure was what got us
+        // here in the first place.
+        setActivationError(
+          err instanceof Error ? err.message : String(err),
+        );
+        return;
       }
       await refreshRecentMenu();
       navigate(`/p/${id}/`);

--- a/web/src/components/ProjectSwitcher.tsx
+++ b/web/src/components/ProjectSwitcher.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useNavigate } from "react-router-dom";
 import {
   activateProject,
@@ -79,6 +80,13 @@ export default function ProjectSwitcher({ currentProject }: ProjectSwitcherProps
   const [submittingMode, setSubmittingMode] = useState<
     "userspace" | "embedded" | null
   >(null);
+  // The setup dialog only exposes a choice for code-repo
+  // directories, presented as a single "coding agent-friendly
+  // setup" checkbox.  Defaults to true (= embedded install) when
+  // the server suggested ``embedded``, which is the code-repo
+  // case.  Non-code dirs get a single button and never see this
+  // state.  Re-synced whenever a new prompt opens.
+  const [codingAgentSetup, setCodingAgentSetup] = useState(true);
 
   const newInputRef = useRef<HTMLInputElement>(null);
   const openInputRef = useRef<HTMLInputElement>(null);
@@ -101,6 +109,21 @@ export default function ProjectSwitcher({ currentProject }: ProjectSwitcherProps
   useEffect(() => {
     if (showOpenForm) openInputRef.current?.focus();
   }, [showOpenForm]);
+
+  // Re-sync the coding-agent-friendly default whenever a new
+  // setup prompt opens — otherwise the checkbox would persist
+  // from a previous dialog (e.g. user opened a code repo, then a
+  // plain folder, then a code repo again).  The server's
+  // ``suggested_mode`` is the source of truth for what should be
+  // pre-selected: "embedded" → checked.  set-state-in-effect is
+  // legitimate here: the new prompt is an external input, not
+  // derived from existing state.
+  useEffect(() => {
+    if (prompt?.kind === "needs_setup") {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setCodingAgentSetup(prompt.suggested_mode === "embedded");
+    }
+  }, [prompt]);
 
   // Escape-key dismiss for any open prompt — the modal's
   // click-outside-to-dismiss has its keyboard equivalent here, so
@@ -206,6 +229,38 @@ export default function ProjectSwitcher({ currentProject }: ProjectSwitcherProps
       `Unhandled create-project result: ${JSON.stringify(exhaustive)}`,
     );
   };
+
+  // Bridge for the native "File → Open Project…" menu path.  When
+  // the menu handler in :file:`Layout.tsx` calls ``createProject``
+  // on a directory that isn't a clean Clarity project (needs_setup
+  // / broken_install / embedded_install_required), it dispatches a
+  // ``clarity-show-create-prompt`` event with the result so this
+  // component can surface its existing setup dialog instead of
+  // each call site rebuilding the prompt UI.  Layout uncollapses
+  // the sidebar first so ProjectSwitcher is mounted to receive.
+  useEffect(() => {
+    const onPrompt = (e: Event) => {
+      const detail = (e as CustomEvent).detail as {
+        name: string;
+        path: string;
+        result: CreateProjectResult;
+      };
+      // Expand the switcher so the user sees what's happening (the
+      // prompt is a fixed overlay, but expanding gives context if
+      // they cancel).
+      setOpen(true);
+      void handleCreateResult(detail.result, {
+        name: detail.name, path: detail.path,
+      });
+    };
+    window.addEventListener("clarity-show-create-prompt", onPrompt);
+    return () =>
+      window.removeEventListener("clarity-show-create-prompt", onPrompt);
+    // handleCreateResult closes over component state, but the
+    // dispatch is rare (menu-driven only) and the closure capture
+    // is intentional — we want whatever the latest closure sees.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // ---- Browser-mode fallback (inline form) -------------------------------
 
@@ -583,9 +638,13 @@ export default function ProjectSwitcher({ currentProject }: ProjectSwitcherProps
 
       {/* Flow-3 SetupPromptDialog (needs_setup / broken_install) and
           the EmbeddedCommandDialog all render as fixed-position
-          modal overlays so they sit above the sidebar UI without
-          fighting its layout. */}
-      {prompt && (
+          modal overlays.  Rendered via a portal to ``document.body``
+          so the overlay escapes the sidebar's animated
+          ``<aside>`` — that container creates a stacking context
+          (transform on collapse) that traps ``position: fixed``
+          descendants, which made the dialog appear behind the
+          main route's chat content. */}
+      {prompt && createPortal(
         // Backdrop is presentation-only; its click-to-dismiss has a
         // keyboard equivalent via the Escape-key effect above, so
         // the a11y click-events-have-key-events guidance is met at
@@ -619,37 +678,50 @@ export default function ProjectSwitcher({ currentProject }: ProjectSwitcherProps
                   {prompt.path}
                 </p>
                 <p className="text-xs text-body-muted mb-4">
-                  This directory doesn't have a Clarity setup yet.
                   {prompt.looks_like_code
-                    ? " It looks like a code repository — an embedded install (with the agent inside the repo) is the natural fit."
-                    : " A userspace project will create a Clarity Protocol/ folder here and manage Clarity from the app."}
+                    ? "This directory looks like a code repository. Clarity will manage your project's notes and conversations here."
+                    : "Clarity will create a folder here for your project's notes and conversations."}
                 </p>
+                {/* Only code-repo directories get a choice; non-code
+                    directories get a single button.  Without
+                    context, "userspace" / "embedded" jargon
+                    confuses users — the checkbox phrases it in
+                    terms of what they actually get (coding-agent
+                    files inside the repo). */}
+                {prompt.looks_like_code && (
+                  <label className="flex items-start gap-2 mb-4 cursor-pointer
+                    py-2 px-2 -mx-2 rounded hover:bg-surface-hover transition-colors">
+                    <input
+                      type="checkbox"
+                      checked={codingAgentSetup}
+                      onChange={(e) => setCodingAgentSetup(e.target.checked)}
+                      className="mt-0.5 shrink-0"
+                    />
+                    <span className="text-xs text-body-muted">
+                      <span className="font-medium text-body">
+                        Coding agent-friendly setup
+                      </span>
+                      <br />
+                      Install Clarity inside this repo so coding agents
+                      (like Claude Code) can read its files alongside
+                      your code.
+                    </span>
+                  </label>
+                )}
                 <div className="space-y-2">
-                  {prompt.looks_like_code && (
-                    <button
-                      disabled={submittingMode !== null}
-                      onClick={() => resolveSetup("embedded")}
-                      className="w-full py-2 text-xs rounded bg-accent text-white
-                        hover:bg-accent-hover disabled:opacity-50 transition-colors"
-                    >
-                      {submittingMode === "embedded"
-                        ? "Working…"
-                        : "Set up as embedded install (recommended)"}
-                    </button>
-                  )}
                   <button
                     disabled={submittingMode !== null}
-                    onClick={() => resolveSetup("userspace")}
-                    className={`w-full py-2 text-xs rounded transition-colors
-                      disabled:opacity-50 ${
-                        prompt.looks_like_code
-                          ? "border border-border text-body hover:bg-surface-hover"
-                          : "bg-accent text-white hover:bg-accent-hover"
-                      }`}
+                    onClick={() => resolveSetup(
+                      prompt.looks_like_code && codingAgentSetup
+                        ? "embedded"
+                        : "userspace",
+                    )}
+                    className="w-full py-2 text-xs rounded bg-accent text-white
+                      hover:bg-accent-hover disabled:opacity-50 transition-colors"
                   >
-                    {submittingMode === "userspace"
+                    {submittingMode !== null
                       ? "Working…"
-                      : "Set up as userspace project"}
+                      : "Set up a Clarity project"}
                   </button>
                   <button
                     onClick={() => setPrompt(null)}
@@ -728,7 +800,8 @@ export default function ProjectSwitcher({ currentProject }: ProjectSwitcherProps
               </>
             )}
           </div>
-        </div>
+        </div>,
+        document.body,
       )}
     </div>
   );

--- a/web/src/components/ProjectSwitcher.tsx
+++ b/web/src/components/ProjectSwitcher.tsx
@@ -141,7 +141,7 @@ export default function ProjectSwitcher({ currentProject }: ProjectSwitcherProps
     setActivating(project.name);
     setError(null);
     try {
-      await activateProject(project.name);
+      await activateProject(project.id);
       setOpen(false);
       refreshRecentMenu();
       navigate(`/p/${project.id}/`);
@@ -164,7 +164,7 @@ export default function ProjectSwitcher({ currentProject }: ProjectSwitcherProps
     setRemoving(project.name);
     setError(null);
     try {
-      await removeProject(project.name);
+      await removeProject(project.id);
       setConfirmRemove(null);
       refresh();
       void refreshRecentMenu();

--- a/web/src/components/ProjectSwitcher.tsx
+++ b/web/src/components/ProjectSwitcher.tsx
@@ -196,6 +196,15 @@ export default function ProjectSwitcher({ currentProject }: ProjectSwitcherProps
       });
       return;
     }
+    // Defensive: an unhandled discriminator means the wire shape
+    // grew a new case without UI wiring.  Throwing surfaces it via
+    // the caller's catch block instead of silently swallowing —
+    // which is exactly the failure mode the launcher's bare
+    // ``HTTPException`` 409 used to produce.
+    const exhaustive: never = result;
+    throw new Error(
+      `Unhandled create-project result: ${JSON.stringify(exhaustive)}`,
+    );
   };
 
   // ---- Browser-mode fallback (inline form) -------------------------------


### PR DESCRIPTION
- The "Recents" list was keyed by name, not pathname, so if you tried to open two things with the same tail name it just failed
- It wasn't reliably showing which file you had open
- If you tried to open a directory that didn't have an existing Clarity project, it threw an error instead of taking you to the setup flow
- The setup flow was confusing with button labels that would make no sense to a normal user. Now it's "Set up a Clarity project" with (in the case of a code directory) a checkbox to set it up in a coding agent-friendly way (ie embedded install).

Resolves #77.