### PR TITLE
docs: list all supported providers in .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 # You can explicitly select your provider by setting this variable; otherwise, Clarity will
 # auto-detect based on which credentials and SDKs it finds. If you set this, it must be one
-# of the supported providers: anthropic, claude-sdk, openai, or azure.
+# of the supported providers: anthropic, claude-sdk, openai, azure, gemini, or github.
 
 # CLARITY_LLM_PROVIDER=azure
 


### PR DESCRIPTION
  Fixes #132

  `.env.sample` documented `CLARITY_LLM_PROVIDER` as accepting only
  `anthropic, claude-sdk, openai, or azure`, but the provider registry in
  `src/clarity_agent/llm/config.py` (`_PROVIDERS` / `_auto_detect_provider`)
  also accepts `gemini` and `github` (GitHub Copilot) — both already listed in
  the README "Supported providers" table. This one-line doc change brings the
  sample in line with the code and README. No code or behavior changes.

  **Before:**
  `# of the supported providers: anthropic, claude-sdk, openai, or azure.`

  **After:**
  `# of the supported providers: anthropic, claude-sdk, openai, azure, gemini, or github.`