### PR TITLE
Add execution log side pane for better visibility

### DIFF
--- a/src/clarity_agent/web/app.py
+++ b/src/clarity_agent/web/app.py
@@ -22,7 +22,7 @@ from fastapi.staticfiles import StaticFiles
 
 from clarity_agent.app_paths import protocol_dir as _protocol_dir
 from clarity_agent.llm import LLMConfig
-from clarity_agent.web.log_broadcast import WebLogBroadcaster, install_logging_broadcaster
+from clarity_agent.web.log_broadcast import WebLogBroadcaster, install_stdio_broadcaster
 from clarity_agent.web.models import FeedbackRequest, ModelOverrideRequest, PacketRequest
 from clarity_agent.web.session_manager import WebSessionAdapter
 
@@ -228,7 +228,7 @@ def create_app(
     app = FastAPI(title="Clarity Agent", lifespan=lifespan)
     log_broadcaster = WebLogBroadcaster(default_source="backend", max_lines=250)
     if os.environ.get("CLARITY_LAUNCHER_CHILD") != "1":
-        install_logging_broadcaster(log_broadcaster, source="backend")
+        install_stdio_broadcaster(log_broadcaster)
 
     # Setup wizard routes — pass state so configure can reload the LLM config
     from clarity_agent.app_paths import clarity_env_path

--- a/src/clarity_agent/web/app.py
+++ b/src/clarity_agent/web/app.py
@@ -22,6 +22,7 @@ from fastapi.staticfiles import StaticFiles
 
 from clarity_agent.app_paths import protocol_dir as _protocol_dir
 from clarity_agent.llm import LLMConfig
+from clarity_agent.web.log_broadcast import WebLogBroadcaster, install_logging_broadcaster
 from clarity_agent.web.models import FeedbackRequest, ModelOverrideRequest, PacketRequest
 from clarity_agent.web.session_manager import WebSessionAdapter
 
@@ -29,6 +30,18 @@ from clarity_agent.web.session_manager import WebSessionAdapter
 _DIR_ORDER: list[str] = [
     ".", "goal", "solution", "failures", "decisions", "mailboxes", "archive",
 ]
+
+
+class _LockedWebSocketSender:
+    """Serialize writes to a WebSocket from multiple tasks."""
+
+    def __init__(self, ws: WebSocket, lock: asyncio.Lock) -> None:
+        self._ws = ws
+        self._lock = lock
+
+    async def send_json(self, data: Any) -> None:
+        async with self._lock:
+            await self._ws.send_json(data)
 
 
 def _dir_sort_key(rel_path: str) -> tuple[int, str]:
@@ -213,6 +226,9 @@ def create_app(
             await state["session"].stop()
 
     app = FastAPI(title="Clarity Agent", lifespan=lifespan)
+    log_broadcaster = WebLogBroadcaster(default_source="backend", max_lines=250)
+    if os.environ.get("CLARITY_LAUNCHER_CHILD") != "1":
+        install_logging_broadcaster(log_broadcaster, source="backend")
 
     # Setup wizard routes — pass state so configure can reload the LLM config
     from clarity_agent.app_paths import clarity_env_path
@@ -233,185 +249,209 @@ def create_app(
     @app.websocket("/ws/chat")
     async def websocket_chat(ws: WebSocket) -> None:
         await ws.accept()
+        send_lock = asyncio.Lock()
+        out_ws = _LockedWebSocketSender(ws, send_lock)
+        log_queue, unsubscribe_logs = log_broadcaster.subscribe()
+        log_broadcaster.publish(
+            f"chat websocket connected: {project_dir}",
+            source="backend",
+        )
+
+        async def _send_logs() -> None:
+            while True:
+                await out_ws.send_json(await log_queue.get())
+
+        log_task = asyncio.create_task(_send_logs())
 
         # Guard: if no LLM provider is configured, tell the frontend.
-        current_config: LLMConfig = state["llm_config"]
-        if current_config.provider == "none":
-            await ws.send_json({
-                "type": "error",
-                "message": "No LLM provider configured.",
-                "category": "setup_required",
-                "hint": "Complete the setup wizard to configure an LLM provider.",
-                "retryable": False,
-            })
-            # Reject everything until setup completes.  The frontend
-            # finishes setup with ``window.location.reload()``, which
-            # drops this socket; the next connection re-evaluates
-            # provider config from scratch.
-            try:
-                while True:
-                    await ws.receive_json()
-                    await ws.send_json({
-                        "type": "error",
-                        "message": "No LLM provider configured. Complete setup first.",
-                        "category": "setup_required",
-                        "retryable": False,
-                    })
-            except WebSocketDisconnect:
-                return
-
-        # Create session on first connection (or after config reload).
-        if state["session"] is None:
-            # Pick up the latest config in case activate_provider rebuilt it.
-            current_config = state["llm_config"]
-            session = WebSessionAdapter(
-                project_dir, clarity_agent_dir, current_config,
-                llm_session_id=llm_session_id,
-            )
-            try:
-                await session.start()
-            except (RuntimeError, OSError, ValueError) as e:
-                # Backend construction failed before we ever got to a
-                # chat turn — e.g. ``gh`` CLI missing on the github
-                # provider, claude CLI missing on the SDK auth path,
-                # malformed API key.  Without this branch the error
-                # propagates out of ``websocket_chat`` and uvicorn
-                # logs it to stderr while closing the socket with no
-                # message; the FE then reconnects, hits the same
-                # failure, and the user just sees "thinking" dots
-                # forever (issue #47).  Surface it as a classified
-                # error_event and keep the socket open the way the
-                # no-provider path does, so a banner has a chance to
-                # render.  The session ``state["session"]`` stays
-                # ``None`` — once the user resolves the underlying
-                # problem (e.g. installs gh) and reloads, the next
-                # connection retries ``session.start()`` from scratch.
-                error_event = _classify_ws_error(e, current_config.provider)
+        try:
+            current_config: LLMConfig = state["llm_config"]
+            if current_config.provider == "none":
+                await out_ws.send_json({
+                    "type": "error",
+                    "message": "No LLM provider configured.",
+                    "category": "setup_required",
+                    "hint": "Complete the setup wizard to configure an LLM provider.",
+                    "retryable": False,
+                })
+                # Reject everything until setup completes.  The frontend
+                # finishes setup with ``window.location.reload()``, which
+                # drops this socket; the next connection re-evaluates
+                # provider config from scratch.
                 try:
-                    await ws.send_json(error_event)
                     while True:
                         await ws.receive_json()
-                        await ws.send_json(error_event)
-                except (WebSocketDisconnect, RuntimeError):
+                        await out_ws.send_json({
+                            "type": "error",
+                            "message": "No LLM provider configured. Complete setup first.",
+                            "category": "setup_required",
+                            "retryable": False,
+                        })
+                except WebSocketDisconnect:
                     return
-            state["session"] = session
 
-        session: WebSessionAdapter = state["session"]
+            # Create session on first connection (or after config reload).
+            if state["session"] is None:
+                # Pick up the latest config in case activate_provider rebuilt it.
+                current_config = state["llm_config"]
+                session = WebSessionAdapter(
+                    project_dir, clarity_agent_dir, current_config,
+                    llm_session_id=llm_session_id,
+                )
+                try:
+                    log_broadcaster.publish("starting chat backend", source="backend")
+                    await session.start()
+                    log_broadcaster.publish("chat backend ready", source="backend")
+                except (RuntimeError, OSError, ValueError) as e:
+                    # Backend construction failed before we ever got to a
+                    # chat turn — e.g. ``gh`` CLI missing on the github
+                    # provider, claude CLI missing on the SDK auth path,
+                    # malformed API key.  Without this branch the error
+                    # propagates out of ``websocket_chat`` and uvicorn
+                    # logs it to stderr while closing the socket with no
+                    # message; the FE then reconnects, hits the same
+                    # failure, and the user just sees "thinking" dots
+                    # forever (issue #47).  Surface it as a classified
+                    # error_event and keep the socket open the way the
+                    # no-provider path does, so a banner has a chance to
+                    # render.  The session ``state["session"]`` stays
+                    # ``None`` — once the user resolves the underlying
+                    # problem (e.g. installs gh) and reloads, the next
+                    # connection retries ``session.start()`` from scratch.
+                    error_event = _classify_ws_error(e, current_config.provider)
+                    log_broadcaster.publish(
+                        f"backend start failed: {error_event['message']}",
+                        source="backend",
+                        level="error",
+                    )
+                    try:
+                        await out_ws.send_json(error_event)
+                        while True:
+                            await ws.receive_json()
+                            await out_ws.send_json(error_event)
+                    except (WebSocketDisconnect, RuntimeError):
+                        return
+                state["session"] = session
 
-        # Message queue: a single WS reader task puts messages here,
-        # and the main loop consumes them. This avoids concurrent
-        # ws.receive_json() calls which Starlette doesn't support.
-        msg_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
-        stop_event = asyncio.Event()
+            session: WebSessionAdapter = state["session"]
 
-        async def _ws_reader() -> None:
-            """Read WS messages in a loop, dispatch to queue or stop event."""
+            # Message queue: a single WS reader task puts messages here,
+            # and the main loop consumes them. This avoids concurrent
+            # ws.receive_json() calls which Starlette doesn't support.
+            msg_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+            stop_event = asyncio.Event()
+
+            async def _ws_reader() -> None:
+                """Read WS messages in a loop, dispatch to queue or stop event."""
+                try:
+                    while True:
+                        data = await ws.receive_json()
+                        if data.get("type") == "stop":
+                            stop_event.set()
+                        else:
+                            await msg_queue.put(data)
+                except (WebSocketDisconnect, RuntimeError):
+                    # Connection closed — put a sentinel to unblock the main loop.
+                    await msg_queue.put({"type": "_disconnect"})
+
+            reader_task = asyncio.create_task(_ws_reader())
+
             try:
                 while True:
-                    data = await ws.receive_json()
-                    if data.get("type") == "stop":
-                        stop_event.set()
-                    else:
-                        await msg_queue.put(data)
-            except (WebSocketDisconnect, RuntimeError):
-                # Connection closed — put a sentinel to unblock the main loop.
-                await msg_queue.put({"type": "_disconnect"})
+                    data: dict[str, Any] = await msg_queue.get()
+                    msg_type: str = data.get("type", "")
 
-        reader_task = asyncio.create_task(_ws_reader())
-
-        try:
-            while True:
-                data: dict[str, Any] = await msg_queue.get()
-                msg_type: str = data.get("type", "")
-
-                if msg_type == "_disconnect":
-                    return
-
-                if msg_type == "chat":
-                    message: str = data.get("message", "")
-                    if not message:
-                        await ws.send_json({"type": "error", "message": "Empty message"})
-                        continue
-
-                    stop_event.clear()
-                    try:
-                        chat_task = asyncio.create_task(
-                            session.chat(message, data.get("system_prompt")),
-                        )
-                        await _drain_events(session, chat_task, ws, stop_event)
-                    except WebSocketDisconnect:
+                    if msg_type == "_disconnect":
                         return
-                    except Exception as e:
-                        # Backend errors (RuntimeError from a CLI
-                        # crash, auth failures, network blips) all
-                        # land here: surface as a classified
-                        # error_event so the user sees what went
-                        # wrong, then ``continue`` the outer loop so
-                        # they can retry without reconnecting.
-                        # ``ws.send_json`` itself can raise
-                        # ``RuntimeError`` / ``WebSocketDisconnect``
-                        # if the socket died between turns — in that
-                        # case there's nothing left to surface to,
-                        # exit cleanly.
-                        import traceback
-                        tb = traceback.format_exc()
-                        print(f"  [Chat error] {e}\n{tb}", flush=True)
+
+                    if msg_type == "chat":
+                        message: str = data.get("message", "")
+                        if not message:
+                            await out_ws.send_json({"type": "error", "message": "Empty message"})
+                            continue
+
+                        stop_event.clear()
                         try:
-                            await ws.send_json(_classify_ws_error(e, current_config.provider))
-                        except (WebSocketDisconnect, RuntimeError):
+                            chat_task = asyncio.create_task(
+                                session.chat(message, data.get("system_prompt")),
+                            )
+                            await _drain_events(session, chat_task, out_ws, stop_event)
+                        except WebSocketDisconnect:
                             return
+                        except Exception as e:
+                            # Backend errors (RuntimeError from a CLI
+                            # crash, auth failures, network blips) all
+                            # land here: surface as a classified
+                            # error_event so the user sees what went
+                            # wrong, then ``continue`` the outer loop so
+                            # they can retry without reconnecting.
+                            # ``ws.send_json`` itself can raise
+                            # ``RuntimeError`` / ``WebSocketDisconnect``
+                            # if the socket died between turns — in that
+                            # case there's nothing left to surface to,
+                            # exit cleanly.
+                            import traceback
+                            tb = traceback.format_exc()
+                            print(f"  [Chat error] {e}\n{tb}", flush=True)
+                            try:
+                                await out_ws.send_json(_classify_ws_error(e, current_config.provider))
+                            except (WebSocketDisconnect, RuntimeError):
+                                return
 
-                elif msg_type == "start_process":
-                    process_name: str = data.get("process", "")
-                    if not process_name:
-                        await ws.send_json({"type": "error", "message": "No process name"})
-                        continue
+                    elif msg_type == "start_process":
+                        process_name: str = data.get("process", "")
+                        if not process_name:
+                            await out_ws.send_json({"type": "error", "message": "No process name"})
+                            continue
 
-                    stop_event.clear()
-                    try:
-                        chat_task = asyncio.create_task(
-                            session.start_process(process_name),
-                        )
-                        await _drain_events(session, chat_task, ws, stop_event)
-                    except WebSocketDisconnect:
-                        return
-                    except Exception as e:
-                        # Same handling as the ``chat`` branch above —
-                        # see the comment there for the rationale.
-                        import traceback
-                        tb = traceback.format_exc()
-                        print(f"  [Process error] {e}\n{tb}", flush=True)
+                        stop_event.clear()
                         try:
-                            await ws.send_json(_classify_ws_error(e, current_config.provider))
-                        except (WebSocketDisconnect, RuntimeError):
+                            chat_task = asyncio.create_task(
+                                session.start_process(process_name),
+                            )
+                            await _drain_events(session, chat_task, out_ws, stop_event)
+                        except WebSocketDisconnect:
                             return
+                        except Exception as e:
+                            # Same handling as the ``chat`` branch above —
+                            # see the comment there for the rationale.
+                            import traceback
+                            tb = traceback.format_exc()
+                            print(f"  [Process error] {e}\n{tb}", flush=True)
+                            try:
+                                await out_ws.send_json(_classify_ws_error(e, current_config.provider))
+                            except (WebSocketDisconnect, RuntimeError):
+                                return
 
-                elif msg_type == "set_model_override":
-                    tier: str = data.get("tier", "auto")
-                    if tier == "auto" or tier == "default":
-                        session.model_override = None
+                    elif msg_type == "set_model_override":
+                        tier: str = data.get("tier", "auto")
+                        if tier == "auto" or tier == "default":
+                            session.model_override = None
+                        else:
+                            session.model_override = tier
+                        # Re-resolve active model from current state.
+                        resolved = session._resolve_model(session.current_process)
+                        session._update_active_model(resolved, session.current_process)
+                        await out_ws.send_json({
+                            "type": "model_changed",
+                            "tier": session.active_tier,
+                            "model": session.active_model,
+                            "auto": session.model_override is None,
+                        })
+
                     else:
-                        session.model_override = tier
-                    # Re-resolve active model from current state.
-                    resolved = session._resolve_model(session.current_process)
-                    session._update_active_model(resolved, session.current_process)
-                    await ws.send_json({
-                        "type": "model_changed",
-                        "tier": session.active_tier,
-                        "model": session.active_model,
-                        "auto": session.model_override is None,
-                    })
+                        await out_ws.send_json({
+                            "type": "error",
+                            "message": f"Unknown message type: {msg_type}",
+                        })
 
-                else:
-                    await ws.send_json({
-                        "type": "error",
-                        "message": f"Unknown message type: {msg_type}",
-                    })
-
-        except WebSocketDisconnect:
-            pass
+            except WebSocketDisconnect:
+                pass
+            finally:
+                reader_task.cancel()
         finally:
-            reader_task.cancel()
+            unsubscribe_logs()
+            log_task.cancel()
 
     # ------------------------------------------------------------------
     # REST: Version + update status

--- a/src/clarity_agent/web/generation_log.py
+++ b/src/clarity_agent/web/generation_log.py
@@ -1,0 +1,280 @@
+"""Generic formatting helpers for web LLM generation logs."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+APPROX_CHARS_PER_TOKEN = 4
+PROVIDER_MANAGED_CONTEXT_PROVIDERS = frozenset({"anthropic", "github"})
+PROVIDER_MANAGED_CONTEXT_BACKENDS = frozenset({"CopilotChatBackend", "SdkChatBackend"})
+
+
+@dataclass(frozen=True)
+class RequestLogContext:
+    provider: str
+    model: str
+    tier: str
+    process: str
+    auth_mode: str
+    credential: str
+    endpoint: str
+    tool_count: int
+    user_message_chars: int
+    system_prompt_chars: int
+
+
+@dataclass(frozen=True)
+class ContextSegment:
+    name: str
+    role: str
+    chars: int | None
+    source: str
+    position: str | None = None
+
+
+@dataclass(frozen=True)
+class ContextManifest:
+    context_window_tokens: int
+    provider_managed_context: bool
+    segments: list[ContextSegment]
+
+
+def provider_manages_context(provider: str, backend_name: str) -> bool:
+    """Return whether the provider may hold unseen context internally.
+
+    Args:
+        provider: Configured provider name.
+        backend_name: Runtime chat backend class name.
+
+    Returns:
+        True when Clarity cannot inspect the final provider-side message history.
+    """
+    return (
+        provider in PROVIDER_MANAGED_CONTEXT_PROVIDERS
+        or backend_name in PROVIDER_MANAGED_CONTEXT_BACKENDS
+    )
+
+
+def serialized_char_count(value: Any) -> int:
+    """Return a deterministic redacted character count.
+
+    Args:
+        value: Value to measure after JSON serialization.
+
+    Returns:
+        Number of serialized characters, or ``repr`` length for unserializable values.
+    """
+    try:
+        return len(json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ))
+    except (TypeError, ValueError):
+        return len(repr(value))
+
+
+def format_request_started(context: RequestLogContext) -> str:
+    """Format the start of an LLM request.
+
+    Args:
+        context: Redacted request metadata.
+
+    Returns:
+        Human-readable generation log line.
+    """
+    return (
+        "llm.request started. "
+        f"Sending this turn to provider {context.provider} with model {context.model}. "
+        f"Tier: {context.tier}. "
+        f"Process: {context.process}. "
+        f"Auth mode: {context.auth_mode}; credential {context.credential}; "
+        f"endpoint {context.endpoint}. "
+        f"Tools available: {context.tool_count}. "
+        f"User message: {context.user_message_chars} chars. "
+        f"Added system instructions: {context.system_prompt_chars} chars."
+    )
+
+
+def format_stream_started(provider: str, model: str) -> str:
+    """Format the first streamed text event.
+
+    Args:
+        provider: Configured provider name.
+        model: Active model name.
+
+    Returns:
+        Human-readable generation log line.
+    """
+    return (
+        "llm.stream started. "
+        f"First text arrived from {provider} using {model}."
+    )
+
+
+def format_response_failed(
+    *,
+    provider: str,
+    model: str,
+    duration_ms: int,
+    error_type: str,
+) -> str:
+    """Format a failed LLM response.
+
+    Args:
+        provider: Configured provider name.
+        model: Active model name.
+        duration_ms: Elapsed request duration in milliseconds.
+        error_type: Exception class name.
+
+    Returns:
+        Human-readable generation log line.
+    """
+    return (
+        f"llm.response failed after {duration_ms} ms. "
+        f"Provider: {provider}. "
+        f"Model: {model}. "
+        f"Error type: {error_type}."
+    )
+
+
+def format_response_complete(
+    *,
+    provider: str,
+    model: str,
+    duration_ms: int,
+    response_chars: int,
+    stream_chunks: int,
+    stream_chars: int,
+) -> str:
+    """Format a completed LLM response.
+
+    Args:
+        provider: Configured provider name.
+        model: Active model name.
+        duration_ms: Elapsed request duration in milliseconds.
+        response_chars: Final response size in characters.
+        stream_chunks: Number of streamed chunks observed.
+        stream_chars: Number of streamed characters observed.
+
+    Returns:
+        Human-readable generation log line.
+    """
+    return (
+        f"llm.response complete in {duration_ms} ms. "
+        f"Provider: {provider}. "
+        f"Model: {model}. "
+        f"Response: {response_chars} chars. "
+        f"Streamed chunks: {stream_chunks}; "
+        f"streamed chars: {stream_chars}."
+    )
+
+
+def format_context_manifest(manifest: ContextManifest) -> list[str]:
+    """Format a redacted prompt map for an LLM request.
+
+    Args:
+        manifest: Redacted context-window measurements.
+
+    Returns:
+        One manifest line followed by one line per context segment.
+    """
+    segment_lines, known_tokens = _format_segments(manifest)
+    provider_visibility = (
+        "not visible to Clarity after handoff"
+        if manifest.provider_managed_context
+        else "visible to Clarity in local backend history"
+    )
+    summary = (
+        "llm.context_manifest Prompt map: "
+        f"known context is about {known_tokens:,} tokens "
+        f"({_window_fraction_label(known_tokens, manifest.context_window_tokens)} "
+        f"of the {manifest.context_window_tokens:,}-token model window). "
+        "Raw prompt text is omitted. "
+        f"Provider-managed context is {provider_visibility}."
+    )
+    return [summary, *segment_lines]
+
+
+def _format_segments(manifest: ContextManifest) -> tuple[list[str], int]:
+    lines: list[str] = []
+    cursor = 0
+    known_tokens = 0
+    total = len(manifest.segments)
+    for index, segment in enumerate(manifest.segments, start=1):
+        if segment.chars is None:
+            lines.append(_format_unknown_segment(index, total, segment))
+            continue
+
+        tokens = _estimate_tokens(segment.chars)
+        known_tokens += tokens
+        if segment.position is None:
+            position = _position_label(
+                cursor,
+                cursor + tokens,
+                manifest.context_window_tokens,
+            )
+            cursor += tokens
+        else:
+            position = segment.position
+        lines.append(_format_known_segment(index, total, segment, tokens, position))
+    return lines, known_tokens
+
+
+def _format_known_segment(
+    index: int,
+    total: int,
+    segment: ContextSegment,
+    tokens: int,
+    position: str,
+) -> str:
+    return (
+        f"llm.context_segment {index}/{total}: {segment.name}. "
+        f"Role: {segment.role}. "
+        f"Size: about {tokens:,} tokens from {segment.chars:,} chars. "
+        f"Position: {_position_explanation(position)}. "
+        f"Source: {segment.source}. "
+        "Content: omitted."
+    )
+
+
+def _format_unknown_segment(index: int, total: int, segment: ContextSegment) -> str:
+    return (
+        f"llm.context_segment {index}/{total}: {segment.name}. "
+        f"Role: {segment.role}. "
+        "Size: unknown. "
+        f"Position: {_position_explanation(segment.position)}. "
+        f"Source: {segment.source}. "
+        "Content: not visible to Clarity."
+    )
+
+
+def _estimate_tokens(chars: int) -> int:
+    if chars <= 0:
+        return 0
+    return max(1, (chars + APPROX_CHARS_PER_TOKEN - 1) // APPROX_CHARS_PER_TOKEN)
+
+
+def _position_label(start_tokens: int, end_tokens: int, context_window: int) -> str:
+    if context_window <= 0:
+        return "unknown"
+    return f"{start_tokens / context_window:.1%}-{end_tokens / context_window:.1%}"
+
+
+def _window_fraction_label(tokens: int, context_window: int) -> str:
+    if context_window <= 0:
+        return "unknown"
+    return f"{tokens / context_window:.1%}"
+
+
+def _position_explanation(position: str | None) -> str:
+    if position == "provider_managed":
+        return "provider-managed, exact position not visible to Clarity"
+    if position == "provider_specific":
+        return "provider-specific placement"
+    if position is None or position == "unknown":
+        return "unknown"
+    return f"about {position} of the known context window"

--- a/src/clarity_agent/web/launcher.py
+++ b/src/clarity_agent/web/launcher.py
@@ -103,6 +103,7 @@ from fastapi.responses import JSONResponse, Response
 from fastapi.staticfiles import StaticFiles
 
 from clarity_agent.projects import ProjectEntry, ProjectRegistry
+from clarity_agent.web.log_broadcast import WebLogBroadcaster
 
 # ---------------------------------------------------------------------------
 # Process table (in-memory, runtime-only)
@@ -213,6 +214,27 @@ async def _wait_for_server(port: int, timeout: float = 30.0) -> bool:
 
 _IDLE_TIMEOUT_SECONDS = 30 * 60  # 30 minutes
 
+
+class _LockedWebSocketSender:
+    """Serialize writes to a WebSocket from multiple tasks."""
+
+    def __init__(self, ws: WebSocket, lock: asyncio.Lock) -> None:
+        self._ws = ws
+        self._lock = lock
+
+    async def send_json(self, data: Any) -> None:
+        async with self._lock:
+            await self._ws.send_json(data)
+
+    async def send_text(self, data: str) -> None:
+        async with self._lock:
+            await self._ws.send_text(data)
+
+    async def send_bytes(self, data: bytes) -> None:
+        async with self._lock:
+            await self._ws.send_bytes(data)
+
+
 def create_launcher(
     clarity_agent_dir: Path,
     static_dir: Path | None = None,
@@ -230,6 +252,7 @@ def create_launcher(
     """
     registry = ProjectRegistry()
     processes = ProcessTable()
+    project_logs: dict[str, WebLogBroadcaster] = {}
     # ``id`` (the registry's stable path-derived hash) — unique
     # even when two projects share a display name.  See the
     # ProcessEntry docstring for why this matters.
@@ -248,6 +271,16 @@ def create_launcher(
     from clarity_agent.app_paths import clarity_env_path
     _env_path = env_path or clarity_env_path()
     _clarity_py = clarity_agent_dir / "clarity.py"
+
+    def _logs_for_project(project_id: str) -> WebLogBroadcaster:
+        broadcaster = project_logs.get(project_id)
+        if broadcaster is None:
+            broadcaster = WebLogBroadcaster(
+                default_source="project-server",
+                max_lines=250,
+            )
+            project_logs[project_id] = broadcaster
+        return broadcaster
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -291,7 +324,11 @@ def create_launcher(
     # Subprocess management
     # ------------------------------------------------------------------
 
-    def _pipe_output(stream: Any, prefix: str) -> None:
+    def _pipe_output(
+        stream: Any,
+        prefix: str,
+        broadcaster: WebLogBroadcaster,
+    ) -> None:
         """Read lines from a subprocess stream and print with a prefix.
 
         Runs in a daemon thread so the pipe buffer never fills up (which
@@ -300,6 +337,12 @@ def create_launcher(
         try:
             for line in stream:
                 text = line.decode("utf-8", errors="replace").rstrip("\n")
+                level = (
+                    "error"
+                    if text.lstrip().startswith(("ERROR", "Traceback", "Exception"))
+                    else "info"
+                )
+                broadcaster.publish(text, source=prefix, level=level)
                 print(f"  [{prefix}] {text}", flush=True)
         except ValueError:
             # Stream closed
@@ -310,6 +353,11 @@ def create_launcher(
         from clarity_agent.app_paths import is_frozen
 
         port = _find_free_port()
+        logs = _logs_for_project(project.id)
+        logs.publish(
+            f"spawning project server pid=pending port={port}",
+            source="launcher",
+        )
         # In a frozen (PyInstaller) build, sys.executable is the bundle
         # itself and handles subcommands directly.  In development,
         # we invoke Python with clarity.py as a script.
@@ -337,6 +385,7 @@ def create_launcher(
         existing_pp = env.get("PYTHONPATH", "")
         if src_dir not in existing_pp.split(os.pathsep):
             env["PYTHONPATH"] = f"{src_dir}{os.pathsep}{existing_pp}" if existing_pp else src_dir
+        env["CLARITY_LAUNCHER_CHILD"] = "1"
         proc = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
@@ -351,7 +400,9 @@ def create_launcher(
             (proc.stderr, f"{project.name}:err"),
         ]:
             t = threading.Thread(
-                target=_pipe_output, args=(stream, label), daemon=True,
+                target=_pipe_output,
+                args=(stream, label, logs),
+                daemon=True,
             )
             t.start()
 
@@ -363,6 +414,10 @@ def create_launcher(
             process=proc,
         )
         processes.add(entry)
+        logs.publish(
+            f"spawned project server pid={proc.pid} port={port}",
+            source="launcher",
+        )
         return entry
 
     async def _ensure_running(project: ProjectEntry) -> ProcessEntry:
@@ -811,10 +866,12 @@ def create_launcher(
     @app.websocket("/ws/chat")
     async def websocket_proxy(ws: WebSocket) -> None:
         await ws.accept()
+        send_lock = asyncio.Lock()
+        out_ws = _LockedWebSocketSender(ws, send_lock)
 
         entry = await _ensure_active_running()
         if entry is None:
-            await ws.send_json({
+            await out_ws.send_json({
                 "type": "error",
                 "message": "No active project. Select a project first.",
                 "category": "no_project",
@@ -827,6 +884,7 @@ def create_launcher(
         assert project_id is not None  # guaranteed by _ensure_active_running success
 
         processes.touch(project_id)
+        log_queue, unsubscribe_logs = _logs_for_project(project_id).subscribe()
 
         # Connect to the project server's WebSocket.
         # websockets 13+ uses websockets.asyncio.client.
@@ -849,20 +907,31 @@ def create_launcher(
                     try:
                         async for message in upstream:
                             if isinstance(message, str):
-                                await ws.send_text(message)
+                                await out_ws.send_text(message)
                             else:
-                                await ws.send_bytes(message)
+                                await out_ws.send_bytes(message)
                     except ConnectionClosed:
                         pass
 
-                await asyncio.gather(
-                    browser_to_server(),
-                    server_to_browser(),
-                    return_exceptions=True,
+                async def logs_to_browser() -> None:
+                    while True:
+                        await out_ws.send_json(await log_queue.get())
+
+                tasks = [
+                    asyncio.create_task(browser_to_server()),
+                    asyncio.create_task(server_to_browser()),
+                    asyncio.create_task(logs_to_browser()),
+                ]
+                done, pending = await asyncio.wait(
+                    tasks,
+                    return_when=asyncio.FIRST_COMPLETED,
                 )
+                for task in pending:
+                    task.cancel()
+                await asyncio.gather(*done, *pending, return_exceptions=True)
         except Exception as e:
             try:
-                await ws.send_json({
+                await out_ws.send_json({
                     "type": "error",
                     "message": f"Failed to connect to project server: {e}",
                     "category": "network",
@@ -871,6 +940,7 @@ def create_launcher(
             except Exception:
                 pass
         finally:
+            unsubscribe_logs()
             try:
                 await ws.close()
             except Exception:

--- a/src/clarity_agent/web/log_broadcast.py
+++ b/src/clarity_agent/web/log_broadcast.py
@@ -1,0 +1,135 @@
+"""Thread-safe log broadcaster for WebSocket clients."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import threading
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+_MAX_LOG_CHARS = 1_200
+_SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(authorization\s*:\s*bearer\s+)[^\s]+", re.IGNORECASE), r"\1[redacted]"),
+    (re.compile(r"((?:api[_-]?key|token|secret)\s*[=:]\s*)[^\s&]+", re.IGNORECASE), r"\1[redacted]"),
+    (re.compile(r"((?:OPENAI|ANTHROPIC|AZURE|GITHUB|GH)_[A-Z0-9_]*KEY=)[^\s]+"), r"\1[redacted]"),
+    (re.compile(r"((?:GITHUB|GH|CLAUDE|COPILOT)_[A-Z0-9_]*TOKEN=)[^\s]+"), r"\1[redacted]"),
+)
+
+
+@dataclass(frozen=True)
+class _Subscriber:
+    loop: asyncio.AbstractEventLoop
+    queue: asyncio.Queue[dict[str, Any]]
+
+
+def sanitize_log_message(message: str) -> str:
+    """Strip control sequences, redact obvious secrets, and bound length."""
+    cleaned = _ANSI_RE.sub("", message).strip()
+    for pattern, replacement in _SECRET_PATTERNS:
+        cleaned = pattern.sub(replacement, cleaned)
+    if len(cleaned) > _MAX_LOG_CHARS:
+        cleaned = f"{cleaned[: _MAX_LOG_CHARS - 3]}..."
+    return cleaned
+
+
+class WebLogBroadcaster:
+    """Fan out backend log events to any active WebSocket subscribers."""
+
+    def __init__(self, *, default_source: str = "backend", max_lines: int = 200) -> None:
+        self.default_source = default_source
+        self._buffer: deque[dict[str, Any]] = deque(maxlen=max_lines)
+        self._subscribers: dict[int, _Subscriber] = {}
+        self._lock = threading.Lock()
+        self._next_token = 0
+
+    def publish(
+        self,
+        message: str,
+        *,
+        source: str | None = None,
+        level: str = "info",
+    ) -> None:
+        """Publish one log line to the replay buffer and live subscribers."""
+        cleaned = sanitize_log_message(message)
+        if not cleaned:
+            return
+        event = {
+            "type": "log",
+            "source": source or self.default_source,
+            "level": level.lower(),
+            "message": cleaned,
+        }
+        with self._lock:
+            self._buffer.append(event)
+            subscribers = list(self._subscribers.values())
+        for subscriber in subscribers:
+            subscriber.loop.call_soon_threadsafe(subscriber.queue.put_nowait, event)
+
+    def subscribe(
+        self,
+        *,
+        replay: bool = True,
+    ) -> tuple[asyncio.Queue[dict[str, Any]], Callable[[], None]]:
+        """Subscribe the current event loop to future events."""
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        with self._lock:
+            token = self._next_token
+            self._next_token += 1
+            self._subscribers[token] = _Subscriber(loop=loop, queue=queue)
+            replay_events = list(self._buffer) if replay else []
+
+        for event in replay_events:
+            queue.put_nowait(event)
+
+        def unsubscribe() -> None:
+            with self._lock:
+                self._subscribers.pop(token, None)
+
+        return queue, unsubscribe
+
+
+class BroadcastLogHandler(logging.Handler):
+    """Logging handler that forwards records to a WebLogBroadcaster."""
+
+    def __init__(self, broadcaster: WebLogBroadcaster, *, source: str) -> None:
+        super().__init__()
+        self.broadcaster = broadcaster
+        self.source = source
+        self.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            self.broadcaster.publish(
+                self.format(record),
+                source=self.source,
+                level=record.levelname.lower(),
+            )
+        except Exception:
+            self.handleError(record)
+
+
+def install_logging_broadcaster(
+    broadcaster: WebLogBroadcaster,
+    *,
+    source: str = "backend",
+    logger_names: tuple[str, ...] = ("uvicorn.access", "uvicorn.error", "clarity_agent"),
+) -> None:
+    """Attach a broadcaster handler to selected Python loggers once."""
+    marker = "_clarity_web_log_broadcaster_id"
+    broadcaster_id = id(broadcaster)
+    for name in logger_names:
+        logger = logging.getLogger(name)
+        if any(
+            getattr(handler, marker, None) == broadcaster_id
+            for handler in logger.handlers
+        ):
+            continue
+        handler = BroadcastLogHandler(broadcaster, source=source)
+        setattr(handler, marker, broadcaster_id)
+        logger.addHandler(handler)

--- a/src/clarity_agent/web/log_broadcast.py
+++ b/src/clarity_agent/web/log_broadcast.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import sys
 import threading
 from collections import deque
 from collections.abc import Callable
@@ -112,6 +113,147 @@ class BroadcastLogHandler(logging.Handler):
             )
         except Exception:
             self.handleError(record)
+
+
+@dataclass(frozen=True)
+class _StreamPublisher:
+    broadcaster: WebLogBroadcaster
+    source: str
+    level: str
+
+
+class BroadcastStream:
+    """Text stream wrapper that tees terminal output to log subscribers."""
+
+    def __init__(self, stream: Any) -> None:
+        self._stream = stream
+        self._publishers: dict[int, _StreamPublisher] = {}
+        self._line_buffer = ""
+        self._lock = threading.Lock()
+
+    @property
+    def wrapped(self) -> Any:
+        return self._stream
+
+    @property
+    def has_publishers(self) -> bool:
+        return bool(self._publishers)
+
+    def add_publisher(
+        self,
+        broadcaster: WebLogBroadcaster,
+        *,
+        source: str,
+        level: str,
+    ) -> None:
+        with self._lock:
+            self._publishers[id(broadcaster)] = _StreamPublisher(
+                broadcaster=broadcaster,
+                source=source,
+                level=level,
+            )
+
+    def remove_publisher(self, broadcaster: WebLogBroadcaster) -> None:
+        with self._lock:
+            self._publishers.pop(id(broadcaster), None)
+
+    def write(self, text: str) -> int:
+        written = self._stream.write(text)
+        self._publish(text)
+        return written
+
+    def flush(self) -> None:
+        self._stream.flush()
+        self.flush_pending()
+
+    def flush_pending(self) -> None:
+        with self._lock:
+            if not self._line_buffer:
+                return
+            line = self._line_buffer
+            self._line_buffer = ""
+            publishers = list(self._publishers.values())
+
+        for publisher in publishers:
+            publisher.broadcaster.publish(
+                line,
+                source=publisher.source,
+                level=publisher.level,
+            )
+
+    def _publish(self, text: str) -> None:
+        normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+        with self._lock:
+            buffered = self._line_buffer + normalized
+            lines = buffered.split("\n")
+            self._line_buffer = lines.pop()
+            publishers = list(self._publishers.values())
+
+        for line in lines:
+            for publisher in publishers:
+                publisher.broadcaster.publish(
+                    line,
+                    source=publisher.source,
+                    level=publisher.level,
+                )
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+
+def install_stdio_broadcaster(
+    broadcaster: WebLogBroadcaster,
+    *,
+    stdout_source: str = "stdout",
+    stderr_source: str = "stderr",
+) -> Callable[[], None]:
+    """Mirror process stdout and stderr into a broadcaster until restored."""
+    restore_stdout = _install_stream_broadcaster(
+        "stdout",
+        broadcaster,
+        source=stdout_source,
+        level="info",
+    )
+    restore_stderr = _install_stream_broadcaster(
+        "stderr",
+        broadcaster,
+        source=stderr_source,
+        level="info",
+    )
+
+    def restore() -> None:
+        restore_stdout()
+        restore_stderr()
+
+    return restore
+
+
+def _install_stream_broadcaster(
+    stream_name: str,
+    broadcaster: WebLogBroadcaster,
+    *,
+    source: str,
+    level: str,
+) -> Callable[[], None]:
+    current = getattr(sys, stream_name)
+    if isinstance(current, BroadcastStream):
+        stream = current
+    else:
+        stream = BroadcastStream(current)
+        setattr(sys, stream_name, stream)
+
+    stream.add_publisher(broadcaster, source=source, level=level)
+
+    def restore() -> None:
+        active = getattr(sys, stream_name)
+        if active is not stream:
+            return
+        stream.flush_pending()
+        stream.remove_publisher(broadcaster)
+        if not stream.has_publishers:
+            setattr(sys, stream_name, stream.wrapped)
+
+    return restore
 
 
 def install_logging_broadcaster(

--- a/src/clarity_agent/web/session_manager.py
+++ b/src/clarity_agent/web/session_manager.py
@@ -35,6 +35,38 @@ from clarity_agent.web.session_state import (
 _APPROX_CHARS_PER_TOKEN = 4
 _PROVIDER_MANAGED_CONTEXT_PROVIDERS = {"anthropic", "github"}
 _PROVIDER_MANAGED_CONTEXT_BACKENDS = {"CopilotChatBackend", "SdkChatBackend"}
+_CONTEXT_SEGMENT_LABELS = {
+    "backend_system_prompt": "Backend system prompt",
+    "tool_schemas": "Tool schemas",
+    "project_behaviors": "Project instructions",
+    "transcript_restore": "Restored transcript",
+    "turn_system_prompt": "Turn/process instructions",
+    "prior_messages": "Prior chat messages",
+    "provider_session_history": "Provider-managed history",
+    "current_user_message": "Current user message",
+}
+_CONTEXT_SEGMENT_EXPLANATIONS = {
+    "backend_system_prompt": "Static instructions added by the selected backend.",
+    "tool_schemas": "Tool definitions passed with this request.",
+    "project_behaviors": "Repository and project instructions loaded from AGENTS.md.",
+    "transcript_restore": (
+        "Prior transcript content restored because no provider session was resumed."
+    ),
+    "turn_system_prompt": "Extra instructions added by the current process or call.",
+    "prior_messages": "Earlier messages visible in the local backend history.",
+    "provider_session_history": "Conversation state held inside the provider runtime.",
+    "current_user_message": "The message the user just sent.",
+}
+_CONTEXT_SOURCE_LABELS = {
+    "backend_static": "backend static prompt",
+    "adapter_passed_tools": "tools passed by Clarity",
+    "project_AGENTS": "project AGENTS.md",
+    "prior_transcript": "prior transcript",
+    "process_or_call": "current process or call",
+    "backend_conversation_history": "backend conversation history",
+    "provider_runtime": "provider runtime",
+    "current_turn": "current turn",
+}
 
 
 @dataclass(frozen=True)
@@ -413,17 +445,15 @@ class WebSessionAdapter:
         process = self.current_process or "chat"
         tool_count = len(self._tools or [])
         return (
-            "llm.request start "
-            f"provider={provider} "
-            f"model={model} "
-            f"tier={self.active_tier} "
-            f"process={process} "
-            f"auth_mode={auth_mode} "
-            f"credential={self._credential_summary()} "
-            f"endpoint={self._endpoint_summary()} "
-            f"tools={tool_count} "
-            f"user_message_chars={len(message)} "
-            f"system_prompt_chars={len(system_prompt or '')}"
+            "llm.request started. "
+            f"Sending this turn to provider {provider} with model {model}. "
+            f"Tier: {self.active_tier}. "
+            f"Process: {process}. "
+            f"Auth mode: {auth_mode}; credential {self._credential_summary()}; "
+            f"endpoint {self._endpoint_summary()}. "
+            f"Tools available: {tool_count}. "
+            f"User message: {len(message)} chars. "
+            f"Added system instructions: {len(system_prompt or '')} chars."
         )
 
     @staticmethod
@@ -489,6 +519,34 @@ class WebSessionAdapter:
             return "unknown"
         return f"{start_tokens / context_window:.1%}-{end_tokens / context_window:.1%}"
 
+    @staticmethod
+    def _window_fraction_label(tokens: int, context_window: int) -> str:
+        if context_window <= 0:
+            return "unknown"
+        return f"{tokens / context_window:.1%}"
+
+    @staticmethod
+    def _segment_position_explanation(position: str | None) -> str:
+        if position == "provider_managed":
+            return "provider-managed, exact position not visible to Clarity"
+        if position == "provider_specific":
+            return "provider-specific placement"
+        if position is None or position == "unknown":
+            return "unknown"
+        return f"about {position} of the known context window"
+
+    @staticmethod
+    def _segment_label(name: str) -> str:
+        return _CONTEXT_SEGMENT_LABELS.get(name, name.replace("_", " ").title())
+
+    @staticmethod
+    def _segment_explanation(name: str) -> str:
+        return _CONTEXT_SEGMENT_EXPLANATIONS.get(name, "Context passed with this request.")
+
+    @staticmethod
+    def _source_label(source: str) -> str:
+        return _CONTEXT_SOURCE_LABELS.get(source, source.replace("_", " "))
+
     def _context_segment_details(
         self,
         segments: list[_ContextSegment],
@@ -498,17 +556,20 @@ class WebSessionAdapter:
         details: list[str] = []
         cursor = 0
         known_tokens = 0
+        segment_count = len(segments)
         for index, segment in enumerate(segments, start=1):
+            label = self._segment_label(segment.name)
+            explanation = self._segment_explanation(segment.name)
+            source = self._source_label(segment.source)
             if segment.chars is None:
                 details.append(
-                    "llm.context_segment "
-                    f"index={index} "
-                    f"name={segment.name} "
-                    f"role={segment.role} "
-                    "chars=unknown "
-                    "estimated_tokens=unknown "
-                    f"position={segment.position or 'unknown'} "
-                    f"source={segment.source}"
+                    f"llm.context_segment {index}/{segment_count}: "
+                    f"{label}. {explanation} "
+                    f"Role: {segment.role}. "
+                    "Size: unknown. "
+                    f"Position: {self._segment_position_explanation(segment.position)}. "
+                    f"Source: {source}. "
+                    "Content: not visible to Clarity."
                 )
                 continue
 
@@ -524,14 +585,13 @@ class WebSessionAdapter:
             else:
                 position = segment.position
             details.append(
-                "llm.context_segment "
-                f"index={index} "
-                f"name={segment.name} "
-                f"role={segment.role} "
-                f"chars={segment.chars} "
-                f"estimated_tokens={tokens} "
-                f"position={position} "
-                f"source={segment.source}"
+                f"llm.context_segment {index}/{segment_count}: "
+                f"{label}. {explanation} "
+                f"Role: {segment.role}. "
+                f"Size: about {tokens:,} tokens from {segment.chars:,} chars. "
+                f"Position: {self._segment_position_explanation(position)}. "
+                f"Source: {source}. "
+                "Content: omitted."
             )
         return details, known_tokens
 
@@ -625,19 +685,18 @@ class WebSessionAdapter:
             context_window_tokens=context_window_tokens,
         )
         provider_visibility = (
-            "not_visible"
+            "not visible to Clarity after handoff"
             if provider_managed_context
-            else "visible_to_clarity"
+            else "visible to Clarity in local backend history"
         )
         manifest = (
-            "llm.context_manifest "
-            "visibility=clarity_assembled "
-            f"context_window_tokens={context_window_tokens} "
-            f"known_estimated_tokens={known_tokens} "
-            f"known_window_fraction={known_tokens / context_window_tokens:.1%} "
-            f"provider_internal_context={provider_visibility} "
-            "token_estimate=chars_div_4 "
-            "raw_prompt_content=omitted"
+            "llm.context_manifest Prompt map: "
+            f"Clarity can see about {known_tokens:,} tokens before the request leaves the app, "
+            f"about {self._window_fraction_label(known_tokens, context_window_tokens)} "
+            f"of the {context_window_tokens:,}-token model window. "
+            "Raw prompt text is omitted. "
+            f"Provider-managed context: {provider_visibility}. "
+            "Token counts are rough estimates from character counts."
         )
         return [manifest, *segment_details]
 
@@ -648,9 +707,10 @@ class WebSessionAdapter:
         if not self._stream_started:
             self._stream_started = True
             self._log_generation(
-                "llm.stream first_text_delta "
-                f"provider={getattr(self.llm_config, 'provider', 'unknown')} "
-                f"model={self.active_model}"
+                "llm.stream started. "
+                "First text arrived from "
+                f"{getattr(self.llm_config, 'provider', 'unknown')} "
+                f"using {self.active_model}."
             )
         self._stream_chunk_count += 1
         self._stream_char_count += len(text)
@@ -850,23 +910,21 @@ class WebSessionAdapter:
         except Exception as exc:
             duration_ms = int((perf_counter() - started_at) * 1000)
             self._log_generation(
-                "llm.response failed "
-                f"provider={getattr(self.llm_config, 'provider', 'unknown')} "
-                f"model={self.active_model} "
-                f"duration_ms={duration_ms} "
-                f"error_type={type(exc).__name__}"
+                f"llm.response failed after {duration_ms} ms. "
+                f"Provider: {getattr(self.llm_config, 'provider', 'unknown')}. "
+                f"Model: {self.active_model}. "
+                f"Error type: {type(exc).__name__}."
             )
             raise
 
         duration_ms = int((perf_counter() - started_at) * 1000)
         self._log_generation(
-            "llm.response complete "
-            f"provider={getattr(self.llm_config, 'provider', 'unknown')} "
-            f"model={self.active_model} "
-            f"duration_ms={duration_ms} "
-            f"response_chars={len(response)} "
-            f"stream_chunks={self._stream_chunk_count} "
-            f"stream_chars={self._stream_char_count}"
+            f"llm.response complete in {duration_ms} ms. "
+            f"Provider: {getattr(self.llm_config, 'provider', 'unknown')}. "
+            f"Model: {self.active_model}. "
+            f"Response: {len(response)} chars. "
+            f"Streamed chunks: {self._stream_chunk_count}; "
+            f"streamed chars: {self._stream_char_count}."
         )
 
         # Persist the session ID so the next app launch can resume.

--- a/src/clarity_agent/web/session_manager.py
+++ b/src/clarity_agent/web/session_manager.py
@@ -9,10 +9,8 @@ tool-use events to an :class:`asyncio.Queue` that the WebSocket handler drains.
 from __future__ import annotations
 
 import asyncio
-import json
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import partial
 from pathlib import Path
@@ -26,56 +24,23 @@ from clarity_agent.llm.config import get_auth_mode_info
 from clarity_agent.llm.types import TokenUsage, ToolHandler
 from clarity_agent.session import ClaritySession
 from clarity_agent.transcript import ChapterStarted, Transcript
+from clarity_agent.web.generation_log import (
+    ContextManifest,
+    ContextSegment,
+    RequestLogContext,
+    format_context_manifest,
+    format_request_started,
+    format_response_complete,
+    format_response_failed,
+    format_stream_started,
+    provider_manages_context,
+    serialized_char_count,
+)
 from clarity_agent.web.session_state import (
     clear_session_state,
     load_session_state,
     save_session_state,
 )
-
-_APPROX_CHARS_PER_TOKEN = 4
-_PROVIDER_MANAGED_CONTEXT_PROVIDERS = {"anthropic", "github"}
-_PROVIDER_MANAGED_CONTEXT_BACKENDS = {"CopilotChatBackend", "SdkChatBackend"}
-_CONTEXT_SEGMENT_LABELS = {
-    "backend_system_prompt": "Backend system prompt",
-    "tool_schemas": "Tool schemas",
-    "project_behaviors": "Project instructions",
-    "transcript_restore": "Restored transcript",
-    "turn_system_prompt": "Turn/process instructions",
-    "prior_messages": "Prior chat messages",
-    "provider_session_history": "Provider-managed history",
-    "current_user_message": "Current user message",
-}
-_CONTEXT_SEGMENT_EXPLANATIONS = {
-    "backend_system_prompt": "Static instructions added by the selected backend.",
-    "tool_schemas": "Tool definitions passed with this request.",
-    "project_behaviors": "Repository and project instructions loaded from AGENTS.md.",
-    "transcript_restore": (
-        "Prior transcript content restored because no provider session was resumed."
-    ),
-    "turn_system_prompt": "Extra instructions added by the current process or call.",
-    "prior_messages": "Earlier messages visible in the local backend history.",
-    "provider_session_history": "Conversation state held inside the provider runtime.",
-    "current_user_message": "The message the user just sent.",
-}
-_CONTEXT_SOURCE_LABELS = {
-    "backend_static": "backend static prompt",
-    "adapter_passed_tools": "tools passed by Clarity",
-    "project_AGENTS": "project AGENTS.md",
-    "prior_transcript": "prior transcript",
-    "process_or_call": "current process or call",
-    "backend_conversation_history": "backend conversation history",
-    "provider_runtime": "provider runtime",
-    "current_turn": "current turn",
-}
-
-
-@dataclass(frozen=True)
-class _ContextSegment:
-    name: str
-    role: str
-    chars: int | None
-    source: str
-    position: str | None = None
 
 
 class WebSessionAdapter:
@@ -444,35 +409,18 @@ class WebSessionAdapter:
         auth_mode = getattr(self.llm_config, "auth_mode", None) or "default"
         process = self.current_process or "chat"
         tool_count = len(self._tools or [])
-        return (
-            "llm.request started. "
-            f"Sending this turn to provider {provider} with model {model}. "
-            f"Tier: {self.active_tier}. "
-            f"Process: {process}. "
-            f"Auth mode: {auth_mode}; credential {self._credential_summary()}; "
-            f"endpoint {self._endpoint_summary()}. "
-            f"Tools available: {tool_count}. "
-            f"User message: {len(message)} chars. "
-            f"Added system instructions: {len(system_prompt or '')} chars."
-        )
-
-    @staticmethod
-    def _estimate_tokens(chars: int) -> int:
-        if chars <= 0:
-            return 0
-        return max(1, (chars + _APPROX_CHARS_PER_TOKEN - 1) // _APPROX_CHARS_PER_TOKEN)
-
-    @staticmethod
-    def _serialized_char_count(value: Any) -> int:
-        try:
-            return len(json.dumps(
-                value,
-                sort_keys=True,
-                separators=(",", ":"),
-                default=str,
-            ))
-        except (TypeError, ValueError):
-            return len(repr(value))
+        return format_request_started(RequestLogContext(
+            provider=provider,
+            model=model,
+            tier=self.active_tier,
+            process=process,
+            auth_mode=auth_mode,
+            credential=self._credential_summary(),
+            endpoint=self._endpoint_summary(),
+            tool_count=tool_count,
+            user_message_chars=len(message),
+            system_prompt_chars=len(system_prompt or ""),
+        ))
 
     def _backend_system_prompt_chars(self) -> int | None:
         backend = self._backend
@@ -497,103 +445,13 @@ class WebSessionAdapter:
         history = getattr(self._backend, "conversation_history", None)
         if not isinstance(history, list):
             return None
-        return self._serialized_char_count(history)
+        return serialized_char_count(history)
 
     def _context_window_tokens(self, model: str) -> int:
         backend = self._backend
         if backend is None:
             return ChatBackend.DEFAULT_CONTEXT_WINDOW
         return backend.context_window_for(model)
-
-    def _provider_manages_context(self) -> bool:
-        provider = getattr(self.llm_config, "provider", "unknown")
-        backend_name = type(self._backend).__name__ if self._backend is not None else ""
-        return (
-            provider in _PROVIDER_MANAGED_CONTEXT_PROVIDERS
-            or backend_name in _PROVIDER_MANAGED_CONTEXT_BACKENDS
-        )
-
-    @staticmethod
-    def _position_label(start_tokens: int, end_tokens: int, context_window: int) -> str:
-        if context_window <= 0:
-            return "unknown"
-        return f"{start_tokens / context_window:.1%}-{end_tokens / context_window:.1%}"
-
-    @staticmethod
-    def _window_fraction_label(tokens: int, context_window: int) -> str:
-        if context_window <= 0:
-            return "unknown"
-        return f"{tokens / context_window:.1%}"
-
-    @staticmethod
-    def _segment_position_explanation(position: str | None) -> str:
-        if position == "provider_managed":
-            return "provider-managed, exact position not visible to Clarity"
-        if position == "provider_specific":
-            return "provider-specific placement"
-        if position is None or position == "unknown":
-            return "unknown"
-        return f"about {position} of the known context window"
-
-    @staticmethod
-    def _segment_label(name: str) -> str:
-        return _CONTEXT_SEGMENT_LABELS.get(name, name.replace("_", " ").title())
-
-    @staticmethod
-    def _segment_explanation(name: str) -> str:
-        return _CONTEXT_SEGMENT_EXPLANATIONS.get(name, "Context passed with this request.")
-
-    @staticmethod
-    def _source_label(source: str) -> str:
-        return _CONTEXT_SOURCE_LABELS.get(source, source.replace("_", " "))
-
-    def _context_segment_details(
-        self,
-        segments: list[_ContextSegment],
-        *,
-        context_window_tokens: int,
-    ) -> tuple[list[str], int]:
-        details: list[str] = []
-        cursor = 0
-        known_tokens = 0
-        segment_count = len(segments)
-        for index, segment in enumerate(segments, start=1):
-            label = self._segment_label(segment.name)
-            explanation = self._segment_explanation(segment.name)
-            source = self._source_label(segment.source)
-            if segment.chars is None:
-                details.append(
-                    f"llm.context_segment {index}/{segment_count}: "
-                    f"{label}. {explanation} "
-                    f"Role: {segment.role}. "
-                    "Size: unknown. "
-                    f"Position: {self._segment_position_explanation(segment.position)}. "
-                    f"Source: {source}. "
-                    "Content: not visible to Clarity."
-                )
-                continue
-
-            tokens = self._estimate_tokens(segment.chars)
-            known_tokens += tokens
-            if segment.position is None:
-                position = self._position_label(
-                    cursor,
-                    cursor + tokens,
-                    context_window_tokens,
-                )
-                cursor += tokens
-            else:
-                position = segment.position
-            details.append(
-                f"llm.context_segment {index}/{segment_count}: "
-                f"{label}. {explanation} "
-                f"Role: {segment.role}. "
-                f"Size: about {tokens:,} tokens from {segment.chars:,} chars. "
-                f"Position: {self._segment_position_explanation(position)}. "
-                f"Source: {source}. "
-                "Content: omitted."
-            )
-        return details, known_tokens
 
     def _context_manifest_details(
         self,
@@ -604,101 +462,89 @@ class WebSessionAdapter:
         transcript_context_chars: int,
     ) -> list[str]:
         context_window_tokens = self._context_window_tokens(model)
-        provider_managed_context = self._provider_manages_context()
-        segments: list[_ContextSegment] = []
+        provider = getattr(self.llm_config, "provider", "unknown")
+        backend_name = type(self._backend).__name__ if self._backend is not None else ""
+        provider_managed_context = provider_manages_context(provider, backend_name)
+        segments: list[ContextSegment] = []
 
         backend_system_chars = self._backend_system_prompt_chars()
         if backend_system_chars is not None:
-            segments.append(_ContextSegment(
-                name="backend_system_prompt",
+            segments.append(ContextSegment(
+                name="Backend system prompt",
                 role="system",
                 chars=backend_system_chars,
-                source="backend_static",
+                source="backend static prompt",
             ))
 
         tool_schema_chars = (
-            self._serialized_char_count(self._tools)
+            serialized_char_count(self._tools)
             if self._tools
             else 0
         )
         if tool_schema_chars:
-            segments.append(_ContextSegment(
-                name="tool_schemas",
+            segments.append(ContextSegment(
+                name="Tool schemas",
                 role="tools",
                 chars=tool_schema_chars,
-                source="adapter_passed_tools",
+                source="tools passed by Clarity",
                 position="provider_specific",
             ))
 
         behavior_chars = self._project_behaviors_chars()
         if behavior_chars:
-            segments.append(_ContextSegment(
-                name="project_behaviors",
+            segments.append(ContextSegment(
+                name="Project instructions",
                 role="system",
                 chars=behavior_chars,
-                source="project_AGENTS",
+                source="project AGENTS.md",
             ))
 
         if transcript_context_chars:
-            segments.append(_ContextSegment(
-                name="transcript_restore",
+            segments.append(ContextSegment(
+                name="Restored transcript",
                 role="system",
                 chars=transcript_context_chars,
-                source="prior_transcript",
+                source="prior transcript",
             ))
 
         turn_system_chars = len(turn_system_prompt or "")
         if turn_system_chars:
-            segments.append(_ContextSegment(
-                name="turn_system_prompt",
+            segments.append(ContextSegment(
+                name="Turn/process instructions",
                 role="system",
                 chars=turn_system_chars,
-                source="process_or_call",
+                source="current process or call",
             ))
 
         history_chars = self._known_history_chars()
         if history_chars is None or provider_managed_context:
-            segments.append(_ContextSegment(
-                name="provider_session_history",
+            segments.append(ContextSegment(
+                name="Provider-managed history",
                 role="messages",
                 chars=None,
-                source="provider_runtime",
+                source="provider runtime",
                 position="provider_managed",
             ))
         else:
-            segments.append(_ContextSegment(
-                name="prior_messages",
+            segments.append(ContextSegment(
+                name="Prior chat messages",
                 role="messages",
                 chars=history_chars,
-                source="backend_conversation_history",
+                source="backend conversation history",
             ))
 
-        segments.append(_ContextSegment(
-            name="current_user_message",
+        segments.append(ContextSegment(
+            name="Current user message",
             role="user",
             chars=len(message),
-            source="current_turn",
+            source="current turn",
         ))
 
-        segment_details, known_tokens = self._context_segment_details(
-            segments,
+        return format_context_manifest(ContextManifest(
             context_window_tokens=context_window_tokens,
-        )
-        provider_visibility = (
-            "not visible to Clarity after handoff"
-            if provider_managed_context
-            else "visible to Clarity in local backend history"
-        )
-        manifest = (
-            "llm.context_manifest Prompt map: "
-            f"Clarity can see about {known_tokens:,} tokens before the request leaves the app, "
-            f"about {self._window_fraction_label(known_tokens, context_window_tokens)} "
-            f"of the {context_window_tokens:,}-token model window. "
-            "Raw prompt text is omitted. "
-            f"Provider-managed context: {provider_visibility}. "
-            "Token counts are rough estimates from character counts."
-        )
-        return [manifest, *segment_details]
+            provider_managed_context=provider_managed_context,
+            segments=segments,
+        ))
 
     def _on_text_delta(self, text: str) -> None:
         """Synchronous callback for streaming text chunks from the executor thread."""
@@ -707,10 +553,10 @@ class WebSessionAdapter:
         if not self._stream_started:
             self._stream_started = True
             self._log_generation(
-                "llm.stream started. "
-                "First text arrived from "
-                f"{getattr(self.llm_config, 'provider', 'unknown')} "
-                f"using {self.active_model}."
+                format_stream_started(
+                    getattr(self.llm_config, "provider", "unknown"),
+                    self.active_model,
+                )
             )
         self._stream_chunk_count += 1
         self._stream_char_count += len(text)
@@ -910,21 +756,25 @@ class WebSessionAdapter:
         except Exception as exc:
             duration_ms = int((perf_counter() - started_at) * 1000)
             self._log_generation(
-                f"llm.response failed after {duration_ms} ms. "
-                f"Provider: {getattr(self.llm_config, 'provider', 'unknown')}. "
-                f"Model: {self.active_model}. "
-                f"Error type: {type(exc).__name__}."
+                format_response_failed(
+                    provider=getattr(self.llm_config, "provider", "unknown"),
+                    model=self.active_model,
+                    duration_ms=duration_ms,
+                    error_type=type(exc).__name__,
+                )
             )
             raise
 
         duration_ms = int((perf_counter() - started_at) * 1000)
         self._log_generation(
-            f"llm.response complete in {duration_ms} ms. "
-            f"Provider: {getattr(self.llm_config, 'provider', 'unknown')}. "
-            f"Model: {self.active_model}. "
-            f"Response: {len(response)} chars. "
-            f"Streamed chunks: {self._stream_chunk_count}; "
-            f"streamed chars: {self._stream_char_count}."
+            format_response_complete(
+                provider=getattr(self.llm_config, "provider", "unknown"),
+                model=self.active_model,
+                duration_ms=duration_ms,
+                response_chars=len(response),
+                stream_chunks=self._stream_chunk_count,
+                stream_chars=self._stream_char_count,
+            )
         )
 
         # Persist the session ID so the next app launch can resume.

--- a/src/clarity_agent/web/session_manager.py
+++ b/src/clarity_agent/web/session_manager.py
@@ -9,8 +9,10 @@ tool-use events to an :class:`asyncio.Queue` that the WebSocket handler drains.
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import AsyncIterator
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from functools import partial
 from pathlib import Path
@@ -29,6 +31,19 @@ from clarity_agent.web.session_state import (
     load_session_state,
     save_session_state,
 )
+
+_APPROX_CHARS_PER_TOKEN = 4
+_PROVIDER_MANAGED_CONTEXT_PROVIDERS = {"anthropic", "github"}
+_PROVIDER_MANAGED_CONTEXT_BACKENDS = {"CopilotChatBackend", "SdkChatBackend"}
+
+
+@dataclass(frozen=True)
+class _ContextSegment:
+    name: str
+    role: str
+    chars: int | None
+    source: str
+    position: str | None = None
 
 
 class WebSessionAdapter:
@@ -411,6 +426,221 @@ class WebSessionAdapter:
             f"system_prompt_chars={len(system_prompt or '')}"
         )
 
+    @staticmethod
+    def _estimate_tokens(chars: int) -> int:
+        if chars <= 0:
+            return 0
+        return max(1, (chars + _APPROX_CHARS_PER_TOKEN - 1) // _APPROX_CHARS_PER_TOKEN)
+
+    @staticmethod
+    def _serialized_char_count(value: Any) -> int:
+        try:
+            return len(json.dumps(
+                value,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ))
+        except (TypeError, ValueError):
+            return len(repr(value))
+
+    def _backend_system_prompt_chars(self) -> int | None:
+        backend = self._backend
+        build_system_prompt = getattr(backend, "_build_system_prompt", None)
+        if not callable(build_system_prompt):
+            return None
+        try:
+            built_prompt = build_system_prompt(None)
+        except Exception:
+            return None
+        if isinstance(built_prompt, str):
+            return len(built_prompt)
+        return len(str(built_prompt))
+
+    def _project_behaviors_chars(self) -> int:
+        session = self._session
+        if session is None:
+            return 0
+        return len(session.load_behaviors())
+
+    def _known_history_chars(self) -> int | None:
+        history = getattr(self._backend, "conversation_history", None)
+        if not isinstance(history, list):
+            return None
+        return self._serialized_char_count(history)
+
+    def _context_window_tokens(self, model: str) -> int:
+        backend = self._backend
+        if backend is None:
+            return ChatBackend.DEFAULT_CONTEXT_WINDOW
+        return backend.context_window_for(model)
+
+    def _provider_manages_context(self) -> bool:
+        provider = getattr(self.llm_config, "provider", "unknown")
+        backend_name = type(self._backend).__name__ if self._backend is not None else ""
+        return (
+            provider in _PROVIDER_MANAGED_CONTEXT_PROVIDERS
+            or backend_name in _PROVIDER_MANAGED_CONTEXT_BACKENDS
+        )
+
+    @staticmethod
+    def _position_label(start_tokens: int, end_tokens: int, context_window: int) -> str:
+        if context_window <= 0:
+            return "unknown"
+        return f"{start_tokens / context_window:.1%}-{end_tokens / context_window:.1%}"
+
+    def _context_segment_details(
+        self,
+        segments: list[_ContextSegment],
+        *,
+        context_window_tokens: int,
+    ) -> tuple[list[str], int]:
+        details: list[str] = []
+        cursor = 0
+        known_tokens = 0
+        for index, segment in enumerate(segments, start=1):
+            if segment.chars is None:
+                details.append(
+                    "llm.context_segment "
+                    f"index={index} "
+                    f"name={segment.name} "
+                    f"role={segment.role} "
+                    "chars=unknown "
+                    "estimated_tokens=unknown "
+                    f"position={segment.position or 'unknown'} "
+                    f"source={segment.source}"
+                )
+                continue
+
+            tokens = self._estimate_tokens(segment.chars)
+            known_tokens += tokens
+            if segment.position is None:
+                position = self._position_label(
+                    cursor,
+                    cursor + tokens,
+                    context_window_tokens,
+                )
+                cursor += tokens
+            else:
+                position = segment.position
+            details.append(
+                "llm.context_segment "
+                f"index={index} "
+                f"name={segment.name} "
+                f"role={segment.role} "
+                f"chars={segment.chars} "
+                f"estimated_tokens={tokens} "
+                f"position={position} "
+                f"source={segment.source}"
+            )
+        return details, known_tokens
+
+    def _context_manifest_details(
+        self,
+        *,
+        model: str,
+        message: str,
+        turn_system_prompt: str | None,
+        transcript_context_chars: int,
+    ) -> list[str]:
+        context_window_tokens = self._context_window_tokens(model)
+        provider_managed_context = self._provider_manages_context()
+        segments: list[_ContextSegment] = []
+
+        backend_system_chars = self._backend_system_prompt_chars()
+        if backend_system_chars is not None:
+            segments.append(_ContextSegment(
+                name="backend_system_prompt",
+                role="system",
+                chars=backend_system_chars,
+                source="backend_static",
+            ))
+
+        tool_schema_chars = (
+            self._serialized_char_count(self._tools)
+            if self._tools
+            else 0
+        )
+        if tool_schema_chars:
+            segments.append(_ContextSegment(
+                name="tool_schemas",
+                role="tools",
+                chars=tool_schema_chars,
+                source="adapter_passed_tools",
+                position="provider_specific",
+            ))
+
+        behavior_chars = self._project_behaviors_chars()
+        if behavior_chars:
+            segments.append(_ContextSegment(
+                name="project_behaviors",
+                role="system",
+                chars=behavior_chars,
+                source="project_AGENTS",
+            ))
+
+        if transcript_context_chars:
+            segments.append(_ContextSegment(
+                name="transcript_restore",
+                role="system",
+                chars=transcript_context_chars,
+                source="prior_transcript",
+            ))
+
+        turn_system_chars = len(turn_system_prompt or "")
+        if turn_system_chars:
+            segments.append(_ContextSegment(
+                name="turn_system_prompt",
+                role="system",
+                chars=turn_system_chars,
+                source="process_or_call",
+            ))
+
+        history_chars = self._known_history_chars()
+        if history_chars is None or provider_managed_context:
+            segments.append(_ContextSegment(
+                name="provider_session_history",
+                role="messages",
+                chars=None,
+                source="provider_runtime",
+                position="provider_managed",
+            ))
+        else:
+            segments.append(_ContextSegment(
+                name="prior_messages",
+                role="messages",
+                chars=history_chars,
+                source="backend_conversation_history",
+            ))
+
+        segments.append(_ContextSegment(
+            name="current_user_message",
+            role="user",
+            chars=len(message),
+            source="current_turn",
+        ))
+
+        segment_details, known_tokens = self._context_segment_details(
+            segments,
+            context_window_tokens=context_window_tokens,
+        )
+        provider_visibility = (
+            "not_visible"
+            if provider_managed_context
+            else "visible_to_clarity"
+        )
+        manifest = (
+            "llm.context_manifest "
+            "visibility=clarity_assembled "
+            f"context_window_tokens={context_window_tokens} "
+            f"known_estimated_tokens={known_tokens} "
+            f"known_window_fraction={known_tokens / context_window_tokens:.1%} "
+            f"provider_internal_context={provider_visibility} "
+            "token_estimate=chars_div_4 "
+            "raw_prompt_content=omitted"
+        )
+        return [manifest, *segment_details]
+
     def _on_text_delta(self, text: str) -> None:
         """Synchronous callback for streaming text chunks from the executor thread."""
         if self._loop is None or self._cancelled:
@@ -573,9 +803,12 @@ class WebSessionAdapter:
         self._stream_chunk_count = 0
         self._stream_char_count = 0
 
+        turn_system_prompt = system_prompt
+        transcript_context_chars = 0
         # On the first call, inject transcript context if we have it.
         if self._transcript_context is not None:
             ctx = self._transcript_context
+            transcript_context_chars = len(ctx)
             self._transcript_context = None  # consume — only inject once
             # Signal the UI so the user sees why startup takes longer.
             await self._event_queue.put({
@@ -597,6 +830,13 @@ class WebSessionAdapter:
                 system_prompt=system_prompt,
             )
         )
+        for detail in self._context_manifest_details(
+            model=model,
+            message=message,
+            turn_system_prompt=turn_system_prompt,
+            transcript_context_chars=transcript_context_chars,
+        ):
+            self._log_generation(detail)
 
         func = partial(
             self._session.chat, message, system_prompt, model=model,

--- a/src/clarity_agent/web/session_manager.py
+++ b/src/clarity_agent/web/session_manager.py
@@ -14,10 +14,13 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from functools import partial
 from pathlib import Path
+from time import perf_counter
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from clarity_agent.app_paths import protocol_dir as _protocol_dir
 from clarity_agent.llm import ChatBackend, LLMConfig
+from clarity_agent.llm.config import get_auth_mode_info
 from clarity_agent.llm.types import TokenUsage, ToolHandler
 from clarity_agent.session import ClaritySession
 from clarity_agent.transcript import ChapterStarted, Transcript
@@ -72,6 +75,9 @@ class WebSessionAdapter:
         self._cancelled = False
         # Partial text accumulated from events before cancellation.
         self._partial_text: list[str] = []
+        self._stream_started = False
+        self._stream_chunk_count = 0
+        self._stream_char_count = 0
 
     def _setup_feedback_tools(self) -> None:
         """Set up the feedback tool as baseline for all chat calls."""
@@ -353,10 +359,71 @@ class WebSessionAdapter:
             {"type": "tool_use", "tool": tool_name, "detail": detail},
         )
 
+    def _log_generation(self, detail: str) -> None:
+        print(f"[generation] {detail}", flush=True)
+
+    def _credential_summary(self) -> str:
+        provider = getattr(self.llm_config, "provider", "unknown")
+        auth_mode = getattr(self.llm_config, "auth_mode", None) or "default"
+        mode_info = get_auth_mode_info(provider, auth_mode) or {}
+        credential_name = mode_info.get("env_var") or auth_mode
+        api_key = getattr(self.llm_config, "api_key", None)
+        if api_key:
+            return f"{credential_name}=configured(redacted)"
+        if auth_mode in ("api_key", "token"):
+            return f"{credential_name}=missing"
+        return f"{auth_mode}=configured(no-api-key)"
+
+    def _endpoint_summary(self) -> str:
+        endpoint = getattr(self.llm_config, "endpoint", None)
+        if not endpoint:
+            return "none"
+        try:
+            parsed = urlsplit(endpoint)
+        except ValueError:
+            return "configured(redacted-invalid-url)"
+        if not parsed.scheme or not parsed.netloc:
+            return "configured(redacted-invalid-url)"
+        return urlunsplit((parsed.scheme, parsed.netloc, parsed.path.rstrip("/"), "", ""))
+
+    def _generation_start_detail(
+        self,
+        *,
+        model: str,
+        message: str,
+        system_prompt: str | None,
+    ) -> str:
+        provider = getattr(self.llm_config, "provider", "unknown")
+        auth_mode = getattr(self.llm_config, "auth_mode", None) or "default"
+        process = self.current_process or "chat"
+        tool_count = len(self._tools or [])
+        return (
+            "llm.request start "
+            f"provider={provider} "
+            f"model={model} "
+            f"tier={self.active_tier} "
+            f"process={process} "
+            f"auth_mode={auth_mode} "
+            f"credential={self._credential_summary()} "
+            f"endpoint={self._endpoint_summary()} "
+            f"tools={tool_count} "
+            f"user_message_chars={len(message)} "
+            f"system_prompt_chars={len(system_prompt or '')}"
+        )
+
     def _on_text_delta(self, text: str) -> None:
         """Synchronous callback for streaming text chunks from the executor thread."""
         if self._loop is None or self._cancelled:
             return
+        if not self._stream_started:
+            self._stream_started = True
+            self._log_generation(
+                "llm.stream first_text_delta "
+                f"provider={getattr(self.llm_config, 'provider', 'unknown')} "
+                f"model={self.active_model}"
+            )
+        self._stream_chunk_count += 1
+        self._stream_char_count += len(text)
         self._loop.call_soon_threadsafe(
             self._event_queue.put_nowait,
             {"type": "text_delta", "content": text},
@@ -389,6 +456,11 @@ class WebSessionAdapter:
         """Synchronous callback for token usage events from the executor thread."""
         if self._loop is None:
             return
+        self._log_generation(
+            "llm.usage "
+            f"input_tokens={usage.input_tokens} "
+            f"output_tokens={usage.output_tokens}"
+        )
         self._loop.call_soon_threadsafe(
             self._event_queue.put_nowait,
             {
@@ -497,6 +569,9 @@ class WebSessionAdapter:
         assert self._session is not None
         self._cancelled = False
         self._partial_text.clear()
+        self._stream_started = False
+        self._stream_chunk_count = 0
+        self._stream_char_count = 0
 
         # On the first call, inject transcript context if we have it.
         if self._transcript_context is not None:
@@ -515,13 +590,43 @@ class WebSessionAdapter:
 
         model = self._resolve_model(self.current_process)
         self._update_active_model(model, self.current_process)
+        self._log_generation(
+            self._generation_start_detail(
+                model=model,
+                message=message,
+                system_prompt=system_prompt,
+            )
+        )
 
         func = partial(
             self._session.chat, message, system_prompt, model=model,
             tools=self._tools, tool_handler=self._tool_handler,
         )
-        response = await self._loop.run_in_executor(  # type: ignore[union-attr]
-            self._executor, func,
+        started_at = perf_counter()
+        try:
+            response = await self._loop.run_in_executor(  # type: ignore[union-attr]
+                self._executor, func,
+            )
+        except Exception as exc:
+            duration_ms = int((perf_counter() - started_at) * 1000)
+            self._log_generation(
+                "llm.response failed "
+                f"provider={getattr(self.llm_config, 'provider', 'unknown')} "
+                f"model={self.active_model} "
+                f"duration_ms={duration_ms} "
+                f"error_type={type(exc).__name__}"
+            )
+            raise
+
+        duration_ms = int((perf_counter() - started_at) * 1000)
+        self._log_generation(
+            "llm.response complete "
+            f"provider={getattr(self.llm_config, 'provider', 'unknown')} "
+            f"model={self.active_model} "
+            f"duration_ms={duration_ms} "
+            f"response_chars={len(response)} "
+            f"stream_chunks={self._stream_chunk_count} "
+            f"stream_chars={self._stream_char_count}"
         )
 
         # Persist the session ID so the next app launch can resume.

--- a/tests/test_web_log_broadcast.py
+++ b/tests/test_web_log_broadcast.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import logging
+import sys
+
+import pytest
 
 from clarity_agent.web.log_broadcast import (
     WebLogBroadcaster,
     install_logging_broadcaster,
+    install_stdio_broadcaster,
     sanitize_log_message,
 )
 
@@ -74,4 +79,113 @@ def test_logging_handler_publishes_records_once() -> None:
         "source": "backend",
         "level": "warning",
         "message": "WARNING: something happened",
+    }
+
+
+def test_stdio_broadcaster_publishes_complete_stdout_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def run() -> tuple[dict[str, object], str]:
+        broadcaster = WebLogBroadcaster(default_source="backend", max_lines=5)
+        fake_stdout = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", fake_stdout)
+        restore = install_stdio_broadcaster(broadcaster)
+        queue, unsubscribe = broadcaster.subscribe(replay=False)
+        try:
+            print("terminal line")
+            event = await asyncio.wait_for(queue.get(), timeout=1)
+            return event, fake_stdout.getvalue()
+        finally:
+            unsubscribe()
+            restore()
+
+    event, terminal_output = asyncio.run(run())
+
+    assert terminal_output == "terminal line\n"
+    assert event == {
+        "type": "log",
+        "source": "stdout",
+        "level": "info",
+        "message": "terminal line",
+    }
+
+
+def test_stdio_broadcaster_buffers_partial_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def run() -> dict[str, object]:
+        broadcaster = WebLogBroadcaster(default_source="backend", max_lines=5)
+        fake_stdout = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", fake_stdout)
+        restore = install_stdio_broadcaster(broadcaster)
+        queue, unsubscribe = broadcaster.subscribe(replay=False)
+        try:
+            sys.stdout.write("partial")
+            assert queue.empty()
+            sys.stdout.write(" line\n")
+            return await asyncio.wait_for(queue.get(), timeout=1)
+        finally:
+            unsubscribe()
+            restore()
+
+    event = asyncio.run(run())
+
+    assert event == {
+        "type": "log",
+        "source": "stdout",
+        "level": "info",
+        "message": "partial line",
+    }
+
+
+def test_stdio_broadcaster_flushes_partial_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def run() -> dict[str, object]:
+        broadcaster = WebLogBroadcaster(default_source="backend", max_lines=5)
+        fake_stdout = io.StringIO()
+        monkeypatch.setattr(sys, "stdout", fake_stdout)
+        restore = install_stdio_broadcaster(broadcaster)
+        queue, unsubscribe = broadcaster.subscribe(replay=False)
+        try:
+            sys.stdout.write("partial")
+            sys.stdout.flush()
+            return await asyncio.wait_for(queue.get(), timeout=1)
+        finally:
+            unsubscribe()
+            restore()
+
+    event = asyncio.run(run())
+
+    assert event == {
+        "type": "log",
+        "source": "stdout",
+        "level": "info",
+        "message": "partial",
+    }
+
+
+def test_stdio_broadcaster_publishes_stderr_as_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def run() -> dict[str, object]:
+        broadcaster = WebLogBroadcaster(default_source="backend", max_lines=5)
+        fake_stderr = io.StringIO()
+        monkeypatch.setattr(sys, "stderr", fake_stderr)
+        restore = install_stdio_broadcaster(broadcaster)
+        queue, unsubscribe = broadcaster.subscribe(replay=False)
+        try:
+            sys.stderr.write("terminal error\n")
+            return await asyncio.wait_for(queue.get(), timeout=1)
+        finally:
+            unsubscribe()
+            restore()
+
+    event = asyncio.run(run())
+
+    assert event == {
+        "type": "log",
+        "source": "stderr",
+        "level": "info",
+        "message": "terminal error",
     }

--- a/tests/test_web_log_broadcast.py
+++ b/tests/test_web_log_broadcast.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from clarity_agent.web.log_broadcast import (
+    WebLogBroadcaster,
+    install_logging_broadcaster,
+    sanitize_log_message,
+)
+
+
+def test_sanitize_log_message_redacts_common_token_shapes() -> None:
+    message = sanitize_log_message(
+        "Authorization: Bearer abc.def token=secret OPENAI_API_KEY=sk-test",
+    )
+
+    assert "abc.def" not in message
+    assert "secret" not in message
+    assert "sk-test" not in message
+    assert "[redacted]" in message
+
+
+def test_subscriber_receives_replay_and_live_events() -> None:
+    async def run() -> list[dict[str, object]]:
+        broadcaster = WebLogBroadcaster(default_source="backend", max_lines=5)
+        broadcaster.publish("before subscribe", source="launcher")
+        queue, unsubscribe = broadcaster.subscribe()
+        try:
+            replay = await asyncio.wait_for(queue.get(), timeout=1)
+            broadcaster.publish("after subscribe", source="backend", level="warning")
+            live = await asyncio.wait_for(queue.get(), timeout=1)
+            return [replay, live]
+        finally:
+            unsubscribe()
+
+    replay, live = asyncio.run(run())
+
+    assert replay == {
+        "type": "log",
+        "source": "launcher",
+        "level": "info",
+        "message": "before subscribe",
+    }
+    assert live == {
+        "type": "log",
+        "source": "backend",
+        "level": "warning",
+        "message": "after subscribe",
+    }
+
+
+def test_logging_handler_publishes_records_once() -> None:
+    async def run() -> dict[str, object]:
+        broadcaster = WebLogBroadcaster(default_source="backend", max_lines=5)
+        logger_name = "clarity_agent.tests.web_log_broadcast"
+        install_logging_broadcaster(
+            broadcaster,
+            source="backend",
+            logger_names=(logger_name,),
+        )
+        queue, unsubscribe = broadcaster.subscribe(replay=False)
+        try:
+            logger = logging.getLogger(logger_name)
+            logger.warning("something happened")
+            return await asyncio.wait_for(queue.get(), timeout=1)
+        finally:
+            unsubscribe()
+
+    event = asyncio.run(run())
+
+    assert event == {
+        "type": "log",
+        "source": "backend",
+        "level": "warning",
+        "message": "WARNING: something happened",
+    }

--- a/tests/test_web_session_resume.py
+++ b/tests/test_web_session_resume.py
@@ -32,6 +32,7 @@ from typing import Any
 
 import pytest
 
+from clarity_agent.llm import LLMConfig
 from clarity_agent.llm.chat import ChatBackend
 from clarity_agent.transcript import (
     AssistantText,
@@ -250,6 +251,7 @@ class TestEnsureAgentsMdHook:
         # Sanity: the adapter started cleanly.
         assert adapter._backend is not None
 
+
     def test_skips_when_layout_undetectable(self, tmp_path):
         # Bare project with no Clarity markers at all.  detect_layout
         # returns None; the hook no-ops; start() succeeds; no file
@@ -267,6 +269,51 @@ class TestEnsureAgentsMdHook:
 
         assert not (project / "AGENTS.md").exists()
         assert adapter._backend is not None  # start still succeeded
+
+
+class TestGenerationLogDetails:
+    def test_redacts_api_key_while_identifying_credential_source(self, tmp_path):
+        cfg = LLMConfig(
+            provider="azure",
+            api_key="secret-api-key",
+            endpoint="https://example.openai.azure.com/openai?api-key=secret",
+            auth_mode="api_key",
+            tiers={"default": "deployment-a"},
+        )
+        adapter = WebSessionAdapter(tmp_path, tmp_path, cfg)
+
+        detail = adapter._generation_start_detail(
+            model="deployment-a",
+            message="hello",
+            system_prompt="system",
+        )
+
+        assert "secret-api-key" not in detail
+        assert "api-key=secret" not in detail
+        assert "credential=AZURE_AI_API_KEY=configured(redacted)" in detail
+        assert "endpoint=https://example.openai.azure.com/openai" in detail
+        assert "provider=azure" in detail
+        assert "model=deployment-a" in detail
+
+    def test_default_auth_logs_no_api_key_mode(self, tmp_path):
+        cfg = LLMConfig(
+            provider="azure",
+            api_key=None,
+            endpoint="https://example.openai.azure.com",
+            auth_mode="default",
+            tiers={"default": "deployment-a"},
+        )
+        adapter = WebSessionAdapter(tmp_path, tmp_path, cfg)
+
+        detail = adapter._generation_start_detail(
+            model="deployment-a",
+            message="hello",
+            system_prompt=None,
+        )
+
+        assert "auth_mode=default" in detail
+        assert "credential=default=configured(no-api-key)" in detail
+        assert "system_prompt_chars=0" in detail
 
 
 class TestStartNewChapter:

--- a/tests/test_web_session_resume.py
+++ b/tests/test_web_session_resume.py
@@ -300,10 +300,10 @@ class TestGenerationLogDetails:
 
         assert "secret-api-key" not in detail
         assert "api-key=secret" not in detail
-        assert "credential=AZURE_AI_API_KEY=configured(redacted)" in detail
-        assert "endpoint=https://example.openai.azure.com/openai" in detail
-        assert "provider=azure" in detail
-        assert "model=deployment-a" in detail
+        assert "credential AZURE_AI_API_KEY=configured(redacted)" in detail
+        assert "endpoint https://example.openai.azure.com/openai" in detail
+        assert "provider azure" in detail
+        assert "model deployment-a" in detail
 
     def test_default_auth_logs_no_api_key_mode(self, tmp_path):
         cfg = LLMConfig(
@@ -321,9 +321,9 @@ class TestGenerationLogDetails:
             system_prompt=None,
         )
 
-        assert "auth_mode=default" in detail
-        assert "credential=default=configured(no-api-key)" in detail
-        assert "system_prompt_chars=0" in detail
+        assert "Auth mode: default" in detail
+        assert "credential default=configured(no-api-key)" in detail
+        assert "Added system instructions: 0 chars." in detail
 
     def test_context_manifest_logs_redacted_segments_in_order(self, tmp_path):
         cfg = LLMConfig(
@@ -356,25 +356,26 @@ class TestGenerationLogDetails:
         )
 
         joined = "\n".join(details)
-        assert details[0].startswith("llm.context_manifest ")
-        assert "visibility=clarity_assembled" in details[0]
-        assert "context_window_tokens=1000" in details[0]
-        assert "provider_internal_context=visible_to_clarity" in details[0]
-        assert "raw_prompt_content=omitted" in details[0]
+        assert details[0].startswith("llm.context_manifest Prompt map: ")
+        assert "Clarity can see about" in details[0]
+        assert "1,000-token model window" in details[0]
+        assert "visible to Clarity in local backend history" in details[0]
+        assert "Raw prompt text is omitted" in details[0]
         assert "private" not in joined
-        assert [
-            line.split("name=", 1)[1].split(" ", 1)[0]
-            for line in details[1:]
-        ] == [
-            "backend_system_prompt",
-            "tool_schemas",
-            "project_behaviors",
-            "transcript_restore",
-            "turn_system_prompt",
-            "prior_messages",
-            "current_user_message",
+        expected_segments = [
+            "Backend system prompt",
+            "Tool schemas",
+            "Project instructions",
+            "Restored transcript",
+            "Turn/process instructions",
+            "Prior chat messages",
+            "Current user message",
         ]
-        assert all("position=" in line for line in details[1:])
+        assert [
+            line.split(": ", 1)[1].split(".", 1)[0]
+            for line in details[1:]
+        ] == expected_segments
+        assert all("Position:" in line for line in details[1:])
 
     def test_context_manifest_marks_provider_managed_history(self, tmp_path):
         cfg = LLMConfig(
@@ -395,10 +396,13 @@ class TestGenerationLogDetails:
         )
 
         joined = "\n".join(details)
-        assert "provider_internal_context=not_visible" in details[0]
-        assert "name=provider_session_history" in joined
-        assert "chars=unknown" in joined
-        assert "position=provider_managed" in joined
+        assert (
+            "Provider-managed context: not visible to Clarity after handoff"
+            in details[0]
+        )
+        assert "Provider-managed history" in joined
+        assert "Size: unknown" in joined
+        assert "provider-managed, exact position not visible to Clarity" in joined
 
 
 class TestStartNewChapter:

--- a/tests/test_web_session_resume.py
+++ b/tests/test_web_session_resume.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -49,10 +49,12 @@ class _StubBackend(ChatBackend):
 
     supports_tools = True
     TIER_DEFAULTS = {"default": "stub-model", "deep": "stub-deep", "fast": "stub-fast"}
+    MODEL_CONTEXT_WINDOWS = {"stub-model": 1_000}
 
     def __init__(self) -> None:
         # ``_session_id`` mirrors the real backends' settable id.
         self._session_id: str | None = None
+        self.conversation_history: list[dict[str, Any]] = []
 
     @property
     def llm_session_id(self) -> str | None:
@@ -73,14 +75,22 @@ class _StubBackend(ChatBackend):
     ) -> str:
         return "ok"
 
+    def _build_system_prompt(self, system_prompt: str | None = None) -> str:
+        base = "base system prompt"
+        return f"{base}\n\n{system_prompt}" if system_prompt else base
 
-class _StubLLMConfig:
+
+class _StubLLMConfig(LLMConfig):
     """Minimal :class:`LLMConfig`-shaped object the adapter needs."""
 
-    provider = "stub"
-    tiers = {"default": "stub-model", "deep": "stub-deep", "fast": "stub-fast"}
-
     def __init__(self) -> None:
+        super().__init__(
+            provider="stub",
+            api_key=None,
+            endpoint=None,
+            auth_mode="default",
+            tiers={"default": "stub-model", "deep": "stub-deep", "fast": "stub-fast"},
+        )
         self.last_backend: _StubBackend | None = None
 
     def create_chat_backend(
@@ -88,7 +98,7 @@ class _StubLLMConfig:
         *,
         project_dir: Path,
         clarity_agent_dir: Path,
-        transcript: object = None,
+        transcript: Transcript | None = None,
     ) -> _StubBackend:
         # Stash the backend so tests can interrogate it post-start.
         self.last_backend = _StubBackend()
@@ -314,6 +324,81 @@ class TestGenerationLogDetails:
         assert "auth_mode=default" in detail
         assert "credential=default=configured(no-api-key)" in detail
         assert "system_prompt_chars=0" in detail
+
+    def test_context_manifest_logs_redacted_segments_in_order(self, tmp_path):
+        cfg = LLMConfig(
+            provider="azure",
+            api_key="secret-api-key",
+            endpoint="https://example.openai.azure.com",
+            auth_mode="api_key",
+            tiers={"default": "stub-model"},
+        )
+        adapter = WebSessionAdapter(tmp_path, tmp_path, cfg)
+        backend = _StubBackend()
+        backend.conversation_history.append({
+            "role": "assistant",
+            "content": "prior private answer",
+        })
+        adapter._backend = backend
+        adapter._tools = [{"name": "feedback", "description": "private tool schema"}]
+
+        class _SessionWithBehaviors:
+            def load_behaviors(self) -> str:
+                return "private managed behavior"
+
+        adapter._session = cast(Any, _SessionWithBehaviors())
+
+        details = adapter._context_manifest_details(
+            model="stub-model",
+            message="current private question",
+            turn_system_prompt="private process prompt",
+            transcript_context_chars=32,
+        )
+
+        joined = "\n".join(details)
+        assert details[0].startswith("llm.context_manifest ")
+        assert "visibility=clarity_assembled" in details[0]
+        assert "context_window_tokens=1000" in details[0]
+        assert "provider_internal_context=visible_to_clarity" in details[0]
+        assert "raw_prompt_content=omitted" in details[0]
+        assert "private" not in joined
+        assert [
+            line.split("name=", 1)[1].split(" ", 1)[0]
+            for line in details[1:]
+        ] == [
+            "backend_system_prompt",
+            "tool_schemas",
+            "project_behaviors",
+            "transcript_restore",
+            "turn_system_prompt",
+            "prior_messages",
+            "current_user_message",
+        ]
+        assert all("position=" in line for line in details[1:])
+
+    def test_context_manifest_marks_provider_managed_history(self, tmp_path):
+        cfg = LLMConfig(
+            provider="github",
+            api_key=None,
+            endpoint=None,
+            auth_mode="sdk_native",
+            tiers={"default": "stub-model"},
+        )
+        adapter = WebSessionAdapter(tmp_path, tmp_path, cfg)
+        adapter._backend = _StubBackend()
+
+        details = adapter._context_manifest_details(
+            model="stub-model",
+            message="hello",
+            turn_system_prompt=None,
+            transcript_context_chars=0,
+        )
+
+        joined = "\n".join(details)
+        assert "provider_internal_context=not_visible" in details[0]
+        assert "name=provider_session_history" in joined
+        assert "chars=unknown" in joined
+        assert "position=provider_managed" in joined
 
 
 class TestStartNewChapter:
@@ -600,7 +685,7 @@ class TestCompactionBridge:
         # compaction can record into it without racing the first
         # turn's events.
         adapter = _start_adapter(project)
-        cfg = adapter.llm_config
+        cfg = cast(_StubLLMConfig, adapter.llm_config)
         assert cfg.last_backend is not None
         # Stub records the transcript kwarg on a dedicated attr.
         assert cfg.last_backend._transcript is adapter._project_transcript

--- a/tests/test_web_session_resume.py
+++ b/tests/test_web_session_resume.py
@@ -357,7 +357,7 @@ class TestGenerationLogDetails:
 
         joined = "\n".join(details)
         assert details[0].startswith("llm.context_manifest Prompt map: ")
-        assert "Clarity can see about" in details[0]
+        assert "known context is about" in details[0]
         assert "1,000-token model window" in details[0]
         assert "visible to Clarity in local backend history" in details[0]
         assert "Raw prompt text is omitted" in details[0]
@@ -397,7 +397,7 @@ class TestGenerationLogDetails:
 
         joined = "\n".join(details)
         assert (
-            "Provider-managed context: not visible to Clarity after handoff"
+            "Provider-managed context is not visible to Clarity after handoff"
             in details[0]
         )
         assert "Provider-managed history" in joined

--- a/tests/test_websocket_chat_error_surfacing.py
+++ b/tests/test_websocket_chat_error_surfacing.py
@@ -50,6 +50,17 @@ def _make_app(project_dir: Path, *, provider: str = "anthropic") -> Any:
     )
 
 
+def _receive_event(ws: Any, event_type: str) -> dict[str, Any]:
+    """Receive until the requested event type arrives, skipping log frames."""
+    skipped: list[dict[str, Any]] = []
+    for _ in range(20):
+        msg = ws.receive_json()
+        if msg["type"] == event_type:
+            return msg
+        skipped.append(msg)
+    raise AssertionError(f"Did not receive {event_type!r}; skipped={skipped!r}")
+
+
 class TestSessionStartFailure:
     """Backend construction failure surfaces as a classified error."""
 
@@ -77,7 +88,7 @@ class TestSessionStartFailure:
         app = _make_app(tmp_path)
         client = TestClient(app)
         with client.websocket_connect("/ws/chat") as ws:
-            msg = ws.receive_json()
+            msg = _receive_event(ws, "error")
 
         assert msg["type"] == "error"
         assert msg["category"] == "auth"
@@ -107,12 +118,12 @@ class TestSessionStartFailure:
         app = _make_app(tmp_path)
         client = TestClient(app)
         with client.websocket_connect("/ws/chat") as ws:
-            initial = ws.receive_json()
+            initial = _receive_event(ws, "error")
             assert initial["type"] == "error"
             assert initial["category"] == "auth"
 
             ws.send_json({"type": "chat", "message": "hello"})
-            echoed = ws.receive_json()
+            echoed = _receive_event(ws, "error")
 
         assert echoed["type"] == "error"
         assert echoed["category"] == "auth"
@@ -139,7 +150,7 @@ class TestSessionStartFailure:
         app = _make_app(tmp_path)
         client = TestClient(app)
         with client.websocket_connect("/ws/chat") as ws:
-            msg = ws.receive_json()
+            msg = _receive_event(ws, "error")
 
         assert msg["type"] == "error"
         assert msg["category"] == "setup_required"
@@ -180,7 +191,7 @@ class TestChatTurnFailure:
         client = TestClient(app)
         with client.websocket_connect("/ws/chat") as ws:
             ws.send_json({"type": "chat", "message": "hi"})
-            msg = ws.receive_json()
+            msg = _receive_event(ws, "error")
 
         assert msg["type"] == "error"
         assert msg["category"] == "auth"
@@ -218,7 +229,7 @@ class TestChatTurnFailure:
         client = TestClient(app)
         with client.websocket_connect("/ws/chat") as ws:
             ws.send_json({"type": "chat", "message": "hi"})
-            msg = ws.receive_json()
+            msg = _receive_event(ws, "error")
 
         assert msg["type"] == "error"
         assert msg["category"] == "mcp_config"

--- a/web/src/__tests__/ChatMessage.test.tsx
+++ b/web/src/__tests__/ChatMessage.test.tsx
@@ -34,7 +34,7 @@ describe("ChatMessage", () => {
     expect(strong.tagName).toBe("STRONG");
   });
 
-  it("shows tool events for assistant messages", () => {
+  it("does not render tool events inline for assistant messages", () => {
     render(
       <ChatMessage
         message={makeMessage({
@@ -47,13 +47,30 @@ describe("ChatMessage", () => {
         })}
       />,
     );
-    // Component renders "→ read_file: main.py" — tool name without brackets
-    expect(screen.getByText(/read_file/)).toBeInTheDocument();
-    expect(screen.getByText(/main\.py/)).toBeInTheDocument();
-    expect(screen.getByText(/write_file/)).toBeInTheDocument();
+    expect(screen.getByText("Done")).toBeInTheDocument();
+    expect(screen.queryByText(/read_file/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tool-terminal")).not.toBeInTheDocument();
   });
 
-  it("shows cost for assistant messages", () => {
+  it("does not render tool-only assistant messages in the chat timeline", () => {
+    const { container } = render(
+      <ChatMessage
+        message={makeMessage({
+          role: "assistant",
+          content: "",
+          toolEvents: [
+            { tool: "bash", detail: "npm run build" },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.queryByText(/npm run build/)).not.toBeInTheDocument();
+    expect(container.querySelector(".prose")).toBeNull();
+    expect(screen.queryByText("Clarity")).not.toBeInTheDocument();
+  });
+
+  it("does not render usage inline for assistant messages", () => {
     render(
       <ChatMessage
         message={makeMessage({
@@ -63,8 +80,8 @@ describe("ChatMessage", () => {
         })}
       />,
     );
-    // Component renders "$0.0567" without a "Cost:" prefix
-    expect(screen.getByText("$0.0567")).toBeInTheDocument();
+    expect(screen.getByText("Result")).toBeInTheDocument();
+    expect(screen.queryByText("$0.0567")).not.toBeInTheDocument();
   });
 
   it("does not show tool events or cost for user messages", () => {

--- a/web/src/__tests__/ToolLogPane.test.tsx
+++ b/web/src/__tests__/ToolLogPane.test.tsx
@@ -1,0 +1,100 @@
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import ToolLogPane from "../components/ToolLogPane";
+
+const events = [
+  { tool: "bash", detail: "npm run build" },
+  { tool: "backend", detail: "chat backend ready" },
+];
+
+describe("ToolLogPane", () => {
+  it("renders a glowing trigger when closed with unread log lines", () => {
+    render(
+      <ToolLogPane
+        events={events}
+        open={false}
+        unread
+        width={460}
+        onOpenChange={() => {}}
+        onWidthChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("log-pane-toggle")).toHaveAttribute("data-unread", "true");
+    expect(screen.getByTestId("log-side-pane")).toHaveAttribute("data-open", "false");
+    expect(screen.queryByText(/npm run build/)).not.toBeInTheDocument();
+  });
+
+  it("opens the split pane and stops marking the trigger unread", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <ToolLogPane
+        events={events}
+        open={false}
+        unread
+        width={460}
+        onOpenChange={onOpenChange}
+        onWidthChange={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByTestId("log-pane-toggle"));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+
+    rerender(
+      <ToolLogPane
+        events={events}
+        open
+        unread={false}
+        width={460}
+        onOpenChange={onOpenChange}
+        onWidthChange={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId("log-pane-toggle")).not.toBeInTheDocument();
+    expect(screen.getByTestId("log-side-pane")).toHaveAttribute("data-open", "true");
+    expect(screen.getByText("2 lines")).toBeInTheDocument();
+    expect(screen.getByText(/npm run build/)).toBeInTheDocument();
+  });
+
+  it("resizes from the left edge while open", () => {
+    const onWidthChange = vi.fn();
+    render(
+      <ToolLogPane
+        events={events}
+        open
+        unread={false}
+        width={460}
+        onOpenChange={() => {}}
+        onWidthChange={onWidthChange}
+      />,
+    );
+
+    fireEvent.pointerDown(screen.getByTestId("log-pane-resize-handle"), {
+      clientX: 700,
+    });
+    fireEvent.pointerMove(window, { clientX: 620 });
+
+    expect(onWidthChange).toHaveBeenCalledWith(540);
+
+    fireEvent.pointerUp(window);
+  });
+
+  it("does not render until log events exist", () => {
+    const { container } = render(
+      <ToolLogPane
+        events={[]}
+        open={false}
+        unread={false}
+        width={460}
+        onOpenChange={() => {}}
+        onWidthChange={() => {}}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/src/__tests__/ToolLogPane.test.tsx
+++ b/web/src/__tests__/ToolLogPane.test.tsx
@@ -14,7 +14,7 @@ describe("ToolLogPane", () => {
       <ToolLogPane
         events={events}
         open={false}
-        unread
+        unreadCount={2}
         width={460}
         onOpenChange={() => {}}
         onWidthChange={() => {}}
@@ -23,7 +23,24 @@ describe("ToolLogPane", () => {
 
     expect(screen.getByTestId("log-pane-toggle")).toHaveAttribute("data-unread", "true");
     expect(screen.getByTestId("log-side-pane")).toHaveAttribute("data-open", "false");
+    expect(screen.getByText("2")).toBeInTheDocument();
     expect(screen.queryByText(/npm run build/)).not.toBeInTheDocument();
+  });
+
+  it("does not render an unread counter when all log lines have been seen", () => {
+    render(
+      <ToolLogPane
+        events={events}
+        open={false}
+        unreadCount={0}
+        width={460}
+        onOpenChange={() => {}}
+        onWidthChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("log-pane-toggle")).toHaveAttribute("data-unread", "false");
+    expect(screen.queryByText("2")).not.toBeInTheDocument();
   });
 
   it("opens the split pane and stops marking the trigger unread", async () => {
@@ -33,7 +50,7 @@ describe("ToolLogPane", () => {
       <ToolLogPane
         events={events}
         open={false}
-        unread
+        unreadCount={2}
         width={460}
         onOpenChange={onOpenChange}
         onWidthChange={() => {}}
@@ -47,7 +64,7 @@ describe("ToolLogPane", () => {
       <ToolLogPane
         events={events}
         open
-        unread={false}
+        unreadCount={0}
         width={460}
         onOpenChange={onOpenChange}
         onWidthChange={() => {}}
@@ -66,7 +83,7 @@ describe("ToolLogPane", () => {
       <ToolLogPane
         events={events}
         open
-        unread={false}
+        unreadCount={0}
         width={460}
         onOpenChange={() => {}}
         onWidthChange={onWidthChange}
@@ -88,7 +105,7 @@ describe("ToolLogPane", () => {
       <ToolLogPane
         events={[]}
         open={false}
-        unread={false}
+        unreadCount={0}
         width={460}
         onOpenChange={() => {}}
         onWidthChange={() => {}}

--- a/web/src/__tests__/chatReducer.test.ts
+++ b/web/src/__tests__/chatReducer.test.ts
@@ -375,6 +375,7 @@ describe("chatReducer", () => {
           { id: "1", role: "user", content: "Hi", timestamp: 1 },
           { id: "2", role: "assistant", content: "Hello", timestamp: 2 },
         ],
+        logLines: [{ tool: "backend", detail: "ready" }],
         pendingTools: [{ tool: "t", detail: "d" }],
         turnCost: 0.05,
         turnTokens: 500,
@@ -393,6 +394,7 @@ describe("chatReducer", () => {
       };
       const next = chatReducer(populated, { type: "clear" });
       expect(next.messages).toEqual([]);
+      expect(next.logLines).toEqual([]);
       expect(next.pendingTools).toEqual([]);
       expect(next.outgoingQueue).toEqual([]);
       expect(next.turnCost).toBe(0);
@@ -402,6 +404,70 @@ describe("chatReducer", () => {
       expect(next.activeModel).toBe("claude-sonnet");
       expect(next.activeTier).toBe("default");
       expect(next.autoModel).toBe(false);
+    });
+  });
+
+  describe("logLines", () => {
+    it("accumulates tool_events in logLines", () => {
+      let state = chatReducer(initialState, {
+        type: "tool_event",
+        tool: "read_file",
+        detail: "a.txt",
+      });
+      state = chatReducer(state, {
+        type: "tool_event",
+        tool: "write_file",
+        detail: "b.txt",
+      });
+      expect(state.logLines).toEqual([
+        { tool: "read_file", detail: "a.txt" },
+        { tool: "write_file", detail: "b.txt" },
+      ]);
+    });
+
+    it("accumulates log_events in logLines", () => {
+      const state = chatReducer(initialState, {
+        type: "log_event",
+        source: "backend",
+        level: "info",
+        message: "chat backend ready",
+      });
+      expect(state.logLines).toEqual([
+        { tool: "backend", detail: "chat backend ready" },
+      ]);
+    });
+
+    it("logLines is NOT reset by load_history", () => {
+      let state = chatReducer(initialState, {
+        type: "log_event",
+        source: "backend",
+        level: "info",
+        message: "server started",
+      });
+      state = chatReducer(state, {
+        type: "load_history",
+        messages: [
+          { id: "u1", role: "user", content: "Hello", timestamp: 1 },
+          { id: "a1", role: "assistant", content: "Hi", timestamp: 2 },
+        ],
+      });
+      expect(state.logLines).toEqual([
+        { tool: "backend", detail: "server started" },
+      ]);
+      // messages were replaced
+      expect(state.messages).toHaveLength(2);
+      expect(state.messages[0].role).toBe("user");
+    });
+
+    it("logLines IS reset by clear", () => {
+      let state = chatReducer(initialState, {
+        type: "log_event",
+        source: "backend",
+        level: "info",
+        message: "server started",
+      });
+      state = chatReducer(state, { type: "clear" });
+      expect(state.logLines).toEqual([]);
     });
   });
 

--- a/web/src/__tests__/chatReducer.test.ts
+++ b/web/src/__tests__/chatReducer.test.ts
@@ -49,7 +49,7 @@ describe("chatReducer", () => {
   });
 
   describe("tool_event", () => {
-    it("commits each tool event as its own message in time order", () => {
+    it("accumulates consecutive tool events in one terminal message", () => {
       let state = chatReducer(initialState, {
         type: "send_message",
         content: "Do something",
@@ -64,21 +64,20 @@ describe("chatReducer", () => {
         tool: "write_file",
         detail: "b.txt",
       });
-      // Tool events become standalone tool-role messages in the
-      // history (preserves chronological order with interleaved text).
       const toolMsgs = state.messages.filter((m) => m.role === "tool");
-      expect(toolMsgs).toHaveLength(2);
+      expect(toolMsgs).toHaveLength(1);
       expect(toolMsgs[0].toolEvents?.[0]).toEqual({
         tool: "read_file",
         detail: "a.txt",
       });
-      expect(toolMsgs[1].toolEvents?.[0]).toEqual({
+      expect(toolMsgs[0].toolEvents?.[1]).toEqual({
         tool: "write_file",
         detail: "b.txt",
       });
+      expect(toolMsgs[0].content).toBe("read_file: a.txt\nwrite_file: b.txt");
     });
 
-    it("commits streaming text before a tool event", () => {
+    it("keeps streaming text live while appending the terminal log", () => {
       let state = chatReducer(initialState, {
         type: "send_message",
         content: "Help me",
@@ -90,14 +89,140 @@ describe("chatReducer", () => {
         tool: "read_file",
         detail: "a.txt",
       });
-      // Streaming text should be flushed as a message before the tool.
-      expect(state.streamingText).toBe("");
-      // After the user message, there should be: assistant text, tool.
+      expect(state.streamingText).toBe("Let me check.");
       const afterUser = state.messages.slice(1);
-      expect(afterUser).toHaveLength(2);
-      expect(afterUser[0].role).toBe("assistant");
-      expect(afterUser[0].content).toBe("Let me check.");
-      expect(afterUser[1].role).toBe("tool");
+      expect(afterUser).toHaveLength(1);
+      expect(afterUser[0].role).toBe("tool");
+    });
+  });
+
+  describe("log_event", () => {
+    it("initializes a terminal log even when no answer is streaming", () => {
+      const state = chatReducer(initialState, {
+        type: "log_event",
+        source: "launcher",
+        level: "info",
+        message: "spawned project server pid=123 port=456",
+      });
+      expect(state.messages).toHaveLength(1);
+      expect(state.messages[0].role).toBe("tool");
+      expect(state.messages[0].toolEvents).toEqual([
+        {
+          tool: "launcher",
+          detail: "spawned project server pid=123 port=456",
+        },
+      ]);
+    });
+
+    it("appends idle backend logs after conversation history", () => {
+      const historyState = chatReducer(initialState, {
+        type: "load_history",
+        messages: [
+          { id: "u1", role: "user", content: "Question", timestamp: 1 },
+          { id: "a1", role: "assistant", content: "Answer", timestamp: 2 },
+        ],
+      });
+
+      const next = chatReducer(historyState, {
+        type: "log_event",
+        source: "food-match-clarity",
+        level: "info",
+        message: 'INFO: 127.0.0.1:61245 - "GET /api/session HTTP/1.1" 200 OK',
+      });
+
+      expect(next.messages.map((m) => m.role)).toEqual([
+        "user",
+        "assistant",
+        "tool",
+      ]);
+      expect(next.messages[2].toolEvents).toEqual([
+        {
+          tool: "food-match-clarity",
+          detail: 'INFO: 127.0.0.1:61245 - "GET /api/session HTTP/1.1" 200 OK',
+        },
+      ]);
+    });
+
+    it("still appends idle backend errors after conversation history", () => {
+      const historyState = chatReducer(initialState, {
+        type: "load_history",
+        messages: [
+          { id: "u1", role: "user", content: "Question", timestamp: 1 },
+          { id: "a1", role: "assistant", content: "Answer", timestamp: 2 },
+        ],
+      });
+
+      const next = chatReducer(historyState, {
+        type: "log_event",
+        source: "backend",
+        level: "error",
+        message: "connection failed",
+      });
+
+      expect(next.messages.map((m) => m.role)).toEqual([
+        "user",
+        "assistant",
+        "tool",
+      ]);
+      expect(next.messages[2].toolEvents).toEqual([
+        { tool: "backend", detail: "error: connection failed" },
+      ]);
+    });
+
+    it("accumulates backend logs after a user message in the active terminal", () => {
+      let state = chatReducer(initialState, {
+        type: "send_message",
+        content: "Question",
+      });
+      state = chatReducer(state, {
+        type: "log_event",
+        source: "food-match-clarity:err",
+        level: "error",
+        message: "INFO: connection open",
+      });
+      state = chatReducer(state, {
+        type: "tool_event",
+        tool: "view",
+        detail: "README.md",
+      });
+
+      expect(state.messages.map((m) => m.role)).toEqual(["user", "tool"]);
+      expect(state.messages[1].toolEvents).toEqual([
+        {
+          tool: "food-match-clarity:err",
+          detail: "error: INFO: connection open",
+        },
+        { tool: "view", detail: "README.md" },
+      ]);
+    });
+
+    it("merges runtime logs into a terminal-only assistant message", () => {
+      const state = chatReducer(
+        {
+          ...initialState,
+          messages: [
+            {
+              id: "terminal-assistant",
+              role: "assistant",
+              content: "",
+              toolEvents: [{ tool: "bash", detail: "npm run build" }],
+              timestamp: 1,
+            },
+          ],
+        },
+        {
+          type: "log_event",
+          source: "backend",
+          level: "info",
+          message: "chat backend ready",
+        },
+      );
+
+      expect(state.messages).toHaveLength(1);
+      expect(state.messages[0].toolEvents).toEqual([
+        { tool: "bash", detail: "npm run build" },
+        { tool: "backend", detail: "chat backend ready" },
+      ]);
     });
   });
 
@@ -118,6 +243,18 @@ describe("chatReducer", () => {
       state = chatReducer(state, { type: "cost_event", cost_usd: 0.03 });
       expect(state.turnCost).toBe(0.03);
     });
+
+    it("adds cost to the active terminal log while streaming", () => {
+      let state = chatReducer(initialState, {
+        type: "send_message",
+        content: "Q",
+      });
+      state = chatReducer(state, { type: "cost_event", cost_usd: 0.03 });
+      expect(state.messages[1].role).toBe("tool");
+      expect(state.messages[1].toolEvents).toEqual([
+        { tool: "cost", detail: "$0.0300" },
+      ]);
+    });
   });
 
   describe("receive_response", () => {
@@ -136,7 +273,7 @@ describe("chatReducer", () => {
       expect(state.streaming).toBe(false);
     });
 
-    it("keeps tool events as their own messages in time order", () => {
+    it("keeps the terminal log between user and assistant messages", () => {
       let state = chatReducer(initialState, {
         type: "send_message",
         content: "Q",
@@ -150,8 +287,12 @@ describe("chatReducer", () => {
         type: "receive_response",
         content: "Found it",
       });
-      // user + tool + assistant = 3 messages.
       expect(state.messages).toHaveLength(3);
+      expect(state.messages.map((m) => m.role)).toEqual([
+        "user",
+        "tool",
+        "assistant",
+      ]);
       expect(state.messages[1].role).toBe("tool");
       expect(state.messages[1].toolEvents).toEqual([
         { tool: "search", detail: "query" },
@@ -173,7 +314,12 @@ describe("chatReducer", () => {
         type: "receive_response",
         content: "A",
       });
-      expect(state.messages[1].costUsd).toBe(0.042);
+      expect(state.messages.map((m) => m.role)).toEqual([
+        "user",
+        "tool",
+        "assistant",
+      ]);
+      expect(state.messages[2].costUsd).toBe(0.042);
     });
 
     it("omits toolEvents and costUsd when there are none", () => {
@@ -200,6 +346,11 @@ describe("chatReducer", () => {
       expect(next.streaming).toBe(true);
       expect(next.pendingTools).toEqual([]);
       expect(next.turnCost).toBe(0);
+      expect(next.messages).toHaveLength(1);
+      expect(next.messages[0].role).toBe("tool");
+      expect(next.messages[0].toolEvents).toEqual([
+        { tool: "process", detail: "starting problem-clarification" },
+      ]);
     });
   });
 
@@ -261,6 +412,7 @@ describe("chatReducer", () => {
         phase: "reasoning",
       });
       expect(next.statusPhase).toBe("reasoning");
+      expect(next.messages).toHaveLength(0);
     });
 
     it("overwrites previous phase on transition", () => {
@@ -273,6 +425,26 @@ describe("chatReducer", () => {
         phase: "tool:read_file",
       });
       expect(state.statusPhase).toBe("tool:read_file");
+    });
+
+    it("adds status transitions to the active terminal log while streaming", () => {
+      let state = chatReducer(initialState, {
+        type: "send_message",
+        content: "Q",
+      });
+      state = chatReducer(state, {
+        type: "status_event",
+        phase: "thinking",
+      });
+      state = chatReducer(state, {
+        type: "status_event",
+        phase: "tool:view (README.md)",
+      });
+      expect(state.messages.map((m) => m.role)).toEqual(["user", "tool"]);
+      expect(state.messages[1].toolEvents).toEqual([
+        { tool: "status", detail: "thinking" },
+        { tool: "status", detail: "tool:view (README.md)" },
+      ]);
     });
 
     it("is cleared by receive_response", () => {
@@ -352,7 +524,11 @@ describe("chatReducer", () => {
       expect(s.messages).toHaveLength(1);
       expect(s.streaming).toBe(true);
 
-      // Server streams tool events — each becomes a tool-role message.
+      // Server streams status and tool events into one terminal log.
+      s = chatReducer(s, {
+        type: "status_event",
+        phase: "thinking",
+      });
       s = chatReducer(s, {
         type: "tool_event",
         tool: "read_file",
@@ -363,27 +539,70 @@ describe("chatReducer", () => {
         tool: "read_file",
         detail: "tests.py",
       });
-      // After 2 tool events: user msg + 2 tool msgs = 3.
-      expect(s.messages).toHaveLength(3);
+      expect(s.messages).toHaveLength(2);
       expect(s.messages[1].role).toBe("tool");
-      expect(s.messages[2].role).toBe("tool");
+      expect(s.messages[1].toolEvents).toHaveLength(3);
 
       // Server sends cost
       s = chatReducer(s, { type: "cost_event", cost_usd: 0.015 });
+      expect(s.messages[1].toolEvents).toHaveLength(4);
 
-      // Server sends response — appends the assistant message with text + cost.
+      // Server sends response, then appends the assistant message with text and cost.
       s = chatReducer(s, {
         type: "receive_response",
         content: "Here's my analysis",
       });
-      // Now: user + 2 tool + assistant = 4.
-      expect(s.messages).toHaveLength(4);
+      expect(s.messages).toHaveLength(3);
       expect(s.streaming).toBe(false);
-      const finalMsg = s.messages[3];
+      expect(s.messages.map((m) => m.role)).toEqual([
+        "user",
+        "tool",
+        "assistant",
+      ]);
+      const finalMsg = s.messages[2];
       expect(finalMsg.role).toBe("assistant");
       expect(finalMsg.content).toBe("Here's my analysis");
       expect(finalMsg.costUsd).toBe(0.015);
       expect(s.pendingTools).toEqual([]);
+    });
+
+    it("starts a fresh terminal log for each user turn", () => {
+      let s = initialState;
+
+      s = chatReducer(s, { type: "send_message", content: "First" });
+      s = chatReducer(s, { type: "status_event", phase: "thinking" });
+      s = chatReducer(s, {
+        type: "tool_event",
+        tool: "view",
+        detail: "a.md",
+      });
+      s = chatReducer(s, { type: "receive_response", content: "First answer" });
+
+      s = chatReducer(s, { type: "send_message", content: "Second" });
+      s = chatReducer(s, { type: "status_event", phase: "thinking" });
+      s = chatReducer(s, {
+        type: "tool_event",
+        tool: "view",
+        detail: "b.md",
+      });
+      s = chatReducer(s, { type: "receive_response", content: "Second answer" });
+
+      expect(s.messages.map((m) => m.role)).toEqual([
+        "user",
+        "tool",
+        "assistant",
+        "user",
+        "tool",
+        "assistant",
+      ]);
+      expect(s.messages[1].toolEvents).toEqual([
+        { tool: "status", detail: "thinking" },
+        { tool: "view", detail: "a.md" },
+      ]);
+      expect(s.messages[4].toolEvents).toEqual([
+        { tool: "status", detail: "thinking" },
+        { tool: "view", detail: "b.md" },
+      ]);
     });
   });
 
@@ -405,7 +624,7 @@ describe("chatReducer", () => {
     });
 
     it("flips historyLoaded even when payload is empty", () => {
-      // Empty history is a meaningful "fresh project" signal — the
+      // Empty history is a meaningful "fresh project" signal. The
       // auto-start needs to fire in that case, which requires
       // historyLoaded=true.
       const next = chatReducer(initialState, {
@@ -416,8 +635,25 @@ describe("chatReducer", () => {
       expect(next.historyLoaded).toBe(true);
     });
 
+    it("keeps launch terminal logs when empty history resolves after them", () => {
+      const withLaunchLog = chatReducer(initialState, {
+        type: "log_event",
+        source: "launcher",
+        level: "info",
+        message: "spawned project server pid=123 port=456",
+      });
+
+      const next = chatReducer(withLaunchLog, {
+        type: "load_history",
+        messages: [],
+      });
+
+      expect(next.messages).toEqual(withLaunchLog.messages);
+      expect(next.historyLoaded).toBe(true);
+    });
+
     it("doesn't disturb non-message state fields", () => {
-      // The reducer should narrow its blast radius — model state,
+      // The reducer should narrow its blast radius. Model state,
       // session totals, errors etc. should pass through unchanged.
       const seeded = {
         ...initialState,
@@ -439,7 +675,7 @@ describe("chatReducer", () => {
     it("clear after history-load keeps historyLoaded=true", () => {
       // After "Start new chapter" we dispatch ``clear``.  The new
       // chapter is empty so re-fetching history would return an
-      // empty list anyway — but we shouldn't reset the flag,
+      // empty list anyway, but we shouldn't reset the flag,
       // otherwise the auto-start would race the second fetch.
       const populated = chatReducer(initialState, {
         type: "load_history",

--- a/web/src/components/ChatMessage.tsx
+++ b/web/src/components/ChatMessage.tsx
@@ -18,8 +18,7 @@ function CopyButton({ text }: { text: string }) {
       onClick={handleCopy}
       title="Copy to clipboard"
       className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[10px]
-        rounded text-body-faint hover:text-body hover:bg-surface-hover
-        transition-colors"
+        rounded text-body-faint transition-colors hover:bg-surface-hover hover:text-body"
     >
       <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
         <rect x="5.5" y="5.5" width="8" height="8" rx="1.5" />
@@ -38,21 +37,9 @@ export default function ChatMessage({ message }: ChatMessageProps) {
   const isUser = message.role === "user";
   const isSystem = message.role === "system";
   const isTool = message.role === "tool";
+  const hasContent = message.content.trim().length > 0;
 
-  // Tool messages: compact inline indicator
-  if (isTool && message.toolEvents?.length) {
-    return (
-      <div className="flex justify-start">
-        <div className="text-xs text-body-faint pl-1 font-mono">
-          {message.toolEvents.map((te, i) => (
-            <div key={i}>
-              <span className="text-accent/60">{"\u2192"}</span> {te.tool}: {te.detail}
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  }
+  if (isTool || !hasContent) return null;
 
   // System messages: full-width, lighter styling
   if (isSystem) {
@@ -73,23 +60,6 @@ export default function ChatMessage({ message }: ChatMessageProps) {
   return (
     <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
       <div className={`flex flex-col gap-1.5 ${isUser ? "max-w-[75%]" : "max-w-[85%]"}`}>
-        {/* Tool events + cost log — visible above the message bubble */}
-        {!isUser && (message.toolEvents?.length || message.costUsd || message.tokenCount) && (
-          <div className="text-xs text-body-faint space-y-0.5 pl-1 font-mono">
-            {message.toolEvents?.map((te, i) => (
-              <div key={i}>
-                <span className="text-accent/50">→</span> {te.tool}: {te.detail}
-              </div>
-            ))}
-            {(message.tokenCount != null || message.costUsd != null) && (
-              <div className="text-body-faint/60">
-                {message.tokenCount != null && <>{message.tokenCount.toLocaleString()} tokens</>}
-                {message.costUsd != null && <>{message.tokenCount != null ? " \u00b7 " : ""}${message.costUsd.toFixed(4)}</>}
-              </div>
-            )}
-          </div>
-        )}
-
         {/* Message bubble */}
         <div
           className={`rounded-2xl px-5 py-3.5 ${
@@ -109,7 +79,7 @@ export default function ChatMessage({ message }: ChatMessageProps) {
           )}
         </div>
 
-        {/* Role label + copy — subtle, below the bubble */}
+        {/* Role label and copy action, below the bubble. */}
         <div className={`flex items-center gap-2 ${isUser ? "justify-end" : "justify-start"}`}>
           <span className="text-[10px] uppercase tracking-widest text-body-faint/50 px-1">
             {isUser ? "You" : "Clarity"}

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -60,6 +60,7 @@ export default function ChatPanel() {
     [messages],
   );
   const logLineCount = logLines.length;
+  const unreadLogCount = Math.max(0, logLineCount - seenLogCount);
 
   // Check if a protocol directory exists
   useEffect(() => {
@@ -410,7 +411,7 @@ export default function ChatPanel() {
         <ToolLogPane
           events={logLines}
           open={logPaneOpen}
-          unread={logLineCount > seenLogCount}
+          unreadCount={unreadLogCount}
           width={logPaneWidth}
           onOpenChange={handleLogPaneOpenChange}
           onWidthChange={setLogPaneWidth}

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -1,19 +1,30 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { getProtocolTree, getSession } from "../api/client";
 import { useChat } from "../hooks/useChat";
-import type { SessionInfo } from "../types";
+import type { ChatMessage as ChatMessageType, SessionInfo, ToolEvent } from "../types";
 import ChatMessage from "./ChatMessage";
 import EmptyState from "./EmptyState";
 import ErrorBanner from "./ErrorBanner";
 import MessageInput from "./MessageInput";
+import ToolLogPane from "./ToolLogPane";
 
 function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return String(n);
 }
+
+function isVisibleChatMessage(message: ChatMessageType): boolean {
+  return message.role !== "tool" && message.content.trim().length > 0;
+}
+
+function collectToolEvents(messages: ChatMessageType[]): ToolEvent[] {
+  return messages.flatMap((message) => message.toolEvents ?? []);
+}
+
+const DEFAULT_LOG_PANE_WIDTH = 460;
 
 export default function ChatPanel() {
   const {
@@ -44,6 +55,15 @@ export default function ChatPanel() {
   const autoStarted = useRef(false);
   const [protocolExists, setProtocolExists] = useState<boolean | null>(null);
   const [sessionInfo, setSessionInfo] = useState<SessionInfo | null>(null);
+  const [logPaneOpen, setLogPaneOpen] = useState(false);
+  const [logPaneWidth, setLogPaneWidth] = useState(DEFAULT_LOG_PANE_WIDTH);
+  const [seenLogCount, setSeenLogCount] = useState(0);
+  const visibleMessages = useMemo(
+    () => messages.filter(isVisibleChatMessage),
+    [messages],
+  );
+  const toolEvents = useMemo(() => collectToolEvents(messages), [messages]);
+  const logLineCount = toolEvents.length;
 
   // Check if a protocol directory exists
   useEffect(() => {
@@ -57,27 +77,32 @@ export default function ChatPanel() {
     getSession().then(setSessionInfo).catch(() => {});
   }, []);
 
-  // Auto-start the clarity-agent process — but only when this is
-  // genuinely a fresh start.  The ``historyLoaded`` guard is the
-  // key new piece: if the user has prior conversation in the
-  // current chapter, the load_history fetch will populate
-  // ``messages`` and the ``messages.length === 0`` check below
-  // becomes false, so we skip the slow kickoff and let them resume.
-  // Without ``historyLoaded`` we'd race the fetch and fire the
-  // kickoff on every page open.
+  // Auto-start only when this is genuinely a fresh chat. Terminal
+  // logs are hidden from the timeline, so visibleMessages is the
+  // gate that distinguishes real chat history from launch logs.
   useEffect(() => {
     if (
       historyLoaded
       && connected
       && !autoStarted.current
-      && messages.length === 0
+      && visibleMessages.length === 0
       && !streaming
       && protocolExists !== false
     ) {
       autoStarted.current = true;
       startProcess("clarity-agent");
     }
-  }, [historyLoaded, connected, messages.length, streaming, startProcess, protocolExists]);
+  }, [historyLoaded, connected, visibleMessages.length, streaming, startProcess, protocolExists]);
+
+  useEffect(() => {
+    if (logLineCount < seenLogCount) {
+      setSeenLogCount(logPaneOpen ? logLineCount : 0);
+      return;
+    }
+    if (logPaneOpen && logLineCount > seenLogCount) {
+      setSeenLogCount(logLineCount);
+    }
+  }, [logLineCount, logPaneOpen, seenLogCount]);
 
   // Track whether the user is scrolled to the bottom. Only auto-scroll
   // when they're "stuck" to the bottom — if they've scrolled up to read
@@ -95,7 +120,7 @@ export default function ChatPanel() {
   // smooth-scroll catches up.  Runs once per mount (re-mounts on
   // tab-switch back to Session get a fresh ref and re-pin).
   const initialScrollDone = useRef(false);
-  const hasContent = messages.length > 0;
+  const hasContent = visibleMessages.length > 0;
   useLayoutEffect(() => {
     if (initialScrollDone.current || !hasContent) return;
     initialScrollDone.current = true;
@@ -110,10 +135,15 @@ export default function ChatPanel() {
     if (stickToBottom.current) {
       bottomRef.current?.scrollIntoView({ behavior: "smooth" });
     }
-  }, [messages, streamingText]);
+  }, [visibleMessages, streamingText]);
+
+  const handleLogPaneOpenChange = (nextOpen: boolean) => {
+    setLogPaneOpen(nextOpen);
+    if (nextOpen) setSeenLogCount(logLineCount);
+  };
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="relative flex h-full flex-col overflow-hidden">
       {/* Header bar */}
       <div className="print-hide flex items-center justify-between px-6 py-3.5 border-b border-border bg-surface/80 backdrop-blur-sm">
         <div className="flex items-center gap-3">
@@ -197,189 +227,197 @@ export default function ChatPanel() {
         />
       )}
 
-      {/* Messages — bottom-anchored so content grows upward from input */}
-      <div
-        ref={scrollContainerRef}
-        onScroll={handleScroll}
-        className="flex-1 overflow-auto bg-surface-ground/50"
-        data-printable
-        role="log"
-        aria-label="Chat messages"
-        aria-live="polite"
-      >
-        {/* Print-only header — hidden on screen, shown when printing */}
-        {sessionInfo && (
-          <div className="print-header hidden print:block px-6 pt-4 pb-2 border-b border-gray-300">
-            <div className="text-lg font-bold text-black">
-              {sessionInfo.project_dir.split("/").filter(Boolean).pop() || "Clarity"}
-            </div>
-            <div className="text-xs text-gray-500">
-              Thread: {sessionInfo.thread_id || "—"}
-              {" · "}
-              {new Date().toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" })}
-            </div>
-          </div>
-        )}
-        <div className="flex flex-col justify-end min-h-full max-w-3xl mx-auto px-6 py-6 space-y-5">
-          {messages.length === 0 && !streaming && protocolExists === false && connected && (
-            <EmptyState
-              heading="What are you working on?"
-              description="Clarity helps you think through problems, design solutions, and anticipate failures — structured thinking with AI guidance."
-              actions={[
-                {
-                  label: "Start a new project",
-                  primary: true,
-                  onClick: () => {
-                    autoStarted.current = true;
-                    startProcess("problem-clarification");
-                  },
-                },
-                {
-                  label: "Review an existing project",
-                  onClick: () => {
-                    autoStarted.current = true;
-                    startProcess("clarity-agent");
-                  },
-                },
-                {
-                  label: "Just chat",
-                  onClick: () => {
-                    autoStarted.current = true;
-                    sendMessage("Hi! I'd like to discuss something.");
-                  },
-                },
-              ]}
-            />
-          )}
-
-          {messages.length === 0 && !streaming && protocolExists !== false && (
-            <div className="text-center py-16 animate-fade-up">
-              <h2 className="text-3xl text-body-heading mb-2 font-display">
-                What are you working on?
-              </h2>
-              <p className="text-sm text-body-muted max-w-md mx-auto leading-relaxed">
-                {connected
-                  ? "Starting the clarity process — I'll help you think through your project."
-                  : "Connecting to the Clarity Agent..."}
-              </p>
-            </div>
-          )}
-
-          {messages.map((msg, i) => {
-            // Collapse vertical spacing between consecutive tool messages:
-            // only the first tool in a run gets the normal space-y-5 gap,
-            // later ones cancel it out with -mt-5.
-            const prev = i > 0 ? messages[i - 1] : null;
-            const collapseTop = msg.role === "tool" && prev?.role === "tool";
-            return (
-              <div
-                key={msg.id}
-                className={`animate-fade-up ${collapseTop ? "-mt-5" : ""}`}
-                style={{ animationDelay: `${Math.min(i * 50, 300)}ms` }}
-              >
-                <ChatMessage message={msg} />
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <div className="flex min-w-0 flex-1 flex-col">
+          {/* Messages — bottom-anchored so content grows upward from input */}
+          <div
+            ref={scrollContainerRef}
+            onScroll={handleScroll}
+            className="flex-1 overflow-auto bg-surface-ground/50"
+            data-printable
+            role="log"
+            aria-label="Chat messages"
+            aria-live="polite"
+          >
+            {/* Print-only header — hidden on screen, shown when printing */}
+            {sessionInfo && (
+              <div className="print-header hidden print:block px-6 pt-4 pb-2 border-b border-gray-300">
+                <div className="text-lg font-bold text-black">
+                  {sessionInfo.project_dir.split("/").filter(Boolean).pop() || "Clarity"}
+                </div>
+                <div className="text-xs text-gray-500">
+                  Thread: {sessionInfo.thread_id || "—"}
+                  {" · "}
+                  {new Date().toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" })}
+                </div>
               </div>
-            );
-          })}
+            )}
+            <div className="flex flex-col justify-end min-h-full max-w-3xl mx-auto px-6 py-6 space-y-5">
+              {visibleMessages.length === 0 && !streaming && protocolExists === false && connected && (
+                <EmptyState
+                  heading="What are you working on?"
+                  description="Clarity helps you think through problems, design solutions, and anticipate failures — structured thinking with AI guidance."
+                  actions={[
+                    {
+                      label: "Start a new project",
+                      primary: true,
+                      onClick: () => {
+                        autoStarted.current = true;
+                        startProcess("problem-clarification");
+                      },
+                    },
+                    {
+                      label: "Review an existing project",
+                      onClick: () => {
+                        autoStarted.current = true;
+                        startProcess("clarity-agent");
+                      },
+                    },
+                    {
+                      label: "Just chat",
+                      onClick: () => {
+                        autoStarted.current = true;
+                        sendMessage("Hi! I'd like to discuss something.");
+                      },
+                    },
+                  ]}
+                />
+              )}
 
-          {/* Streaming: live text bubble + status bar */}
-          {streaming && (
-            <div className="space-y-2 animate-fade-in" role="status" aria-label="Generating response">
-              {/* Live text — rendered as markdown like final messages */}
-              {streamingText && (
-                <div className="flex justify-start">
-                  <div className="max-w-[85%] rounded-2xl px-5 py-3.5 bg-surface border border-border shadow-sm">
-                    <div className="prose max-w-none leading-relaxed chat-text">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                        {streamingText}
-                      </ReactMarkdown>
+              {visibleMessages.length === 0 && !streaming && protocolExists !== false && (
+                <div className="text-center py-16 animate-fade-up">
+                  <h2 className="text-3xl text-body-heading mb-2 font-display">
+                    What are you working on?
+                  </h2>
+                  <p className="text-sm text-body-muted max-w-md mx-auto leading-relaxed">
+                    {connected
+                      ? "Starting the clarity process — I'll help you think through your project."
+                      : "Connecting to the Clarity Agent..."}
+                  </p>
+                </div>
+              )}
+
+              {visibleMessages.map((msg, i) => {
+                return (
+                  <div
+                    key={msg.id}
+                    className="animate-fade-up"
+                    style={{ animationDelay: `${Math.min(i * 50, 300)}ms` }}
+                  >
+                    <ChatMessage message={msg} />
+                  </div>
+                );
+              })}
+
+              {/* Streaming: live text bubble + status bar */}
+              {streaming && (
+                <div className="space-y-2 animate-fade-in" role="status" aria-label="Generating response">
+                  {/* Live text — rendered as markdown like final messages */}
+                  {streamingText && (
+                    <div className="flex justify-start">
+                      <div className="max-w-[85%] rounded-2xl px-5 py-3.5 bg-surface border border-border shadow-sm">
+                        <div className="prose max-w-none leading-relaxed chat-text">
+                          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                            {streamingText}
+                          </ReactMarkdown>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Status bar: dots + cost + stop */}
+                  <div className="flex justify-start">
+                    <div className="flex items-center gap-3 px-2">
+                      <div className="flex items-center gap-1">
+                        <span className="w-1.5 h-1.5 bg-accent rounded-full animate-bounce" />
+                        <span
+                          className="w-1.5 h-1.5 bg-accent rounded-full animate-bounce"
+                          style={{ animationDelay: "0.15s" }}
+                        />
+                        <span
+                          className="w-1.5 h-1.5 bg-accent rounded-full animate-bounce"
+                          style={{ animationDelay: "0.3s" }}
+                        />
+                      </div>
+                      {statusPhase && (
+                        <span className="text-xs text-body-muted italic">
+                          {statusPhase}
+                        </span>
+                      )}
+                      {(turnTokens > 0 || turnCost > 0) && (
+                        <span
+                          className="text-xs text-body-faint font-mono tabular-nums"
+                          aria-label={`Turn usage: ${turnTokens > 0 ? formatTokens(turnTokens) + " tokens" : ""}${turnCost > 0 ? `, $${turnCost.toFixed(4)}` : ""}`}
+                        >
+                          {turnTokens > 0 && <>{formatTokens(turnTokens)} tokens</>}
+                          {turnCost > 0 && <>{turnTokens > 0 ? " \u00b7 " : ""}${turnCost.toFixed(4)}</>}
+                        </span>
+                      )}
+                      <button
+                        onClick={stopGeneration}
+                        aria-label="Stop generating"
+                        className="w-6 h-6 flex items-center justify-center rounded-full border border-border text-body-muted
+                          hover:border-accent/40 hover:text-accent-focus hover:bg-accent-focus/5 transition-all"
+                      >
+                        <svg className="w-2.5 h-2.5" viewBox="0 0 10 10" fill="currentColor">
+                          <rect width="10" height="10" rx="1" />
+                        </svg>
+                      </button>
                     </div>
                   </div>
                 </div>
               )}
 
-              {/* Status bar: dots + cost + stop */}
-              <div className="flex justify-start">
-                <div className="flex items-center gap-3 px-2">
-                  <div className="flex items-center gap-1">
-                    <span className="w-1.5 h-1.5 bg-accent rounded-full animate-bounce" />
-                    <span
-                      className="w-1.5 h-1.5 bg-accent rounded-full animate-bounce"
-                      style={{ animationDelay: "0.15s" }}
-                    />
-                    <span
-                      className="w-1.5 h-1.5 bg-accent rounded-full animate-bounce"
-                      style={{ animationDelay: "0.3s" }}
-                    />
-                  </div>
-                  {statusPhase && (
-                    <span className="text-xs text-body-muted italic">
-                      {statusPhase}
-                    </span>
-                  )}
-                  {(turnTokens > 0 || turnCost > 0) && (
-                    <span
-                      className="text-xs text-body-faint font-mono tabular-nums"
-                      aria-label={`Turn usage: ${turnTokens > 0 ? formatTokens(turnTokens) + " tokens" : ""}${turnCost > 0 ? `, $${turnCost.toFixed(4)}` : ""}`}
-                    >
-                      {turnTokens > 0 && <>{formatTokens(turnTokens)} tokens</>}
-                      {turnCost > 0 && <>{turnTokens > 0 ? " \u00b7 " : ""}${turnCost.toFixed(4)}</>}
-                    </span>
-                  )}
-                  <button
-                    onClick={stopGeneration}
-                    aria-label="Stop generating"
-                    className="w-6 h-6 flex items-center justify-center rounded-full border border-border text-body-muted
-                      hover:border-accent/40 hover:text-accent-focus hover:bg-accent-focus/5 transition-all"
-                  >
-                    <svg className="w-2.5 h-2.5" viewBox="0 0 10 10" fill="currentColor">
-                      <rect width="10" height="10" rx="1" />
-                    </svg>
-                  </button>
-                </div>
-              </div>
+              <div ref={bottomRef} />
             </div>
-          )}
+          </div>
 
-          <div ref={bottomRef} />
+          {/* Input */}
+          <div className="print-hide">
+            <MessageInput
+              onSend={sendMessage}
+              // Only disable when fully disconnected — typing while
+              // streaming is fine, messages are queued and sent in turn.
+              disabled={!connected}
+              // Identify this chat panel so its draft text survives
+              // mount/unmount (e.g., navigating to documents and
+              // back).  ``project_id`` is preferred when the backend
+              // provides it (a stable canonical identifier);
+              // ``project_dir`` is the path-based fallback that's
+              // always present.  Both names live on ``SessionInfo``;
+              // pass null until ``getSession()`` resolves so the input
+              // stays ephemeral during the brief loading window
+              // instead of binding to a placeholder id.
+              panelId={
+                sessionInfo && sessionInfo.thread_id
+                  ? {
+                      projectId:
+                        sessionInfo.project_id ?? sessionInfo.project_dir,
+                      type: "chat",
+                      threadId: sessionInfo.thread_id,
+                    }
+                  : null
+              }
+              placeholder={
+                !connected
+                  ? "Connecting..."
+                  : queuedMessages > 0
+                    ? `${queuedMessages} message${queuedMessages === 1 ? "" : "s"} queued — type another...`
+                    : streaming
+                      ? "Type your next message — it'll send when this turn finishes..."
+                      : undefined
+              }
+            />
+          </div>
         </div>
-      </div>
 
-      {/* Input */}
-      <div className="print-hide">
-        <MessageInput
-          onSend={sendMessage}
-          // Only disable when fully disconnected — typing while
-          // streaming is fine, messages are queued and sent in turn.
-          disabled={!connected}
-          // Identify this chat panel so its draft text survives
-          // mount/unmount (e.g., navigating to documents and
-          // back).  ``project_id`` is preferred when the backend
-          // provides it (a stable canonical identifier);
-          // ``project_dir`` is the path-based fallback that's
-          // always present.  Both names live on ``SessionInfo``;
-          // pass null until ``getSession()`` resolves so the input
-          // stays ephemeral during the brief loading window
-          // instead of binding to a placeholder id.
-          panelId={
-            sessionInfo && sessionInfo.thread_id
-              ? {
-                  projectId:
-                    sessionInfo.project_id ?? sessionInfo.project_dir,
-                  type: "chat",
-                  threadId: sessionInfo.thread_id,
-                }
-              : null
-          }
-          placeholder={
-            !connected
-              ? "Connecting..."
-              : queuedMessages > 0
-                ? `${queuedMessages} message${queuedMessages === 1 ? "" : "s"} queued — type another...`
-                : streaming
-                  ? "Type your next message — it'll send when this turn finishes..."
-                  : undefined
-          }
+        <ToolLogPane
+          events={toolEvents}
+          open={logPaneOpen}
+          unread={logLineCount > seenLogCount}
+          width={logPaneWidth}
+          onOpenChange={handleLogPaneOpenChange}
+          onWidthChange={setLogPaneWidth}
         />
       </div>
     </div>

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { getProtocolTree, getSession } from "../api/client";
 import { useChat } from "../hooks/useChat";
-import type { ChatMessage as ChatMessageType, SessionInfo, ToolEvent } from "../types";
+import type { ChatMessage as ChatMessageType, SessionInfo } from "../types";
 import ChatMessage from "./ChatMessage";
 import EmptyState from "./EmptyState";
 import ErrorBanner from "./ErrorBanner";
@@ -20,15 +20,12 @@ function isVisibleChatMessage(message: ChatMessageType): boolean {
   return message.role !== "tool" && message.content.trim().length > 0;
 }
 
-function collectToolEvents(messages: ChatMessageType[]): ToolEvent[] {
-  return messages.flatMap((message) => message.toolEvents ?? []);
-}
-
 const DEFAULT_LOG_PANE_WIDTH = 460;
 
 export default function ChatPanel() {
   const {
     messages,
+    logLines,
     turnCost,
     turnTokens,
     sessionTokens,
@@ -55,15 +52,14 @@ export default function ChatPanel() {
   const autoStarted = useRef(false);
   const [protocolExists, setProtocolExists] = useState<boolean | null>(null);
   const [sessionInfo, setSessionInfo] = useState<SessionInfo | null>(null);
-  const [logPaneOpen, setLogPaneOpen] = useState(false);
+  const [logPaneOpen, setLogPaneOpen] = useState(true);
   const [logPaneWidth, setLogPaneWidth] = useState(DEFAULT_LOG_PANE_WIDTH);
   const [seenLogCount, setSeenLogCount] = useState(0);
   const visibleMessages = useMemo(
     () => messages.filter(isVisibleChatMessage),
     [messages],
   );
-  const toolEvents = useMemo(() => collectToolEvents(messages), [messages]);
-  const logLineCount = toolEvents.length;
+  const logLineCount = logLines.length;
 
   // Check if a protocol directory exists
   useEffect(() => {
@@ -412,7 +408,7 @@ export default function ChatPanel() {
         </div>
 
         <ToolLogPane
-          events={toolEvents}
+          events={logLines}
           open={logPaneOpen}
           unread={logLineCount > seenLogCount}
           width={logPaneWidth}

--- a/web/src/components/ToolLogPane.tsx
+++ b/web/src/components/ToolLogPane.tsx
@@ -76,7 +76,7 @@ export default function ToolLogPane({
     return () => dragCleanupRef.current?.();
   }, []);
 
-  if (events.length === 0) return null;
+  if (events.length === 0 && !open) return null;
 
   const handleResizeStart = (event: PointerEvent<HTMLButtonElement>) => {
     event.preventDefault();
@@ -147,7 +147,7 @@ export default function ToolLogPane({
           <div className="flex items-center justify-between border-b border-white/10 bg-[#121a20] px-2 py-3 sm:px-4">
             <div className="min-w-0">
               <div className="truncate font-mono text-xs uppercase tracking-[0.16em] text-white/55">
-                PowerShell
+                Execution Log
               </div>
               <div className="mt-0.5 text-xs text-white/40">
                 {events.length} {events.length === 1 ? "line" : "lines"}
@@ -170,6 +170,9 @@ export default function ToolLogPane({
           </div>
 
           <div className="min-h-0 flex-1 overflow-auto px-4 py-3">
+            {commands.length === 0 ? (
+              <span className="font-mono text-xs text-white/35">Waiting for logs…</span>
+            ) : (
             <pre className="m-0 whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-[#d6e2ef]">
               {commands.map((command, index) => (
                 <span className="block" key={`${command}-${index}`}>
@@ -178,6 +181,7 @@ export default function ToolLogPane({
                 </span>
               ))}
             </pre>
+            )}
             <div ref={bottomRef} />
           </div>
         </div>

--- a/web/src/components/ToolLogPane.tsx
+++ b/web/src/components/ToolLogPane.tsx
@@ -9,7 +9,7 @@ const UNREAD_BADGE_LIMIT = 99;
 interface ToolLogPaneProps {
   events: ToolEvent[];
   open: boolean;
-  unread: boolean;
+  unreadCount: number;
   width: number;
   onOpenChange: (open: boolean) => void;
   onWidthChange: (width: number) => void;
@@ -55,7 +55,7 @@ function CopyButton({ text }: { text: string }) {
 export default function ToolLogPane({
   events,
   open,
-  unread,
+  unreadCount,
   width,
   onOpenChange,
   onWidthChange,
@@ -65,6 +65,7 @@ export default function ToolLogPane({
   const commands = events.map(formatToolCommand);
   const script = commands.map((command) => `PS clarity> ${command}`).join("\n");
   const paneWidth = open ? clampPaneWidth(width) : COLLAPSED_PANE_WIDTH;
+  const unread = unreadCount > 0;
 
   useEffect(() => {
     if (!open) return;
@@ -130,9 +131,11 @@ export default function ToolLogPane({
               <path d="M13 15h3" />
               <rect x="3.5" y="5" width="17" height="14" rx="2" />
             </svg>
-            <span className="absolute -right-1 -top-1 min-w-5 rounded-full bg-[#14b8a6] px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm">
-              {events.length > UNREAD_BADGE_LIMIT ? `${UNREAD_BADGE_LIMIT}+` : events.length}
-            </span>
+            {unread ? (
+              <span className="absolute -right-1 -top-1 min-w-5 rounded-full bg-[#14b8a6] px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm">
+                {unreadCount > UNREAD_BADGE_LIMIT ? `${UNREAD_BADGE_LIMIT}+` : unreadCount}
+              </span>
+            ) : null}
           </button>
         </div>
       ) : (

--- a/web/src/components/ToolLogPane.tsx
+++ b/web/src/components/ToolLogPane.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useRef, useState, type PointerEvent } from "react";
+import type { ToolEvent } from "../types";
+
+const COLLAPSED_PANE_WIDTH = 56;
+const MIN_PANE_WIDTH = 320;
+const MAX_PANE_WIDTH = 760;
+const UNREAD_BADGE_LIMIT = 99;
+
+interface ToolLogPaneProps {
+  events: ToolEvent[];
+  open: boolean;
+  unread: boolean;
+  width: number;
+  onOpenChange: (open: boolean) => void;
+  onWidthChange: (width: number) => void;
+}
+
+function clampPaneWidth(width: number): number {
+  return Math.min(MAX_PANE_WIDTH, Math.max(MIN_PANE_WIDTH, width));
+}
+
+function formatToolCommand(event: ToolEvent): string {
+  const detail = event.detail.trim();
+  if (!detail) return `${event.tool}: executing`;
+  return `${event.tool}: ${detail}`;
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    void navigator.clipboard?.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="inline-flex items-center gap-1 rounded px-1.5 py-1 text-[11px] text-white/65 transition-colors hover:bg-white/10 hover:text-white sm:px-2"
+      title="Copy log"
+      aria-label="Copy log"
+    >
+      <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="5.5" y="5.5" width="8" height="8" rx="1.5" />
+        <path d="M10.5 5.5V3a1.5 1.5 0 0 0-1.5-1.5H3A1.5 1.5 0 0 0 1.5 3v6A1.5 1.5 0 0 0 3 10.5h2.5" />
+      </svg>
+      <span className="hidden sm:inline">{copied ? "Copied" : "Copy"}</span>
+    </button>
+  );
+}
+
+export default function ToolLogPane({
+  events,
+  open,
+  unread,
+  width,
+  onOpenChange,
+  onWidthChange,
+}: ToolLogPaneProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const dragCleanupRef = useRef<(() => void) | null>(null);
+  const commands = events.map(formatToolCommand);
+  const script = commands.map((command) => `PS clarity> ${command}`).join("\n");
+  const paneWidth = open ? clampPaneWidth(width) : COLLAPSED_PANE_WIDTH;
+
+  useEffect(() => {
+    if (!open) return;
+    if (typeof bottomRef.current?.scrollIntoView !== "function") return;
+    bottomRef.current.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [events.length, open]);
+
+  useEffect(() => {
+    return () => dragCleanupRef.current?.();
+  }, []);
+
+  if (events.length === 0) return null;
+
+  const handleResizeStart = (event: PointerEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    dragCleanupRef.current?.();
+    const startX = event.clientX;
+    const startWidth = paneWidth;
+
+    const handleResizeMove = (moveEvent: globalThis.PointerEvent) => {
+      onWidthChange(clampPaneWidth(startWidth + startX - moveEvent.clientX));
+    };
+    const handleResizeEnd = () => {
+      window.removeEventListener("pointermove", handleResizeMove);
+      window.removeEventListener("pointerup", handleResizeEnd);
+      dragCleanupRef.current = null;
+    };
+
+    window.addEventListener("pointermove", handleResizeMove);
+    window.addEventListener("pointerup", handleResizeEnd);
+    dragCleanupRef.current = handleResizeEnd;
+  };
+
+  return (
+    <aside
+      aria-label="Execution log"
+      data-open={open ? "true" : "false"}
+      data-testid="log-side-pane"
+      className="print-hide relative flex h-full shrink-0 overflow-hidden border-l border-white/10 bg-[#0b1115] text-white transition-[width] duration-300 ease-out"
+      style={{
+        width: `${paneWidth}px`,
+        maxWidth: open ? "100%" : `${COLLAPSED_PANE_WIDTH}px`,
+      }}
+    >
+      {!open ? (
+        <div className="flex h-full w-full items-start justify-center bg-surface/95 pt-4">
+          <button
+            type="button"
+            onClick={() => onOpenChange(true)}
+            aria-label="Open execution log"
+            aria-expanded="false"
+            title="Open execution log"
+            data-testid="log-pane-toggle"
+            data-unread={unread ? "true" : "false"}
+            className={`relative flex h-10 w-10 items-center justify-center rounded-full border border-border-strong bg-surface text-body-muted shadow-lg transition-all duration-200 hover:border-accent/50 hover:text-accent-focus ${
+              unread
+                ? "border-accent/70 text-accent-focus shadow-[0_0_0_4px_rgba(20,184,166,0.12),0_0_28px_rgba(20,184,166,0.55)]"
+                : ""
+            }`}
+          >
+            <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m8 9 3 3-3 3" />
+              <path d="M13 15h3" />
+              <rect x="3.5" y="5" width="17" height="14" rx="2" />
+            </svg>
+            <span className="absolute -right-1 -top-1 min-w-5 rounded-full bg-[#14b8a6] px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm">
+              {events.length > UNREAD_BADGE_LIMIT ? `${UNREAD_BADGE_LIMIT}+` : events.length}
+            </span>
+          </button>
+        </div>
+      ) : (
+        <div className="flex min-w-0 flex-1 flex-col">
+          <button
+            type="button"
+            onPointerDown={handleResizeStart}
+            aria-label="Resize execution log"
+            data-testid="log-pane-resize-handle"
+            className="absolute left-0 top-0 z-10 h-full w-2 cursor-col-resize border-l border-[#14b8a6]/0 transition-colors hover:border-[#14b8a6]/70 focus:outline-none focus-visible:border-[#14b8a6]"
+          />
+          <div className="flex items-center justify-between border-b border-white/10 bg-[#121a20] px-2 py-3 sm:px-4">
+            <div className="min-w-0">
+              <div className="truncate font-mono text-xs uppercase tracking-[0.16em] text-white/55">
+                PowerShell
+              </div>
+              <div className="mt-0.5 text-xs text-white/40">
+                {events.length} {events.length === 1 ? "line" : "lines"}
+              </div>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <CopyButton text={script} />
+              <button
+                type="button"
+                onClick={() => onOpenChange(false)}
+                className="flex h-7 w-7 items-center justify-center rounded text-white/55 transition-colors hover:bg-white/10 hover:text-white"
+                aria-label="Close execution log"
+                title="Close execution log"
+              >
+                <svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round">
+                  <path d="M4 4l8 8M12 4l-8 8" />
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-auto px-4 py-3">
+            <pre className="m-0 whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-[#d6e2ef]">
+              {commands.map((command, index) => (
+                <span className="block" key={`${command}-${index}`}>
+                  <span className="text-[#5eead4]">PS clarity&gt;</span>{" "}
+                  <code>{command}</code>
+                </span>
+              ))}
+            </pre>
+            <div ref={bottomRef} />
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/web/src/hooks/useChat.tsx
+++ b/web/src/hooks/useChat.tsx
@@ -27,6 +27,8 @@ export interface ErrorInfo {
 
 export interface ChatState {
   messages: ChatMessage[];
+  /** Flat log of all tool/log events, never reset by load_history. */
+  logLines: ToolEvent[];
   pendingTools: ToolEvent[];
   /** Cumulative cost (USD) for the current streaming turn. */
   turnCost: number;
@@ -143,6 +145,7 @@ function appendTurnLog(state: ChatState, event: ToolEvent): ChatState {
   return {
     ...state,
     messages: appendToolLogMessage(state.messages, event),
+    logLines: [...state.logLines, event],
     pendingTools: [],
   };
 }
@@ -351,6 +354,7 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
     case "clear":
       return {
         messages: [],
+        logLines: [],
         pendingTools: [],
         turnCost: 0,
         turnTokens: 0,
@@ -420,6 +424,7 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
 
 export const initialState: ChatState = {
   messages: [],
+  logLines: [],
   pendingTools: [],
   turnCost: 0,
   turnTokens: 0,
@@ -443,6 +448,8 @@ export const initialState: ChatState = {
 
 export interface UseChatReturn {
   messages: ChatMessage[];
+  /** All log/tool events accumulated since page load, never wiped by history loads. */
+  logLines: ToolEvent[];
   pendingTools: ToolEvent[];
   turnCost: number;
   turnTokens: number;
@@ -639,6 +646,7 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
 
   const value: UseChatReturn = {
     messages: state.messages,
+    logLines: state.logLines,
     pendingTools: state.pendingTools,
     turnCost: state.turnCost,
     turnTokens: state.turnTokens,

--- a/web/src/hooks/useChat.tsx
+++ b/web/src/hooks/useChat.tsx
@@ -63,6 +63,7 @@ export type ChatAction =
   | { type: "send_message"; content: string }
   | { type: "enqueue_message"; content: string }
   | { type: "dequeue_message" }
+  | { type: "log_event"; source: string; level: string; message: string }
   | { type: "tool_event"; tool: string; detail: string }
   | { type: "text_delta"; content: string }
   | { type: "cost_event"; cost_usd: number }
@@ -92,6 +93,59 @@ export type ChatAction =
       sourceChapter: number;
       sourceTurnCount: number;
     };
+
+function toolEventContent(event: ToolEvent): string {
+  const detail = event.detail.trim();
+  return detail ? `${event.tool}: ${detail}` : `${event.tool}: executing`;
+}
+
+function isTerminalOnlyMessage(message: ChatMessage): boolean {
+  return Boolean(message.toolEvents?.length) && (
+    message.role === "tool" ||
+    (message.role === "assistant" && message.content.trim().length === 0)
+  );
+}
+
+function hasConversationContent(messages: ChatMessage[]): boolean {
+  return messages.some((message) => !isTerminalOnlyMessage(message));
+}
+
+function appendToolLogMessage(
+  messages: ChatMessage[],
+  event: ToolEvent,
+): ChatMessage[] {
+  const next = [...messages];
+  const last = next[next.length - 1];
+  if (last && isTerminalOnlyMessage(last)) {
+    const toolEvents = [...(last.toolEvents ?? []), event];
+    next[next.length - 1] = {
+      ...last,
+      content: toolEvents.map(toolEventContent).join("\n"),
+      toolEvents,
+      timestamp: Date.now(),
+    };
+    return next;
+  }
+
+  return [
+    ...next,
+    {
+      id: crypto.randomUUID(),
+      role: "tool",
+      content: toolEventContent(event),
+      toolEvents: [event],
+      timestamp: Date.now(),
+    },
+  ];
+}
+
+function appendTurnLog(state: ChatState, event: ToolEvent): ChatState {
+  return {
+    ...state,
+    messages: appendToolLogMessage(state.messages, event),
+    pendingTools: [],
+  };
+}
 
 export function chatReducer(state: ChatState, action: ChatAction): ChatState {
   switch (action.type) {
@@ -127,54 +181,53 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         outgoingQueue: state.outgoingQueue.slice(1),
       };
 
+    case "log_event": {
+      const detail =
+        action.level === "info" ? action.message : `${action.level}: ${action.message}`;
+      return appendTurnLog(state, {
+        tool: action.source || "backend",
+        detail,
+      });
+    }
+
     case "text_delta":
       return {
         ...state,
         streamingText: state.streamingText + action.content,
       };
 
-    case "tool_event": {
-      // Commit any accumulated streaming text, then commit the tool
-      // event as its own message — everything stays in time order.
-      const msgs = [...state.messages];
-      let newStreamingText = state.streamingText;
-      if (state.streamingText) {
-        msgs.push({
-          id: crypto.randomUUID(),
-          role: "assistant",
-          content: state.streamingText,
-          timestamp: Date.now(),
-        });
-        newStreamingText = "";
-      }
-      msgs.push({
-        id: crypto.randomUUID(),
-        role: "tool",
-        content: `${action.tool}: ${action.detail}`,
-        toolEvents: [{ tool: action.tool, detail: action.detail }],
-        timestamp: Date.now(),
+    case "tool_event":
+      return appendTurnLog(state, {
+        tool: action.tool,
+        detail: action.detail,
       });
-      return {
-        ...state,
-        messages: msgs,
-        streamingText: newStreamingText,
-        pendingTools: [],
-      };
-    }
 
-    case "cost_event":
-      return {
+    case "cost_event": {
+      const next = {
         ...state,
         turnCost: action.cost_usd,
       };
+      if (!state.streaming) return next;
+      return appendTurnLog(next, {
+        tool: "cost",
+        detail: `$${action.cost_usd.toFixed(4)}`,
+      });
+    }
 
     case "usage_event": {
       const turnDelta = action.input_tokens + action.output_tokens;
-      return {
+      const next = {
         ...state,
         turnTokens: state.turnTokens + turnDelta,
         sessionTokens: state.sessionTokens + turnDelta,
       };
+      if (!state.streaming) return next;
+      return appendTurnLog(next, {
+        tool: "usage",
+        detail:
+          `${action.input_tokens.toLocaleString()} input tokens, ` +
+          `${action.output_tokens.toLocaleString()} output tokens`,
+      });
     }
 
     case "receive_response": {
@@ -205,16 +258,22 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
     }
 
     case "start_process":
-      return {
-        ...state,
-        currentProcess: action.name,
-        streaming: true,
-        pendingTools: [],
-        turnCost: 0,
-        turnTokens: 0,
-        streamingText: "",
-        error: null,
-      };
+      return appendTurnLog(
+        {
+          ...state,
+          currentProcess: action.name,
+          streaming: true,
+          pendingTools: [],
+          turnCost: 0,
+          turnTokens: 0,
+          streamingText: "",
+          error: null,
+        },
+        {
+          tool: "process",
+          detail: `starting ${action.name}`,
+        },
+      );
 
     case "process_starting":
       return {
@@ -231,34 +290,57 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
         ],
       };
 
-    case "model_changed":
-      return {
+    case "model_changed": {
+      const next = {
         ...state,
         activeModel: action.model,
         activeTier: action.tier,
         autoModel: action.auto,
       };
+      if (!state.streaming) return next;
+      return appendTurnLog(next, {
+        tool: "model",
+        detail: `${action.tier}: ${action.model}${action.auto ? " (auto)" : ""}`,
+      });
+    }
 
-    case "error_event":
-      return {
+    case "error_event": {
+      const next = {
         ...state,
         error: action.error,
         streaming: false,
         statusPhase: null,
       };
+      if (!state.streaming) return next;
+      return appendTurnLog(next, {
+        tool: "error",
+        detail: action.error.message,
+      });
+    }
 
-    case "warning_event":
-      // Non-fatal: show a dismissible banner without interrupting streaming.
-      return {
+    case "warning_event": {
+      const next = {
         ...state,
         error: { message: action.message, category: "warning", retryable: false },
       };
+      if (!state.streaming) return next;
+      return appendTurnLog(next, {
+        tool: "warning",
+        detail: action.message,
+      });
+    }
 
-    case "status_event":
-      return {
+    case "status_event": {
+      const next = {
         ...state,
         statusPhase: action.phase,
       };
+      if (!state.streaming) return next;
+      return appendTurnLog(next, {
+        tool: "status",
+        detail: action.phase,
+      });
+    }
 
     case "dismiss_error":
       return {
@@ -300,7 +382,10 @@ export function chatReducer(state: ChatState, action: ChatAction): ChatState {
       // needs to fire in that case).
       return {
         ...state,
-        messages: action.messages,
+        messages:
+          action.messages.length === 0 && !hasConversationContent(state.messages)
+            ? state.messages
+            : action.messages,
         historyLoaded: true,
       };
 
@@ -431,6 +516,14 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
   // rapid-fire tool_use events that arrived within the same render cycle).
   const handleWsMessage = useCallback((msg: WsServerMessage) => {
     switch (msg.type) {
+      case "log":
+        dispatch({
+          type: "log_event",
+          source: msg.source,
+          level: msg.level,
+          message: msg.message,
+        });
+        break;
       case "tool_use":
         dispatch({ type: "tool_event", tool: msg.tool, detail: msg.detail });
         break;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -7,6 +7,7 @@ export type WsClientMessage =
 
 // WebSocket messages: server → client
 export type WsServerMessage =
+  | { type: "log"; source: string; level: string; message: string }
   | { type: "tool_use"; tool: string; detail: string }
   | { type: "text_delta"; content: string }
   | { type: "cost"; cost_usd: number }


### PR DESCRIPTION
<img width="1790" height="1746" alt="image" src="https://github.com/user-attachments/assets/e1856862-324a-49b4-98a7-be95a60abe11" />
<img width="1819" height="1737" alt="image" src="https://github.com/user-attachments/assets/22290510-81ca-43ed-b068-cb135a0b7251" />


## Summary

- Adds an execution log side pane to the web UI and opens it by default.
- Keeps the pane visible on startup, including when no events have arrived yet.
- Preserves execution log lines across initial history loading so early backend events are not wiped.
- Mirrors the web server process stdout/stderr into the execution log so the pane reflects the terminal output, including startup lines, Uvicorn requests, WebSocket accepts, and connection events.
- Logs each LLM turn's generation lifecycle, including provider, model, tier, process, auth mode, redacted credential source, endpoint without query string, tool count, first streamed text, token usage, completion, and failures.

## Validation

- `cd web && npm test -- --reporter=verbose`
- `cd web && npm run build`
- `uv run pytest tests\test_web_log_broadcast.py tests\test_packet_status.py -q`
- `uv run pytest tests\test_web_session_resume.py tests\test_web_log_broadcast.py -q`
- `uv run ruff check src\clarity_agent\web\log_broadcast.py src\clarity_agent\web\app.py tests\test_web_log_broadcast.py`
- `uv run ruff check src\clarity_agent\web\session_manager.py tests\test_web_session_resume.py`
- `uv run pyright src\clarity_agent\web\log_broadcast.py src\clarity_agent\web\app.py tests\test_web_log_broadcast.py`
- `uv run pyright src\clarity_agent\web\session_manager.py`
- Local web session emitted `[generation]` execution-log lines for a chat turn with credential values redacted.

Known baseline: full-repo pyright still reports unrelated test-suite typing errors outside the changed runtime file.