### PR TITLE
Fix embed mode: MCP-first snippet with schema version bump (#79)

### DIFF
--- a/src/clarity_agent/setup/snippet.md
+++ b/src/clarity_agent/setup/snippet.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD041 -->
 <!-- clarity-begin -->
 <!-- clarity-meta
-schema_version: 1
+schema_version: 2
 mode: {{MODE}}
 protocol_dir_name: {{PROTOCOL_DIR_NAME}}
 processes_dir: {{PROCESSES_DIR}}
@@ -10,13 +10,13 @@ processes_dir: {{PROCESSES_DIR}}
 
 ## Clarity Protocol
 
-This project uses the Clarity Protocol for structured thinking about consequential decisions — what to build and why, how it should be designed, where it might fail. Protocol documents live in `{{PROTOCOL_DIR_NAME}}/`. Process guides live in `{{PROCESSES_DIR}}/`; the entry point for any Clarity work is `{{PROCESSES_DIR}}/clarity-agent.md`.
+This project uses the Clarity Protocol for structured thinking about consequential decisions — what to build and why, how it should be designed, where it might fail. Protocol documents live in `{{PROTOCOL_DIR_NAME}}/`. A Clarity MCP server is configured for this project (see `.vscode/mcp.json`). Use its tools to interact with the protocol — do not try to install or run Clarity directly.
 
 ### When to engage
 
 **Before building — think when it matters.** Two triggers:
 
-1. *The user asks.* When they want to explore what to build, clarify requirements, brainstorm risks, or work through a decision: first check whether the `run_clarity` MCP tool is in your available tools. If it is, use the MCP tools. If it isn't, read and follow `{{PROCESSES_DIR}}/clarity-agent.md` directly. Don't ask the user which to use; make this determination yourself.
+1. *The user asks.* When they want to explore what to build, clarify requirements, brainstorm risks, or work through a decision: call the `run_clarity` MCP tool.
 
 2. *You recognize an inflection point.* Before making choices that would be expensive to reverse — new services, auth/trust models, data schemas, external integrations, significant API contracts — call `check_decision` with what you plan to do. It returns existing decisions, requirements, and architecture so you can check for conflicts. Don't interrupt for routine implementation. The test: "If this turns out wrong, is it a 5-minute fix or a multi-day rework?" Interrupt for the latter.
 

--- a/src/clarity_agent/setup/snippet.py
+++ b/src/clarity_agent/setup/snippet.py
@@ -39,7 +39,7 @@ END_DELIMITER = "<!-- clarity-end -->"
 # the per-project values (mode / protocol_dir_name / processes_dir)
 # have moved.  Resist bumping for cosmetic copy edits; the resulting
 # in-place rewrites are an upgrade-time tax on every user.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 _META_BEGIN = "<!-- clarity-meta"
 _META_END = "-->"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -162,7 +162,7 @@ class TestCheckInstallationType:
             Mode,
             ProjectLayout,
         )
-        from clarity_agent.setup.snippet import ensure_agents_md
+        from clarity_agent.setup.snippet import SCHEMA_VERSION, ensure_agents_md
 
         host = tmp_path / "myproject"
         host.mkdir()
@@ -181,7 +181,7 @@ class TestCheckInstallationType:
         agents_md = host / "AGENTS.md"
         agents_md.write_text(
             agents_md.read_text().replace(
-                "schema_version: 1", "schema_version: 999",
+                f"schema_version: {SCHEMA_VERSION}", "schema_version: 999",
             ),
         )
 
@@ -191,7 +191,7 @@ class TestCheckInstallationType:
         assert results[1].fix_fn is not None
         # The fix_fn must restore the current rendering.
         assert results[1].fix_fn() is True
-        assert "schema_version: 1" in agents_md.read_text()
+        assert f"schema_version: {SCHEMA_VERSION}" in agents_md.read_text()
 
     def test_embedded_no_clarity_reference(self, tmp_path: Path) -> None:
         host = tmp_path / "myproject"

--- a/tests/test_snippet.py
+++ b/tests/test_snippet.py
@@ -334,7 +334,7 @@ class TestEnsureAgentsMd:
 
         # Force a rewrite via meta drift.
         tampered = layout.agents_md.read_text().replace(
-            "schema_version: 1", "schema_version: 0",
+            f"schema_version: {SCHEMA_VERSION}", "schema_version: 0",
         )
         layout.agents_md.write_text(tampered)
 


### PR DESCRIPTION
The embedded AGENTS.md snippet now clearly directs agents to use the MCP server configured in .vscode/mcp.json rather than offering an ambiguous fallback to read process guides directly (which don't exist in the target project). Schema version bumped to 2 so existing embeds pick up the new wording on next project open.

This is now based off of Eve's PR and makes just the additional changes noted above. 