### PR TITLE
Block AskUserQuestion tool from Claude SDK backend (#102)

### DIFF
--- a/src/clarity_agent/llm/impl/claude_sdk.py
+++ b/src/clarity_agent/llm/impl/claude_sdk.py
@@ -352,6 +352,14 @@ class SdkChatBackend(ChatBackend):
         options = self._sdk.ClaudeAgentOptions(
             system_prompt=self._current_system_prompt,
             allowed_tools=["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
+            # ``AskUserQuestion`` is in Claude Code's default tool set
+            # but requires an interactive TUI to resolve — there's no
+            # SDK callback for delivering the user's answer back to
+            # the paused tool call, so it just hangs.  Blocking it
+            # tells the model "you don't have this tool"; it falls
+            # back to asking the question in plain text in its
+            # response, which our chat UI already renders.  See #102.
+            disallowed_tools=["AskUserQuestion"],
             permission_mode="bypassPermissions",
             model=self.resolve_model(model),
             cwd=str(self.project_dir),


### PR DESCRIPTION
Fixes #102.

## The problem

The Claude Agent SDK is a thin Python wrapper around the bundled `claude` CLI binary; the CLI is what implements every default tool (`Read`, `Write`, `Edit`, `Bash`, `WebFetch`, `Task`, `TodoWrite`, etc.) and runs the model's tool loop end-to-end inside its subprocess. Our Python code is a passive observer of the resulting `ToolUseBlock` stream — we don't participate in tool execution.

`AskUserQuestion` is the one tool in Claude Code's default set that can't be resolved entirely inside the CLI: it needs the user to answer. In an interactive `claude` session the CLI renders the question in its TUI. In SDK mode (`claude --print`, which is what the Python SDK uses) there's no TUI, and the SDK exposes no callback for delivering an answer back to the paused tool call. So the call just hangs — the user never sees the question, the model never gets a response, and the turn stalls.

(Side note: `claude --help` lists `--brief` as *"Enable `SendUserMessage` tool for agent-to-user communication"* — opt-in, not default. So Anthropic gates `SendUserMessage` behind an explicit flag for SDK use, but `AskUserQuestion` is in the default set. Possibly a recent regression on their end.)

## The fix

Pass `disallowed_tools=["AskUserQuestion"]` to `ClaudeAgentOptions` in `_run_query`. The CLI propagates that to the model as "you don't have this tool," and the model falls back to asking the question in plain text in its response — which our chat UI already renders. Every other default tool (`Task`, `WebSearch`, `WebFetch`, `TodoWrite`, file & shell tools) keeps working unchanged.

The other call site, `_arun_tool_loop_sdk` (the no-API-key fallback for the explicit tool-use loop), is untouched: it uses `allowed_tools=[]` plus manual `tool_call` code-fence parsing, so the Claude Code default toolset isn't in play there.

## Why this doesn't affect other providers

This is specifically a Claude Code runtime quirk. The OpenAI / Gemini / Azure / direct-Anthropic backends are raw messages-API clients — they only see tools we explicitly pass in via the `tools=` request parameter, and they have no concept of `AskUserQuestion`. The GitHub Copilot SDK is the only other agent-runtime wrapper, but its tool surface is bounded and doesn't include an equivalent.

## Test plan

- [ ] Trigger a turn where the model would naturally want to ask a clarifying question (e.g. "help me plan a project" with deliberately vague input)
- [ ] Confirm the question appears as text in the assistant's response rather than the turn stalling
- [ ] Confirm other default tools (`Task`, `WebSearch`, `TodoWrite`, file tools) still work
- [ ] `python -m pytest tests/test_llm.py` (ran locally: 99 passed)
