### PR TITLE
Fix GitHub Copilot CLI setup wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ The `src/clarity_agent/llm/` package abstracts all LLM interaction behind two in
 | **Anthropic** | `anthropic` | `ANTHROPIC_API_KEY` | Default auth uses `claude login` (`--auth-mode claude_sdk`); use `--auth-mode api_key` for direct API access. |
 | **Azure AI Inference** | `azure` | `AZURE_AI_API_KEY` | Also requires `--endpoint` or `AZURE_AI_ENDPOINT`. |
 | **OpenAI** | `openai` | `OPENAI_API_KEY` | Tool definitions translated from Anthropic format. |
-| **GitHub Copilot** | `github` | `GITHUB_TOKEN` | Also supports zero-config via `gh auth login` (`--auth-mode gh_cli`). |
+| **GitHub Copilot** | `github` | `GITHUB_TOKEN` | Supports bundled GitHub Copilot CLI login (`copilot auth login`), GitHub CLI fallback (`--auth-mode gh_cli`), and personal access tokens. |
 | **Google Gemini** | `gemini` | `GEMINI_API_KEY` | API key from [Google AI Studio](https://aistudio.google.com/apikey). |
 
 Select a provider with `--provider`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ The `src/clarity_agent/llm/` package abstracts all LLM interaction behind two in
 | **Anthropic** | `anthropic` | `ANTHROPIC_API_KEY` | Default auth uses `claude login` (`--auth-mode claude_sdk`); use `--auth-mode api_key` for direct API access. |
 | **Azure AI Inference** | `azure` | `AZURE_AI_API_KEY` | Also requires `--endpoint` or `AZURE_AI_ENDPOINT`. |
 | **OpenAI** | `openai` | `OPENAI_API_KEY` | Tool definitions translated from Anthropic format. |
-| **GitHub Copilot** | `github` | `GITHUB_TOKEN` | Supports bundled GitHub Copilot CLI login (`copilot auth login`), GitHub CLI fallback (`--auth-mode gh_cli`), and personal access tokens. |
+| **GitHub Copilot** | `github` | `GITHUB_TOKEN` | Supports bundled GitHub Copilot CLI login (`copilot auth login`), GitHub CLI auth (`--auth-mode gh_cli`), and personal access tokens. |
 | **Google Gemini** | `gemini` | `GEMINI_API_KEY` | API key from [Google AI Studio](https://aistudio.google.com/apikey). |
 
 Select a provider with `--provider`:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ On first launch, the setup wizard walks you through connecting an LLM provider.
 | **Anthropic (Claude)** | Claude Code login (`claude login`) · API key from [console.anthropic.com](https://console.anthropic.com/settings/keys) |
 | **OpenAI (GPT)** | API key from [platform.openai.com](https://platform.openai.com/api-keys) |
 | **Azure AI** | Microsoft sign-in · Azure CLI (`az login`) · API key |
-| **GitHub Copilot** | GitHub Copilot CLI (`copilot auth login`) · GitHub CLI fallback (`gh auth login`) · personal access token |
+| **GitHub Copilot** | GitHub Copilot CLI (`copilot auth login`) · GitHub CLI (`gh auth login`) · personal access token |
 | **Google Gemini** | API key from [Google AI Studio](https://aistudio.google.com/apikey) |
 
 Clarity works best with frontier models — structured thinking is where model quality matters most. The setup wizard tests your credentials before saving them. Run `clarity doctor` at any time to re-check the configuration.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ On first launch, the setup wizard walks you through connecting an LLM provider.
 | **Anthropic (Claude)** | Claude Code login (`claude login`) · API key from [console.anthropic.com](https://console.anthropic.com/settings/keys) |
 | **OpenAI (GPT)** | API key from [platform.openai.com](https://platform.openai.com/api-keys) |
 | **Azure AI** | Microsoft sign-in · Azure CLI (`az login`) · API key |
-| **GitHub Copilot** | GitHub CLI (`gh auth login`) · personal access token |
+| **GitHub Copilot** | GitHub Copilot CLI (`copilot auth login`) · GitHub CLI fallback (`gh auth login`) · personal access token |
 | **Google Gemini** | API key from [Google AI Studio](https://aistudio.google.com/apikey) |
 
 Clarity works best with frontier models — structured thinking is where model quality matters most. The setup wizard tests your credentials before saving them. Run `clarity doctor` at any time to re-check the configuration.

--- a/src/clarity_agent/llm/config.py
+++ b/src/clarity_agent/llm/config.py
@@ -204,16 +204,16 @@ _PROVIDERS: dict[str, dict[str, Any]] = {
         "auth_modes": [
             {
                 "name": "sdk_native",
-                "display_name": "Copilot login (recommended)",
+                "display_name": "GitHub Copilot CLI login",
                 "description": (
-                    "Zero-config via the bundled Copilot CLI's own login. "
+                    "Zero-config via the bundled GitHub Copilot CLI's own login. "
                     "No external tools to install."
                 ),
                 "package": "copilot",
                 "env_var": None,
                 "setup_help": (
                     "Run 'copilot auth login' in a terminal to sign in. "
-                    "The Copilot CLI is bundled with the Python package, "
+                    "The GitHub Copilot CLI is bundled with the Python package, "
                     "so no separate install is required."
                 ),
                 "setup_url": "https://docs.github.com/en/copilot",
@@ -221,16 +221,17 @@ _PROVIDERS: dict[str, dict[str, Any]] = {
             },
             {
                 "name": "gh_cli",
-                "display_name": "GitHub CLI",
+                "display_name": "GitHub CLI fallback",
                 "description": (
-                    "Use the gh CLI's stored token — convenient if you "
-                    "already have 'gh auth login' set up."
+                    "Use an existing GitHub CLI token from 'gh auth login'. "
+                    "Choose this only if you already have gh set up."
                 ),
                 "package": "copilot",
                 "env_var": None,
                 "setup_help": (
-                    "This option uses the GitHub CLI's authentication. "
-                    "You must have run 'gh auth login' first."
+                    "This fallback uses GitHub CLI authentication, not the "
+                    "GitHub Copilot CLI. You must have run 'gh auth login' "
+                    "first."
                 ),
                 "setup_url": "https://cli.github.com/",
                 "fields": [],

--- a/src/clarity_agent/llm/config.py
+++ b/src/clarity_agent/llm/config.py
@@ -204,7 +204,7 @@ _PROVIDERS: dict[str, dict[str, Any]] = {
         "auth_modes": [
             {
                 "name": "sdk_native",
-                "display_name": "GitHub Copilot CLI",
+                "display_name": "GitHub Copilot CLI (recommended)",
                 "description": (
                     "Sign in with Copilot using the bundled CLI. "
                     "No separate GitHub CLI install required."

--- a/src/clarity_agent/llm/config.py
+++ b/src/clarity_agent/llm/config.py
@@ -204,7 +204,7 @@ _PROVIDERS: dict[str, dict[str, Any]] = {
         "auth_modes": [
             {
                 "name": "sdk_native",
-                "display_name": "GitHub Copilot CLI (recommended)",
+                "display_name": "GitHub Copilot CLI (copilot, recommended)",
                 "description": (
                     "Sign in with Copilot using the bundled CLI. "
                     "No separate GitHub CLI install required."

--- a/src/clarity_agent/llm/config.py
+++ b/src/clarity_agent/llm/config.py
@@ -204,34 +204,33 @@ _PROVIDERS: dict[str, dict[str, Any]] = {
         "auth_modes": [
             {
                 "name": "sdk_native",
-                "display_name": "GitHub Copilot CLI login",
+                "display_name": "GitHub Copilot CLI",
                 "description": (
-                    "Zero-config via the bundled GitHub Copilot CLI's own login. "
-                    "No external tools to install."
+                    "Sign in with Copilot using the bundled CLI. "
+                    "No separate GitHub CLI install required."
                 ),
                 "package": "copilot",
                 "env_var": None,
                 "setup_help": (
                     "Run 'copilot auth login' in a terminal to sign in. "
                     "The GitHub Copilot CLI is bundled with the Python package, "
-                    "so no separate install is required."
+                    "so no separate GitHub CLI install is required."
                 ),
                 "setup_url": "https://docs.github.com/en/copilot",
                 "fields": [],
             },
             {
                 "name": "gh_cli",
-                "display_name": "GitHub CLI fallback",
+                "display_name": "GitHub CLI (gh)",
                 "description": (
                     "Use an existing GitHub CLI token from 'gh auth login'. "
-                    "Choose this only if you already have gh set up."
+                    "Choose this only if gh is already set up."
                 ),
                 "package": "copilot",
                 "env_var": None,
                 "setup_help": (
-                    "This fallback uses GitHub CLI authentication, not the "
-                    "GitHub Copilot CLI. You must have run 'gh auth login' "
-                    "first."
+                    "This uses GitHub CLI authentication, not 'copilot auth "
+                    "login'. You must have run 'gh auth login' first."
                 ),
                 "setup_url": "https://cli.github.com/",
                 "fields": [],

--- a/src/clarity_agent/setup/doctor.py
+++ b/src/clarity_agent/setup/doctor.py
@@ -943,7 +943,7 @@ def _probe_copilot(agent_dir: Path) -> CheckResult:
         rung = "Copilot login"
     else:
         token = get_gh_cli_token(raise_on_failure=True)
-        rung = "gh CLI"
+        rung = "GitHub CLI fallback"
 
     backend = CopilotChatBackend(
         project_dir=agent_dir,

--- a/src/clarity_agent/setup/doctor.py
+++ b/src/clarity_agent/setup/doctor.py
@@ -943,7 +943,7 @@ def _probe_copilot(agent_dir: Path) -> CheckResult:
         rung = "Copilot login"
     else:
         token = get_gh_cli_token(raise_on_failure=True)
-        rung = "GitHub CLI fallback"
+        rung = "GitHub CLI (gh)"
 
     backend = CopilotChatBackend(
         project_dir=agent_dir,

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -126,7 +126,7 @@ class TestProviderMetadata:
 
         assert sdk_mode is not None
         assert gh_mode is not None
-        assert sdk_mode["display_name"] == "GitHub Copilot CLI"
+        assert sdk_mode["display_name"] == "GitHub Copilot CLI (recommended)"
         assert "No separate GitHub CLI install required" in sdk_mode["description"]
         assert "copilot auth login" in sdk_mode["setup_help"]
         assert gh_mode["display_name"] == "GitHub CLI (gh)"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -126,7 +126,7 @@ class TestProviderMetadata:
 
         assert sdk_mode is not None
         assert gh_mode is not None
-        assert sdk_mode["display_name"] == "GitHub Copilot CLI (recommended)"
+        assert sdk_mode["display_name"] == "GitHub Copilot CLI (copilot, recommended)"
         assert "No separate GitHub CLI install required" in sdk_mode["description"]
         assert "copilot auth login" in sdk_mode["setup_help"]
         assert gh_mode["display_name"] == "GitHub CLI (gh)"

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -126,11 +126,11 @@ class TestProviderMetadata:
 
         assert sdk_mode is not None
         assert gh_mode is not None
-        assert sdk_mode["display_name"] == "GitHub Copilot CLI login"
-        assert "bundled GitHub Copilot CLI" in sdk_mode["description"]
+        assert sdk_mode["display_name"] == "GitHub Copilot CLI"
+        assert "No separate GitHub CLI install required" in sdk_mode["description"]
         assert "copilot auth login" in sdk_mode["setup_help"]
-        assert gh_mode["display_name"] == "GitHub CLI fallback"
-        assert "not the GitHub Copilot CLI" in gh_mode["setup_help"]
+        assert gh_mode["display_name"] == "GitHub CLI (gh)"
+        assert "not 'copilot auth login'" in gh_mode["setup_help"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -23,7 +23,7 @@ from clarity_agent.llm import (
     create_chat_backend,
     create_client,
 )
-from clarity_agent.llm.config import LLMConfigError
+from clarity_agent.llm.config import LLMConfigError, get_auth_mode_info
 
 # ---------------------------------------------------------------------------
 # Streaming mock helpers (used by OpenAI and Azure tests)
@@ -109,6 +109,28 @@ class TestLLMResponse:
         resp = LLMResponse()
         assert resp.content == []
         assert resp.stop_reason == "end_turn"
+
+
+# ---------------------------------------------------------------------------
+# Provider metadata
+# ---------------------------------------------------------------------------
+
+class TestProviderMetadata:
+    """Provider metadata drives first-run setup and preferences UI copy."""
+
+    def test_github_auth_modes_distinguish_copilot_cli_from_gh_fallback(
+        self,
+    ) -> None:
+        sdk_mode = get_auth_mode_info("github", "sdk_native")
+        gh_mode = get_auth_mode_info("github", "gh_cli")
+
+        assert sdk_mode is not None
+        assert gh_mode is not None
+        assert sdk_mode["display_name"] == "GitHub Copilot CLI login"
+        assert "bundled GitHub Copilot CLI" in sdk_mode["description"]
+        assert "copilot auth login" in sdk_mode["setup_help"]
+        assert gh_mode["display_name"] == "GitHub CLI fallback"
+        assert "not the GitHub Copilot CLI" in gh_mode["setup_help"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Clarify that the primary GitHub auth path is GitHub Copilot CLI login via `copilot auth login`
- Label `gh auth login` as a GitHub CLI fallback in setup metadata, doctor output, and docs
- Add regression coverage for GitHub provider auth-mode copy

Fixes #117

## Tests
- `uv run pytest tests/test_llm.py::TestProviderMetadata tests/test_llm.py::TestAutoDetectProvider`
- `uv run ruff check src\clarity_agent\llm\config.py src\clarity_agent\setup\doctor.py tests\test_llm.py`
- `git --no-pager diff --check`