### PR TITLE
For GHCP, try using SDK native auth before falling back to gh auth login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,16 +22,21 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install uv
-          uv pip install --system -e ".[dev]"
+          # `uv sync` honors uv.lock — `uv pip install` does NOT, which
+          # is how we previously ended up with stale transitive deps
+          # (notably github-copilot-sdk 0.1.0 instead of the locked 0.3.0,
+          # missing SubprocessConfig).  `--locked` makes a stale lock
+          # fail loudly rather than silently re-resolving.
+          uv sync --extra dev --locked
 
       - name: Lint (ruff)
-        run: ruff check src/ tests/ dev-tools/ evals/
+        run: uv run ruff check src/ tests/ dev-tools/ evals/
 
       - name: Type check (pyright)
-        run: pyright src/ evals/
+        run: uv run pyright src/ evals/
 
       - name: Run tests
-        run: pytest tests/ -q
+        run: uv run pytest tests/ -q
 
   tauri-build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install uv
-          uv sync --extra web --extra cli --extra brainstorm --extra docx --extra openai --extra azure --extra bundle --locked
+          # `dev` self-references [cli,web,mcp] and adds pyinstaller,
+          # which clarity.py install --release needs.  The previous
+          # bare-pip command referenced 5 non-existent extras
+          # (brainstorm/docx/openai/azure/bundle); pip silently
+          # ignored them, uv (correctly) errors.
+          uv sync --extra dev --locked
 
       - name: Install web dependencies
         run: cd web && npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,14 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Install Python dependencies
-        run: pip install -e ".[web,cli,brainstorm,docx,openai,azure,bundle]"
+        # `uv sync --locked` so we get the same versions resolved in
+        # uv.lock (notably github-copilot-sdk 0.3.0, which `uv pip` /
+        # bare `pip` would silently downgrade to 0.1.0 and break the
+        # SubprocessConfig import).
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install uv
+          uv sync --extra web --extra cli --extra brainstorm --extra docx --extra openai --extra azure --extra bundle --locked
 
       - name: Install web dependencies
         run: cd web && npm ci
@@ -107,7 +114,7 @@ jobs:
         run: cargo test --manifest-path src-tauri/Cargo.toml
 
       - name: Build desktop app
-        run: python clarity.py install --release
+        run: uv run python clarity.py install --release
         env:
           CI: true
           # Ad-hoc sign on macOS CI (no signing identity available).

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -27,10 +27,12 @@ jobs:
           python-version: "3.13"
 
       - name: Install dependencies
+        # `uv sync --locked` honors uv.lock; `uv pip` does NOT, which
+        # is how we previously ended up with stale transitive deps.
         run: |
           python -m pip install --upgrade pip
           python -m pip install uv
-          uv pip install --system -e ".[dev]"
+          uv sync --extra dev --locked
 
       - name: Run evals
         env:
@@ -42,9 +44,9 @@ jobs:
           FILTER="${{ github.event.inputs.case_filter }}"
           COMMON_ARGS=(-v --tb=short --junit-xml=evals-results.xml --output-dir=./eval-artifacts)
           if [ -n "$FILTER" ]; then
-            pytest evals/cases/ "${COMMON_ARGS[@]}" -k "$FILTER"
+            uv run pytest evals/cases/ "${COMMON_ARGS[@]}" -k "$FILTER"
           else
-            pytest evals/cases/ "${COMMON_ARGS[@]}"
+            uv run pytest evals/cases/ "${COMMON_ARGS[@]}"
           fi
 
       - name: Upload results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install uv
-          uv sync --extra web --extra cli --extra brainstorm --extra docx --extra openai --extra azure --extra bundle --locked
+          # `dev` self-references [cli,web,mcp] and adds pyinstaller,
+          # which clarity.py install --release needs.  The previous
+          # bare-pip command referenced 5 non-existent extras
+          # (brainstorm/docx/openai/azure/bundle); pip silently
+          # ignored them, uv (correctly) errors.
+          uv sync --extra dev --locked
 
       - name: Install web dependencies
         run: cd web && npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,14 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-release-
 
       - name: Install Python dependencies
-        run: pip install -e ".[web,cli,brainstorm,docx,openai,azure,bundle]"
+        # `uv sync --locked` honors uv.lock; `pip install` does NOT,
+        # which is how we previously ended up with stale transitive
+        # deps (notably github-copilot-sdk 0.1.0, missing
+        # SubprocessConfig).
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install uv
+          uv sync --extra web --extra cli --extra brainstorm --extra docx --extra openai --extra azure --extra bundle --locked
 
       - name: Install web dependencies
         run: cd web && npm ci
@@ -135,7 +142,7 @@ jobs:
           echo "Stamped _version.py with version=${GITHUB_REF_NAME}, source=release"
 
       - name: Build release
-        run: python clarity.py install --release
+        run: uv run python clarity.py install --release
         env:
           CI: true
           # Use configured signing identity if available, otherwise ad-hoc sign.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   "azure-ai-inference>=1.0.0b9",
   "azure-identity>=1.14.0",
   "aiohttp>=3.9.0",
-  "github-copilot-sdk>=0.1.0",
+  "github-copilot-sdk>=0.3.0",
   # Document generation.
   "python-docx>=1.1",
   "mistune>=3.2.1",

--- a/src/clarity_agent/llm/config.py
+++ b/src/clarity_agent/llm/config.py
@@ -203,11 +203,28 @@ _PROVIDERS: dict[str, dict[str, Any]] = {
         "endpoint_env_var": None,
         "auth_modes": [
             {
+                "name": "sdk_native",
+                "display_name": "Copilot login (recommended)",
+                "description": (
+                    "Zero-config via the bundled Copilot CLI's own login. "
+                    "No external tools to install."
+                ),
+                "package": "copilot",
+                "env_var": None,
+                "setup_help": (
+                    "Run 'copilot auth login' in a terminal to sign in. "
+                    "The Copilot CLI is bundled with the Python package, "
+                    "so no separate install is required."
+                ),
+                "setup_url": "https://docs.github.com/en/copilot",
+                "fields": [],
+            },
+            {
                 "name": "gh_cli",
                 "display_name": "GitHub CLI",
                 "description": (
-                    "Zero-config via the gh CLI — uses your existing "
-                    "GitHub login. No token needed."
+                    "Use the gh CLI's stored token — convenient if you "
+                    "already have 'gh auth login' set up."
                 ),
                 "package": "copilot",
                 "env_var": None,
@@ -368,9 +385,20 @@ def _auto_detect_provider() -> tuple[str, str] | None:
     if os.environ.get("CLAUDECODE") and _has_package("claude_agent_sdk"):
         return ("anthropic", "claude_sdk")
 
-    # GitHub Copilot via gh CLI — most ambient fallback (almost any
-    # developer has `gh` installed), so check last.
-    from clarity_agent.llm.impl.github_copilot import get_gh_cli_token
+    # GitHub Copilot via the SDK's own logged-in user — the
+    # recommended path.  Requires that the user has already run
+    # ``copilot auth login``; the bundled CLI manages its own
+    # credential store.  Probed by spawning a transient client.
+    from clarity_agent.llm.impl.github_copilot import (
+        get_gh_cli_token,
+        probe_sdk_native_auth,
+    )
+    if _has_package("copilot") and probe_sdk_native_auth():
+        return ("github", "sdk_native")
+
+    # GitHub Copilot via gh CLI — ambient fallback for users who have
+    # ``gh auth login`` but haven't done ``copilot auth login``.  The
+    # SDK accepts the gh token via ``SubprocessConfig.github_token``.
     if get_gh_cli_token():
         return ("github", "gh_cli")
 

--- a/src/clarity_agent/llm/factory.py
+++ b/src/clarity_agent/llm/factory.py
@@ -138,6 +138,12 @@ def create_chat_backend(
         )
 
     # The github provider uses the Copilot SDK agent runtime.
+    # Auth-mode dispatch:
+    #   - "token"      → explicit GITHUB_TOKEN, passed as-is
+    #   - "sdk_native" → ``token=None`` → SDK uses its own logged-in
+    #                    user (``use_logged_in_user=True``)
+    #   - "gh_cli"     → pull a token from ``gh auth token`` and pass
+    #                    it to the SDK like an explicit token
     if config.provider == "github":
         from clarity_agent.llm.impl.github_copilot import (
             CopilotChatBackend,

--- a/src/clarity_agent/llm/impl/github_copilot.py
+++ b/src/clarity_agent/llm/impl/github_copilot.py
@@ -37,8 +37,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from clarity_agent.transcript import Transcript
 
-from copilot import CopilotClient
-from copilot.client import SubprocessConfig
+from copilot import CopilotClient, SubprocessConfig
 from copilot.generated.session_events import SessionEvent, SessionEventType
 from copilot.session import (
     CopilotSession,

--- a/src/clarity_agent/llm/impl/github_copilot.py
+++ b/src/clarity_agent/llm/impl/github_copilot.py
@@ -5,9 +5,18 @@ Copilot SDK for conversations.  Like the Claude SDK backend, this
 wraps an agent runtime rather than a raw messages API — there is no
 corresponding :class:`LLMClient`.
 
-Authentication uses the GitHub CLI (``gh auth token``), a
-``GITHUB_TOKEN`` / ``GH_TOKEN`` env var, or the Copilot SDK's
-built-in OAuth flow.
+Authentication is layered.  In order of priority:
+
+1. An explicit ``GITHUB_TOKEN`` env var (passed via ``token=`` from
+   the factory) — highest precedence, lets CI / custom setups
+   override everything else.
+2. The Copilot CLI's own stored login (``copilot auth login``) —
+   activated by passing ``token=None``; the bundled CLI handles its
+   own credential storage and refresh.  Probed via
+   :func:`probe_sdk_native_auth`.
+3. ``gh auth token`` from the GitHub CLI as an ambient fallback —
+   convenient for users who already live in ``gh`` but haven't run
+   ``copilot auth login``.  Probed via :func:`get_gh_cli_token`.
 """
 
 from __future__ import annotations
@@ -29,6 +38,7 @@ if TYPE_CHECKING:
     from clarity_agent.transcript import Transcript
 
 from copilot import CopilotClient
+from copilot.client import SubprocessConfig
 from copilot.generated.session_events import SessionEvent, SessionEventType
 from copilot.session import (
     CopilotSession,
@@ -106,6 +116,42 @@ async def _wait_for_done_with_idle_timeout(
             # An event may have arrived during the wait, refreshing
             # activity_timestamp[0].  Loop and recompute.
             continue
+
+
+def probe_sdk_native_auth() -> bool:
+    """Check whether the Copilot SDK has a usable logged-in user.
+
+    Spins up a transient :class:`CopilotClient` against the bundled
+    Copilot CLI binary, queries ``auth.getStatus``, and tears the
+    connection back down.  Returns ``True`` iff the CLI reports an
+    authenticated user — the same auth state that powers
+    ``CopilotChatBackend`` when constructed with ``token=None``.
+
+    Used by the autodetection cascade to decide whether to recommend
+    SDK-native auth before falling back to ``gh auth token``.  Cost is
+    a single subprocess spawn (~hundreds of ms); only call once per
+    detection pass, not per chat request.
+    """
+
+    async def _probe() -> bool:
+        client = CopilotClient()
+        try:
+            await client.start()
+            status = await client.get_auth_status()
+            return bool(status.isAuthenticated)
+        finally:
+            try:
+                await client.stop()
+            except Exception:
+                pass
+
+    try:
+        return asyncio.run(_probe())
+    except Exception:
+        # Bundled CLI missing, RPC failure, no event loop available —
+        # treat as "not authenticated" rather than propagating, since
+        # the caller is just choosing which rung of the ladder to use.
+        return False
 
 
 def get_gh_cli_token(*, raise_on_failure: bool = False) -> str | None:
@@ -327,7 +373,12 @@ class CopilotChatBackend(ChatBackend):
     async def _ensure_client(self) -> CopilotClient:
         if self._client is not None:
             return self._client
-        self._client = CopilotClient()
+        # ``token=None`` means "fall through to the SDK's own login" —
+        # ``SubprocessConfig`` resolves ``use_logged_in_user=True`` when
+        # ``github_token`` is unset.  A non-None token wins and is passed
+        # straight through (env var or gh-cli token).
+        config = SubprocessConfig(github_token=self._token) if self._token else None
+        self._client = CopilotClient(config)
         await self._client.start()
         return self._client
 

--- a/src/clarity_agent/setup/doctor.py
+++ b/src/clarity_agent/setup/doctor.py
@@ -920,10 +920,30 @@ def _probe_sdk(agent_dir: Path) -> CheckResult:
 
 
 def _probe_copilot(agent_dir: Path) -> CheckResult:
-    """Probe the GitHub Copilot SDK by spinning up a CopilotChatBackend."""
-    from clarity_agent.llm.impl.github_copilot import CopilotChatBackend, get_gh_cli_token
+    """Probe the GitHub Copilot SDK by spinning up a CopilotChatBackend.
 
-    token = os.environ.get("GITHUB_TOKEN") or get_gh_cli_token(raise_on_failure=True)
+    Walks the same auth ladder as ``detect_provider_auth``:
+    ``$GITHUB_TOKEN`` → SDK-native login → ``gh auth token``.  The
+    success message names which rung carried the call so users can
+    confirm their setup is actually using what they think it is.
+    """
+    from clarity_agent.llm.impl.github_copilot import (
+        CopilotChatBackend,
+        get_gh_cli_token,
+        probe_sdk_native_auth,
+    )
+
+    token: str | None
+    rung: str
+    if os.environ.get("GITHUB_TOKEN"):
+        token = os.environ["GITHUB_TOKEN"]
+        rung = "GITHUB_TOKEN"
+    elif probe_sdk_native_auth():
+        token = None
+        rung = "Copilot login"
+    else:
+        token = get_gh_cli_token(raise_on_failure=True)
+        rung = "gh CLI"
 
     backend = CopilotChatBackend(
         project_dir=agent_dir,
@@ -943,12 +963,12 @@ def _probe_copilot(agent_dir: Path) -> CheckResult:
         return CheckResult(
             name="Backend health",
             status=Status.PASS,
-            message="GitHub Copilot responded successfully",
+            message=f"GitHub Copilot responded successfully (via {rung})",
         )
     return CheckResult(
         name="Backend health",
         status=Status.WARN,
-        message="GitHub Copilot returned an empty response",
+        message=f"GitHub Copilot returned an empty response (via {rung})",
     )
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -548,6 +548,9 @@ class TestLLMConfigCLI:
         with patch(
             "clarity_agent.llm.impl.github_copilot.get_gh_cli_token",
             return_value=None,
+        ), patch(
+            "clarity_agent.llm.impl.github_copilot.probe_sdk_native_auth",
+            return_value=False,
         ), pytest.raises(LLMConfigError):
             LLMConfig.create(args)
 
@@ -765,12 +768,61 @@ class TestAutoDetectProvider:
     def test_returns_none_when_nothing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from clarity_agent.llm.config import _auto_detect_provider
         self._clear_all_keys(monkeypatch)
-        # Mock away the gh CLI probe so it doesn't detect a local login.
+        # Mock away BOTH Copilot probes — gh CLI and the bundled
+        # SDK login — so the test environment doesn't accidentally
+        # detect a real local setup.
         with patch(
             "clarity_agent.llm.impl.github_copilot.get_gh_cli_token",
             return_value=None,
+        ), patch(
+            "clarity_agent.llm.impl.github_copilot.probe_sdk_native_auth",
+            return_value=False,
         ):
             assert _auto_detect_provider() is None
+
+    def test_detects_github_sdk_native(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SDK-native auth (Copilot login) is picked when the probe succeeds."""
+        from clarity_agent.llm.config import _auto_detect_provider
+        self._clear_all_keys(monkeypatch)
+        with patch("clarity_agent.llm.config._has_package", return_value=True), \
+             patch(
+                "clarity_agent.llm.impl.github_copilot.probe_sdk_native_auth",
+                return_value=True,
+             ), patch(
+                "clarity_agent.llm.impl.github_copilot.get_gh_cli_token",
+                return_value="should-not-be-used",
+             ):
+            assert _auto_detect_provider() == ("github", "sdk_native")
+
+    def test_detects_github_gh_cli_fallback(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """gh CLI fires when the SDK-native probe says we aren't logged in."""
+        from clarity_agent.llm.config import _auto_detect_provider
+        self._clear_all_keys(monkeypatch)
+        with patch("clarity_agent.llm.config._has_package", return_value=True), \
+             patch(
+                "clarity_agent.llm.impl.github_copilot.probe_sdk_native_auth",
+                return_value=False,
+             ), patch(
+                "clarity_agent.llm.impl.github_copilot.get_gh_cli_token",
+                return_value="gh-token",
+             ):
+            assert _auto_detect_provider() == ("github", "gh_cli")
+
+    def test_github_token_beats_sdk_native(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Explicit GITHUB_TOKEN wins over the SDK-native probe."""
+        from clarity_agent.llm.config import _auto_detect_provider
+        self._clear_all_keys(monkeypatch)
+        monkeypatch.setenv("GITHUB_TOKEN", "explicit")
+        with patch("clarity_agent.llm.config._has_package", return_value=True), \
+             patch(
+                "clarity_agent.llm.impl.github_copilot.probe_sdk_native_auth",
+                return_value=True,
+             ):
+            assert _auto_detect_provider() == ("github", "token")
 
     def test_anthropic_takes_priority_over_claudecode(
         self, monkeypatch: pytest.MonkeyPatch,

--- a/uv.lock
+++ b/uv.lock
@@ -345,7 +345,7 @@ wheels = [
 
 [[package]]
 name = "clarity-agent"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -401,7 +401,7 @@ requires-dist = [
     { name = "clarity-agent", extras = ["cli", "web", "mcp"], marker = "extra == 'dev'" },
     { name = "claude-agent-sdk", marker = "extra == 'cli'", specifier = ">=0.1.0" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.104.0" },
-    { name = "github-copilot-sdk", specifier = ">=0.1.0" },
+    { name = "github-copilot-sdk", specifier = ">=0.3.0" },
     { name = "google-genai", specifier = ">=1.0" },
     { name = "httpx", marker = "extra == 'web'", specifier = ">=0.27.0" },
     { name = "keyring", specifier = ">=25.0" },


### PR DESCRIPTION
We should really default to using the library, which doesn't rely on having `gh` installed and running. Of course, this isn't perfectly reliable either, because `copilot auth login` (that manages the library) and `gh auth login` affect *separate login credential keychains* because of *course* they do. So we maintain both as fallbacks, to maximize the chance that something will work.

Also changed the CI pipeline to use `uv sync` instead of `uv pip` -- there's no reason to use that backward-compatibility command, and all it causes is for CI to ignore the lockfiles that real deployments (dev and prod) would use. This caused some fairly random "works locally, fails in CI" issues with this change because thanks to an error in the internal package version stamping, pip would pull an old version of the GHCP SDK but uv sync would get it right.