### PR TITLE
Use ANTHROPIC_API_KEY with SdkChatBackend

### DIFF
--- a/src/clarity_agent/llm/config.py
+++ b/src/clarity_agent/llm/config.py
@@ -58,27 +58,13 @@ _PROVIDERS: dict[str, dict[str, Any]] = {
         "endpoint_env_var": None,
         "auth_modes": [
             {
-                "name": "claude_sdk",
-                "display_name": "Claude Code",
-                "description": (
-                    "Sign in through Claude Code — no API key needed. "
-                    "Best for personal use and development."
-                ),
-                "package": "claude_agent_sdk",
-                "env_var": None,
-                "setup_help": (
-                    "This option uses the Claude Code CLI's authentication. "
-                    "You must have run 'claude login' in your terminal first."
-                ),
-                "setup_url": "https://claude.ai/download",
-                "fields": [],
-            },
-            {
                 "name": "api_key",
-                "display_name": "API Key",
+                "display_name": "API Key (recommended)",
                 "description": (
-                    "Use an API key from console.anthropic.com. "
-                    "Best for teams and automated setups."
+                    "Paste an API key from console.anthropic.com. "
+                    "Works from anywhere with no extra tools — the "
+                    "right choice if you're new to Claude or aren't "
+                    "comfortable with terminal commands."
                 ),
                 "package": "anthropic",
                 "env_var": "ANTHROPIC_API_KEY",
@@ -94,6 +80,24 @@ _PROVIDERS: dict[str, dict[str, Any]] = {
                      "help": "Starts with sk-ant-. Found under API Keys "
                              "in the Anthropic Console."},
                 ],
+            },
+            {
+                "name": "claude_sdk",
+                "display_name": "Claude Code login",
+                "description": (
+                    "Reuse the credentials from 'claude login' if you "
+                    "already use Claude Code. No API key to manage. "
+                    "Note: this is an off-label use of Claude Code's "
+                    "auth that Anthropic may remove in a future update."
+                ),
+                "package": "claude_agent_sdk",
+                "env_var": None,
+                "setup_help": (
+                    "This option uses the Claude Code CLI's authentication. "
+                    "You must have run 'claude login' in your terminal first."
+                ),
+                "setup_url": "https://claude.ai/download",
+                "fields": [],
             },
         ],
     },

--- a/src/clarity_agent/llm/factory.py
+++ b/src/clarity_agent/llm/factory.py
@@ -127,13 +127,28 @@ def create_chat_backend(
     Raises:
         ValueError: If the provider is not recognized.
     """
-    # The claude_sdk auth mode uses a fundamentally different backend
-    # that wraps the Claude Code agent runtime rather than a raw API.
-    if config.provider == "anthropic" and config.auth_mode == "claude_sdk":
+    # Both Anthropic auth modes route through SdkChatBackend (the
+    # Claude Agent SDK runtime).  The difference is just *how* the
+    # SDK authenticates:
+    #
+    #   - ``api_key``    → explicit ``ANTHROPIC_API_KEY`` passed in.
+    #                      Recommended; works anywhere with no extra
+    #                      setup.
+    #   - ``claude_sdk`` → SDK uses ``claude login`` credentials.
+    #                      Convenient for existing Claude Code users
+    #                      but officially off-label and may be
+    #                      removed by Anthropic in the future.
+    #
+    # The low-level :class:`AnthropicClient` is no longer used as a
+    # chat backend — keeping every Anthropic conversation on the SDK
+    # runtime means tool calls, compaction, and session resume all
+    # use the same code path regardless of how the user authed.
+    if config.provider == "anthropic":
         from clarity_agent.llm.impl.claude_sdk import SdkChatBackend
         return SdkChatBackend(
             project_dir=project_dir,
             clarity_agent_dir=clarity_agent_dir,
+            api_key=config.api_key,
             transcript=transcript,
         )
 

--- a/src/clarity_agent/llm/impl/claude_sdk.py
+++ b/src/clarity_agent/llm/impl/claude_sdk.py
@@ -117,6 +117,7 @@ class SdkChatBackend(ChatBackend):
         *,
         project_dir: Path,
         clarity_agent_dir: Path,
+        api_key: str | None = None,
         transcript: Transcript | None = None,
     ) -> None:
         try:
@@ -133,6 +134,16 @@ class SdkChatBackend(ChatBackend):
         self.clarity_agent_dir: Path = clarity_agent_dir
         self._session_id: str | None = None
         self._current_system_prompt: str | None = None
+        # Explicit API key (from ``ANTHROPIC_API_KEY`` flag or env).
+        # When set, the API-mode tool loop passes it directly to
+        # :class:`anthropic.AsyncAnthropic`, and the SDK subprocess
+        # path injects it via ``ClaudeAgentOptions.env`` so the CLI
+        # picks it up even if the parent process's env doesn't have
+        # it.  ``None`` means "let the SDK use its own auth"
+        # (``claude login`` credentials) — the off-label path that
+        # may be deprecated upstream; ``api_key`` is now the
+        # recommended route.
+        self._api_key: str | None = api_key
         self._api_client: Any = None  # lazily-created anthropic.AsyncAnthropic
         # Set by the PreCompact hook when the SDK is about to
         # compact.  Drained by the post-query detection in
@@ -329,6 +340,15 @@ class SdkChatBackend(ChatBackend):
 
         had_session = self._session_id is not None
 
+        # Inject the api_key into the SDK subprocess's env when we
+        # have an explicit one — covers the case where the user
+        # passed ``--api-key`` and the parent env doesn't already
+        # contain ``ANTHROPIC_API_KEY``.  ``env`` merges with parent
+        # env (only the keys we list override), so omitting it when
+        # we have no key is the equivalent of "inherit parent".
+        sdk_env: dict[str, str] = (
+            {"ANTHROPIC_API_KEY": self._api_key} if self._api_key else {}
+        )
         options = self._sdk.ClaudeAgentOptions(
             system_prompt=self._current_system_prompt,
             allowed_tools=["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
@@ -337,6 +357,7 @@ class SdkChatBackend(ChatBackend):
             cwd=str(self.project_dir),
             max_turns=25,
             resume=self._session_id,
+            env=sdk_env,
             # PreCompact fires immediately before the SDK compacts
             # an existing session.  We just want to know about it —
             # the handler captures the transcript path and returns
@@ -466,8 +487,12 @@ class SdkChatBackend(ChatBackend):
         return asyncio.run(self._async_chat(user_message, system_prompt, model=model))
 
     def _has_api_key(self) -> bool:
-        """Check whether a direct Anthropic API key is available."""
-        return bool(os.environ.get("ANTHROPIC_API_KEY"))
+        """Check whether a direct Anthropic API key is available.
+
+        Returns ``True`` if either an explicit key was passed to the
+        constructor or ``ANTHROPIC_API_KEY`` is present in the env.
+        """
+        return bool(self._api_key or os.environ.get("ANTHROPIC_API_KEY"))
 
     # ------------------------------------------------------------------
     # Tool-schema encoding for SDK fallback
@@ -582,7 +607,11 @@ class SdkChatBackend(ChatBackend):
                     "with the Claude SDK backend. "
                     "Install with: pip install anthropic"
                 ) from exc
-            self._api_client = anthropic.AsyncAnthropic()
+            # Pass the explicit api_key when we have one; the
+            # anthropic SDK falls back to the env var when this is
+            # ``None``, so this single call covers both the
+            # ``--api-key``-flag path and the bare-env-var path.
+            self._api_client = anthropic.AsyncAnthropic(api_key=self._api_key)
 
         resolved_model: str = self.resolve_model(model)
         messages: list[dict[str, Any]] = [

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -159,16 +159,27 @@ class TestCreateChatBackend:
     """create_chat_backend builds the right ChatBackend for each provider."""
 
     def test_anthropic_provider(self, tmp_path: Any) -> None:
-        config = LLMConfig(provider="anthropic", api_key="fake-key")
-        with patch("clarity_agent.llm.impl.anthropic._anthropic_mod") as mock_mod:
-            mock_mod.AsyncAnthropic.return_value = MagicMock()
-            backend = create_chat_backend(
-                config,
-                project_dir=tmp_path,
-                clarity_agent_dir=tmp_path,
-            )
-        assert isinstance(backend, ClientChatBackend)
+        """Anthropic API-key auth now routes through SdkChatBackend.
+
+        The low-level :class:`AnthropicClient` is no longer used as a
+        chat backend (see #105): both Anthropic auth modes share the
+        SDK runtime so tool calls / compaction / resume behave the
+        same regardless of how the user authed.
+        """
+        from clarity_agent.llm.impl.claude_sdk import SdkChatBackend
+        config = LLMConfig(
+            provider="anthropic", auth_mode="api_key", api_key="fake-key",
+        )
+        backend = create_chat_backend(
+            config,
+            project_dir=tmp_path,
+            clarity_agent_dir=tmp_path,
+        )
+        assert isinstance(backend, SdkChatBackend)
         assert hasattr(backend, "chat")
+        # The key threads through to the backend so it can hand it
+        # to ``AsyncAnthropic`` / the SDK subprocess env.
+        assert backend._api_key == "fake-key"
 
     def test_azure_provider(self, tmp_path: Any) -> None:
         config = LLMConfig(
@@ -1842,13 +1853,28 @@ class TestSdkToolCallParsing:
         cls = self._get_cls()
         monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
         backend = MagicMock(spec=cls)
+        # ``_api_key`` is set in ``__init__``, so MagicMock(spec=cls)
+        # doesn't expose it.  Pin to ``None`` so we genuinely exercise
+        # the env-var branch.
+        backend._api_key = None
         assert cls._has_api_key(backend) is True
 
     def test_has_api_key_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
         cls = self._get_cls()
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         backend = MagicMock(spec=cls)
+        backend._api_key = None
         assert cls._has_api_key(backend) is False
+
+    def test_has_api_key_explicit_constructor_arg(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An explicit constructor api_key counts even when env is unset."""
+        cls = self._get_cls()
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        backend = MagicMock(spec=cls)
+        backend._api_key = "sk-ant-xyz"
+        assert cls._has_api_key(backend) is True
 
 
 class TestSdkToolLoopRouting:

--- a/web/src/components/PreferencesPanel.tsx
+++ b/web/src/components/PreferencesPanel.tsx
@@ -53,6 +53,11 @@ function Expandable({ open, children }: { open: boolean; children: React.ReactNo
 
 function ProviderTab({ settings, onSaved }: { settings: AppSettings; onSaved: () => void }) {
   const [providers, setProviders] = useState<ProviderInfo[]>([]);
+  // ``getSetupProviders`` can take a few seconds on first call
+  // (lazy backend probes); without a spinner the tab opens onto an
+  // empty pane which reads as "broken".  Start ``true`` so the very
+  // first render is the spinner, never an empty grid.
+  const [providersLoading, setProvidersLoading] = useState(true);
   const [selected, setSelected] = useState<ProviderInfo | null>(null);
   const [selectedMode, setSelectedMode] = useState<AuthModeInfo | null>(null);
   const [credentials, setCredentials] = useState<Record<string, string>>({});
@@ -62,21 +67,23 @@ function ProviderTab({ settings, onSaved }: { settings: AppSettings; onSaved: ()
   const [result, setResult] = useState<{ ok: boolean; message: string; hint?: string } | null>(null);
 
   useEffect(() => {
-    getSetupProviders().then((r) => {
-      setProviders(r.providers);
-      if (settings.provider) {
-        const current = r.providers.find((p) => p.name === settings.provider);
-        if (current) {
-          setSelected(current);
-          if (settings.auth_mode) {
-            const mode = current.auth_modes.find((m) => m.name === settings.auth_mode);
-            if (mode) setSelectedMode(mode);
-          } else if (current.auth_modes.length === 1) {
-            setSelectedMode(current.auth_modes[0]);
+    getSetupProviders()
+      .then((r) => {
+        setProviders(r.providers);
+        if (settings.provider) {
+          const current = r.providers.find((p) => p.name === settings.provider);
+          if (current) {
+            setSelected(current);
+            if (settings.auth_mode) {
+              const mode = current.auth_modes.find((m) => m.name === settings.auth_mode);
+              if (mode) setSelectedMode(mode);
+            } else if (current.auth_modes.length === 1) {
+              setSelectedMode(current.auth_modes[0]);
+            }
           }
         }
-      }
-    });
+      })
+      .finally(() => setProvidersLoading(false));
   }, [settings.provider, settings.auth_mode]);
 
   // Determine which providers are configured (have stored credentials).
@@ -176,6 +183,18 @@ function ProviderTab({ settings, onSaved }: { settings: AppSettings; onSaved: ()
 
   const isActive = (provName: string, modeName?: string) =>
     provName === settings.provider && (!modeName || modeName === settings.auth_mode);
+
+  if (providersLoading && providers.length === 0) {
+    return (
+      <div className="flex items-center justify-center gap-3 py-12">
+        <svg className="w-5 h-5 animate-spin text-accent-focus" viewBox="0 0 24 24" fill="none">
+          <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" opacity="0.3" />
+          <path d="M12 2a10 10 0 019.95 9" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        </svg>
+        <span className="text-sm text-body-muted">Loading providers…</span>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-2">


### PR DESCRIPTION
This PR does three things:

- If you use ANTHROPIC_API_KEY to auth, it previously also caused us to use the low-level AnthropicClient LLM BE. However, this method works fine with the (better) high-level SdkChatBackend, so change it so that switching the auth doesn't also switch the backend.
- We update the text in the providers panel to make ANTHROPIC_API_KEY the default way to auth for Anthropic, and add some clarification, because it turns out that our `claude login` method is an unsupported hack that may be broken by them in the future. (Sigh)
- Also, add a spinner when loading the providers panel, because it's weird-looking not to have one.

Resolves #105 .
Resolves #46 .