### PR TITLE
Add MCP generate_packet tool

### DIFF
--- a/.clarity-protocol/decisions/decision-01-product-priority.md
+++ b/.clarity-protocol/decisions/decision-01-product-priority.md
@@ -11,7 +11,7 @@
 |------|--------|
 | 2026-03-03 | Decision made. Three existing products (AGENTS.md snippet, web app, CLI); six new products prioritized. |
 | 2026-04-06 | Integration strategy exploration validated MCP-first approach; confirmed "MCP as universal connector" thesis is strong given near-universal adoption across professional tools. |
-| 2026-06-08 | Review: 3 of 6 priorities now implemented. #1 MCP hybrid (8-tool server + `clarity embed` + npx runner). #3 IDE integration (VS Code extension with protocol sidebar). #5 Desktop app (Windows + Linux). Original products also evolved: coding agent integration now uses MCP instead of shell invocations. |
+| 2026-06-08 | Review: 3 of 6 priorities implemented. #1 MCP hybrid (focused MCP server + `clarity embed` + npx runner). #3 IDE integration (VS Code extension with protocol sidebar). #5 Desktop app (Windows + Linux). Original products also evolved: coding agent integration uses MCP instead of shell invocations. |
 
 ## Question
 
@@ -40,7 +40,7 @@ Which new products should we prioritize exploring beyond the existing three (AGE
 
 **Priority order:**
 
-1. **MCP-enhanced hybrid** — first new product to explore. The path to implementation is shortest from where we are: MCP exposure of Layer 3 is already in the near-term work plan, and the hybrid combines that with a light guide loaded as context. Validates the Layer 3 portability thesis. Medium reach today, but MCP adoption is growing. ✅ *Implemented: MCP server with 8-tool surface, `clarity embed` for project setup, npx runner built (not yet published).*
+1. **MCP-enhanced hybrid** — first new product to explore. The path to implementation is shortest from where we are: MCP exposure of Layer 3 is already in the near-term work plan, and the hybrid combines that with a light guide loaded as context. Validates the Layer 3 portability thesis. Medium reach today, but MCP adoption is growing. ✅ *Implemented: MCP server with focused tool surface, `clarity embed` for project setup, npx runner built (not yet published).*
 
 2. **General-purpose AI integration (light)** — second priority. Higher reach than the hybrid (anyone with any AI tool), but blocked on Layer 1 formalization → light expression, which is on a separate timeline. When it ships, this is likely the highest-reach product form.
 

--- a/.clarity-protocol/decisions/decision-02-mcp-surface-area.md
+++ b/.clarity-protocol/decisions/decision-02-mcp-surface-area.md
@@ -21,7 +21,7 @@ Additionally, 6 MCP resources provide passive context: `clarity://summary`, `cla
 
 ## Rationale
 
-A coding agent needs a focused set of actions, not a menu of everything the system can do. The key insight: `run_clarity` handles routing (it inlines the appropriate process guide), so the agent doesn't need separate process-discovery or process-selection tools. Similarly, `write_protocol_document` auto-records content hashes, eliminating the need for a separate `record_packet_status` tool. `generate_packet` is exposed because sharing a synthesized packet is a common endpoint for MCP users, and Markdown output can be returned directly without adding file-write permissions.
+A coding agent needs a focused set of actions, not a menu of everything the system can do. The key insight: `run_clarity` handles routing (it inlines the appropriate process guide), so the agent doesn't need separate process-discovery or process-selection tools. Similarly, `write_protocol_document` auto-records content hashes, eliminating the need for a separate `record_packet_status` tool. `generate_packet` is exposed because sharing a synthesized packet is a common endpoint for MCP users. It returns Markdown directly by default and DOCX as an MCP embedded resource, avoiding file-write permissions while preserving a binary document path.
 
 The internal functions remain available for the web UI, CLI, and desktop app where a richer interface is appropriate and the user has different interaction patterns (browsing, clicking, selecting).
 

--- a/.clarity-protocol/decisions/decision-02-mcp-surface-area.md
+++ b/.clarity-protocol/decisions/decision-02-mcp-surface-area.md
@@ -5,22 +5,23 @@
 
 ## Context
 
-The MCP server needed a tool surface for coding agents. The Python codebase has ~20+ callable functions (init_protocol, list_processes, read_process_guide, generate_packet, get_mailbox_status, check_failure_state, snapshot_mailbox, list_mailbox_items, read_mailbox_item, archive_mailbox_item, etc.). Exposing all of them would create a large, confusing tool surface that coding agents would struggle to navigate effectively.
+The MCP server needed a tool surface for coding agents. The Python codebase has many callable functions (init_protocol, list_processes, read_process_guide, get_mailbox_status, check_failure_state, snapshot_mailbox, list_mailbox_items, read_mailbox_item, archive_mailbox_item, etc.). Exposing all of them would create a large, confusing tool surface that coding agents would struggle to navigate effectively.
 
 ## Decision
 
-Expose exactly 8 tools as the public MCP surface. All other functions remain importable Python for the web/CLI/desktop modes but are hidden from MCP clients.
+Expose exactly 9 tools as the public MCP surface. All other functions remain importable Python for the web/CLI/desktop modes but are hidden from MCP clients.
 
-The 8 tools are organized around three workflow moments:
+The 9 tools are organized around four workflow moments:
 - **Before acting:** `check_decision`
 - **Assess and navigate:** `run_clarity`, `get_packet_status`
 - **Read, write, record:** `read_protocol_document`, `write_protocol_document`, `record_decision`, `record_failure`, `record_suggestion`
+- **Share and review:** `generate_packet`
 
 Additionally, 6 MCP resources provide passive context: `clarity://summary`, `clarity://decisions`, `clarity://behaviors`, `clarity://processes/{name}`, `clarity://thinkers/{name}`, and `clarity://protocol/{path}`.
 
 ## Rationale
 
-A coding agent needs a focused set of actions, not a menu of everything the system can do. The key insight: `run_clarity` handles routing (it inlines the appropriate process guide), so the agent doesn't need separate process-discovery or process-selection tools. Similarly, `write_protocol_document` auto-records content hashes, eliminating the need for a separate `record_packet_status` tool.
+A coding agent needs a focused set of actions, not a menu of everything the system can do. The key insight: `run_clarity` handles routing (it inlines the appropriate process guide), so the agent doesn't need separate process-discovery or process-selection tools. Similarly, `write_protocol_document` auto-records content hashes, eliminating the need for a separate `record_packet_status` tool. `generate_packet` is exposed because sharing a synthesized packet is a common endpoint for MCP users, and Markdown output can be returned directly without adding file-write permissions.
 
 The internal functions remain available for the web UI, CLI, and desktop app where a richer interface is appropriate and the user has different interaction patterns (browsing, clicking, selecting).
 

--- a/.clarity-protocol/solution/architecture.md
+++ b/.clarity-protocol/solution/architecture.md
@@ -378,6 +378,8 @@ Infrastructure is exposed via **MCP** rather than invoked directly as Python com
 | `record_suggestion` | Record a suggestion to update a protocol document | Anytime |
 | `generate_packet` | Generate a shareable review packet from protocol content | When sharing or reviewing the protocol |
 
+`generate_packet` keeps selection at the view level (`complete`, `short`, `engineer`, etc.) and does not expose lower-level packet source IDs. It returns Markdown text by default, or an MCP embedded DOCX resource when `output_format="docx"`.
+
 **Design decision: small public surface, rich internal library.** Only these 9 tools are exposed as MCP tools. Additional functions (`init_protocol`, `list_processes`, `read_process_guide`, `get_mailbox_status`, `check_failure_state`, `snapshot_mailbox`, etc.) remain importable Python for the web/CLI/desktop modes but are deliberately hidden from the MCP surface. The rationale: a coding agent needs a focused set of actions; the `run_clarity` tool handles routing and inlines process guides, so the agent doesn't need separate process-discovery tools.
 
 **MCP resources** (passive context, not actions):

--- a/.clarity-protocol/solution/architecture.md
+++ b/.clarity-protocol/solution/architecture.md
@@ -364,7 +364,7 @@ The staleness tracking infrastructure (Layer 3) could potentially be extended to
 
 Infrastructure is exposed via **MCP** rather than invoked directly as Python commands. The MCP server (`src/clarity_agent/mcp/server.py`) wraps existing Python infrastructure with a focused tool surface designed for how coding agents actually work.
 
-**The 8-tool public surface:**
+**The 9-tool public surface:**
 
 | Tool | Purpose | Workflow moment |
 |---|---|---|
@@ -376,8 +376,9 @@ Infrastructure is exposed via **MCP** rather than invoked directly as Python com
 | `record_decision` | Create a structured decision record with context, rationale, alternatives | After making a significant choice |
 | `record_failure` | Record a potential failure mode to the brainstorm mailbox | During failure brainstorming |
 | `record_suggestion` | Record a suggestion to update a protocol document | Anytime |
+| `generate_packet` | Generate a shareable review packet from protocol content | When sharing or reviewing the protocol |
 
-**Design decision: small public surface, rich internal library.** Only these 8 tools are exposed as MCP tools. Additional functions (`init_protocol`, `list_processes`, `read_process_guide`, `generate_packet`, `get_mailbox_status`, `check_failure_state`, `snapshot_mailbox`, etc.) remain importable Python for the web/CLI/desktop modes but are deliberately hidden from the MCP surface. The rationale: a coding agent needs a focused set of actions; the `run_clarity` tool handles routing and inlines process guides, so the agent doesn't need separate process-discovery tools.
+**Design decision: small public surface, rich internal library.** Only these 9 tools are exposed as MCP tools. Additional functions (`init_protocol`, `list_processes`, `read_process_guide`, `get_mailbox_status`, `check_failure_state`, `snapshot_mailbox`, etc.) remain importable Python for the web/CLI/desktop modes but are deliberately hidden from the MCP surface. The rationale: a coding agent needs a focused set of actions; the `run_clarity` tool handles routing and inlines process guides, so the agent doesn't need separate process-discovery tools.
 
 **MCP resources** (passive context, not actions):
 

--- a/src/clarity_agent/mcp/README.md
+++ b/src/clarity_agent/mcp/README.md
@@ -137,7 +137,7 @@ When the agent calls `run_clarity()`, the server checks the project directory fo
 
 `write_protocol_document` automatically records content hashes so the staleness tracker stays current without a separate `record_packet_status` call.
 
-`generate_packet` takes a packet view name such as `complete`, `short`, or `engineer`. It returns Markdown packets directly. For binary formats such as DOCX, it confirms the packet can be generated and reports the byte size; use the web UI or CLI to download the file.
+`generate_packet` takes a packet view name such as `complete`, `short`, or `engineer` and returns the selected packet as Markdown text. Use the web UI or CLI for file formats such as DOCX.
 
 All read/write operations are scoped to the project directory with path traversal protection.
 

--- a/src/clarity_agent/mcp/README.md
+++ b/src/clarity_agent/mcp/README.md
@@ -137,7 +137,7 @@ When the agent calls `run_clarity()`, the server checks the project directory fo
 
 `write_protocol_document` automatically records content hashes so the staleness tracker stays current without a separate `record_packet_status` call.
 
-`generate_packet` returns Markdown packets directly. For binary formats such as DOCX, it confirms the packet can be generated and reports the byte size; use the web UI or CLI to download the file.
+`generate_packet` takes a packet view name such as `complete`, `short`, or `engineer`. It returns Markdown packets directly. For binary formats such as DOCX, it confirms the packet can be generated and reports the byte size; use the web UI or CLI to download the file.
 
 All read/write operations are scoped to the project directory with path traversal protection.
 

--- a/src/clarity_agent/mcp/README.md
+++ b/src/clarity_agent/mcp/README.md
@@ -95,7 +95,7 @@ Replace `/path/to/clarity-agent` with the absolute path to your clarity-agent cl
 
 ## Available Tools
 
-The MCP server exposes 8 tools, designed around three moments in a coding agent's workflow:
+The MCP server exposes 9 tools, designed around four moments in a coding agent's workflow:
 
 ### Before acting: check for conflicts
 
@@ -120,6 +120,12 @@ The MCP server exposes 8 tools, designed around three moments in a coding agent'
 | `record_failure` | Record a failure mode or risk |
 | `record_suggestion` | Record a suggestion to update a project document |
 
+### Share and review
+
+| Tool | Purpose |
+|---|---|
+| `generate_packet` | Generate a shareable review packet from protocol content |
+
 ## How It Works
 
 The server uses two directories:
@@ -130,6 +136,8 @@ The server uses two directories:
 When the agent calls `run_clarity()`, the server checks the project directory for `.clarity-protocol/`. If none exists, it returns the startup guide. If one exists, it checks document staleness, recommends the next process, and inlines the process guide content so the agent can follow it immediately.
 
 `write_protocol_document` automatically records content hashes so the staleness tracker stays current without a separate `record_packet_status` call.
+
+`generate_packet` returns Markdown packets directly. For binary formats such as DOCX, it confirms the packet can be generated and reports the byte size; use the web UI or CLI to download the file.
 
 All read/write operations are scoped to the project directory with path traversal protection.
 
@@ -142,6 +150,7 @@ Before making choices that would be expensive to reverse, call check_decision.
 When starting work or returning after a break, call run_clarity.
 After completing significant implementation, call get_packet_status.
 Record significant choices with record_decision. Add risks with record_failure.
+Generate shareable review packets with generate_packet.
 ```
 
 **New project:**

--- a/src/clarity_agent/mcp/README.md
+++ b/src/clarity_agent/mcp/README.md
@@ -137,7 +137,7 @@ When the agent calls `run_clarity()`, the server checks the project directory fo
 
 `write_protocol_document` automatically records content hashes so the staleness tracker stays current without a separate `record_packet_status` call.
 
-`generate_packet` takes a packet view name such as `complete`, `short`, or `engineer` and returns the selected packet as Markdown text. Use the web UI or CLI for file formats such as DOCX.
+`generate_packet` takes a packet view name such as `complete`, `short`, or `engineer`. By default it returns the selected packet as Markdown text. With `output_format="docx"`, it returns an MCP embedded resource whose blob is a base64-encoded DOCX file with MIME type `application/vnd.openxmlformats-officedocument.wordprocessingml.document`.
 
 All read/write operations are scoped to the project directory with path traversal protection.
 

--- a/src/clarity_agent/mcp/server.py
+++ b/src/clarity_agent/mcp/server.py
@@ -419,8 +419,7 @@ def record_failure(
 @mcp.tool()
 def generate_packet(
     output_format: str = "markdown",
-    sections: str | None = None,
-    view: str | None = None,
+    view: str = "complete",
     project_dir: str | None = None,
 ) -> str:
     """Generate a review packet document from protocol content.
@@ -432,8 +431,7 @@ def generate_packet(
 
     Args:
         output_format: Packet renderer to use, such as "markdown" or "docx".
-        sections: Optional comma-separated source IDs to include.
-        view: Optional packet view ID, such as "complete", "short", or "engineer".
+        view: Packet view ID, such as "complete", "short", or "engineer".
         project_dir: Project directory (default: CLARITY_PROJECT_DIR or cwd).
     """
     from clarity_agent.packet import PacketError
@@ -443,17 +441,12 @@ def generate_packet(
     if not proto_dir.exists():
         return "No protocol directory found."
 
-    include = (
-        [section.strip() for section in sections.split(",") if section.strip()]
-        if sections
-        else None
-    )
+    selected_view = view.strip() or "complete"
     try:
         content: bytes = _generate(
             proto_dir,
-            include=include,
             format=output_format,
-            view=view,
+            view=selected_view,
         )
     except PacketError as exc:
         return f"Error generating packet: {exc}"

--- a/src/clarity_agent/mcp/server.py
+++ b/src/clarity_agent/mcp/server.py
@@ -418,19 +418,15 @@ def record_failure(
 
 @mcp.tool()
 def generate_packet(
-    output_format: str = "markdown",
     view: str = "complete",
     project_dir: str | None = None,
 ) -> str:
     """Generate a review packet document from protocol content.
 
     Use this when the user wants a shareable packet from the current
-    protocol. Markdown output is returned directly. Binary formats such
-    as docx are generated to confirm availability, but MCP returns only
-    a status message because text tools cannot return binary files.
+    protocol. Markdown output is returned directly.
 
     Args:
-        output_format: Packet renderer to use, such as "markdown" or "docx".
         view: Packet view ID, such as "complete", "short", or "engineer".
         project_dir: Project directory (default: CLARITY_PROJECT_DIR or cwd).
     """
@@ -445,18 +441,13 @@ def generate_packet(
     try:
         content: bytes = _generate(
             proto_dir,
-            format=output_format,
+            format="markdown",
             view=selected_view,
         )
     except PacketError as exc:
         return f"Error generating packet: {exc}"
 
-    if output_format == "markdown":
-        return content.decode("utf-8")
-    return (
-        f"Generated {output_format} packet ({len(content)} bytes). "
-        "Use the web UI or CLI to download binary formats."
-    )
+    return content.decode("utf-8")
 
 
 @mcp.tool()

--- a/src/clarity_agent/mcp/server.py
+++ b/src/clarity_agent/mcp/server.py
@@ -2,10 +2,10 @@
 
 Exposes the clarity-agent process as MCP tools and resources using the
 FastMCP framework. The tool surface is intentionally small: a coding
-agent needs only a handful of tools to integrate clarity into its
-workflow. Internal helper functions (process guide access, mailbox
-management, packet generation) remain available as plain functions for
-the desktop/web/CLI modes but are not exposed as MCP tools.
+agent needs only a focused set of tools to integrate clarity into its
+workflow. Internal helper functions (process guide access and mailbox
+management) remain available as plain functions for the desktop/web/CLI
+modes but are not exposed as MCP tools.
 
 Run via::
 
@@ -47,7 +47,8 @@ mcp = FastMCP(
         "Call run_clarity when starting work on a project or returning "
         "after a break. "
         "After completing significant implementation, call "
-        "get_packet_status to check if protocol documents need updating."
+        "get_packet_status to check if protocol documents need updating. "
+        "Call generate_packet when the user needs a shareable review packet."
     ),
 )
 
@@ -97,7 +98,7 @@ def _resolve_agent_dir() -> Path:
 
 
 # ===================================================================
-# MCP TOOLS (8 tools — the coding agent surface)
+# MCP TOOLS (9 tools — the coding agent surface)
 # ===================================================================
 
 
@@ -416,6 +417,56 @@ def record_failure(
 
 
 @mcp.tool()
+def generate_packet(
+    output_format: str = "markdown",
+    sections: str | None = None,
+    view: str | None = None,
+    project_dir: str | None = None,
+) -> str:
+    """Generate a review packet document from protocol content.
+
+    Use this when the user wants a shareable packet from the current
+    protocol. Markdown output is returned directly. Binary formats such
+    as docx are generated to confirm availability, but MCP returns only
+    a status message because text tools cannot return binary files.
+
+    Args:
+        output_format: Packet renderer to use, such as "markdown" or "docx".
+        sections: Optional comma-separated source IDs to include.
+        view: Optional packet view ID, such as "complete", "short", or "engineer".
+        project_dir: Project directory (default: CLARITY_PROJECT_DIR or cwd).
+    """
+    from clarity_agent.packet import PacketError
+    from clarity_agent.packet import generate_packet as _generate
+
+    proto_dir = _resolve_protocol_dir(project_dir)
+    if not proto_dir.exists():
+        return "No protocol directory found."
+
+    include = (
+        [section.strip() for section in sections.split(",") if section.strip()]
+        if sections
+        else None
+    )
+    try:
+        content: bytes = _generate(
+            proto_dir,
+            include=include,
+            format=output_format,
+            view=view,
+        )
+    except PacketError as exc:
+        return f"Error generating packet: {exc}"
+
+    if output_format == "markdown":
+        return content.decode("utf-8")
+    return (
+        f"Generated {output_format} packet ({len(content)} bytes). "
+        "Use the web UI or CLI to download binary formats."
+    )
+
+
+@mcp.tool()
 def record_suggestion(
     title: str,
     target_document: str,
@@ -627,35 +678,6 @@ def read_behaviors(project_dir: str | None = None) -> str:
             "Re-open the project in Clarity to refresh it."
         )
     return block
-
-
-def generate_packet(
-    output_format: str = "markdown",
-    sections: str | None = None,
-    view: str | None = None,
-    project_dir: str | None = None,
-) -> str:
-    """Generate a review packet document from protocol content."""
-    from clarity_agent.packet import generate_packet as _generate
-
-    proto_dir = _resolve_protocol_dir(project_dir)
-    if not proto_dir.exists():
-        return "No protocol directory found."
-
-    include = sections.split(",") if sections else None
-    try:
-        content: bytes = _generate(
-            proto_dir,
-            include=include,
-            format=output_format,
-            view=view,
-        )
-        if output_format == "markdown":
-            return content.decode("utf-8")
-        else:
-            return f"Generated {output_format} packet ({len(content)} bytes). Use the web UI or CLI to download binary formats."
-    except Exception as e:
-        return f"Error generating packet: {e}"
 
 
 def get_mailbox_status(project_dir: str | None = None) -> str:

--- a/src/clarity_agent/mcp/server.py
+++ b/src/clarity_agent/mcp/server.py
@@ -28,12 +28,18 @@ from __future__ import annotations
 
 import json
 import os
+from base64 import b64encode
 from datetime import UTC, datetime
 from pathlib import Path
+from urllib.parse import quote
 
+from mcp import types
 from mcp.server.fastmcp import FastMCP
+from pydantic import AnyUrl
 
 DEFAULT_SSE_PORT = 8421
+MCP_PACKET_FORMATS = frozenset({"markdown", "docx"})
+PACKET_DOCX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 
 mcp = FastMCP(
     "clarity-agent",
@@ -419,16 +425,22 @@ def record_failure(
 @mcp.tool()
 def generate_packet(
     view: str = "complete",
+    output_format: str = "markdown",
     project_dir: str | None = None,
-) -> str:
+) -> str | types.EmbeddedResource:
     """Generate a review packet document from protocol content.
 
     Use this when the user wants a shareable packet from the current
-    protocol. Markdown output is returned directly.
+    protocol. Markdown output is returned directly. DOCX output is returned
+    as an MCP embedded resource with a base64-encoded blob.
 
     Args:
         view: Packet view ID, such as "complete", "short", or "engineer".
+        output_format: Output format to return, either "markdown" or "docx".
         project_dir: Project directory (default: CLARITY_PROJECT_DIR or cwd).
+
+    Returns:
+        Markdown text, or an embedded DOCX resource.
     """
     from clarity_agent.packet import PacketError
     from clarity_agent.packet import generate_packet as _generate
@@ -438,16 +450,35 @@ def generate_packet(
         return "No protocol directory found."
 
     selected_view = view.strip() or "complete"
+    selected_format = output_format.strip().lower() or "markdown"
+    if selected_format not in MCP_PACKET_FORMATS:
+        available = ", ".join(sorted(MCP_PACKET_FORMATS))
+        return (
+            f"Error generating packet: Unsupported MCP packet output format "
+            f"'{output_format}'. Available: {available}"
+        )
+
     try:
         content: bytes = _generate(
             proto_dir,
-            format="markdown",
+            format=selected_format,
             view=selected_view,
         )
     except PacketError as exc:
         return f"Error generating packet: {exc}"
 
-    return content.decode("utf-8")
+    if selected_format == "markdown":
+        return content.decode("utf-8")
+
+    filename = f"packet-{selected_view}.docx"
+    return types.EmbeddedResource(
+        type="resource",
+        resource=types.BlobResourceContents(
+            uri=AnyUrl(f"clarity-packet://generated/{quote(filename)}"),
+            mimeType=PACKET_DOCX_MIME_TYPE,
+            blob=b64encode(content).decode("ascii"),
+        ),
+    )
 
 
 @mcp.tool()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -387,7 +387,7 @@ class TestGeneratePacket:
         assert isinstance(result, str)
         assert "Test Problem" in result
 
-    def test_accepts_comma_separated_sections(
+    def test_accepts_packet_view(
         self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
@@ -396,7 +396,7 @@ class TestGeneratePacket:
         write_protocol_document("goal/problem.md", "# Test Problem\n\nA real problem.")
         write_protocol_document("solution/solution.md", "# Test Solution\n\nA real solution.")
 
-        result = generate_packet(sections="problem, solution")
+        result = generate_packet(view="engineer")
         assert "Test Problem" in result
         assert "Test Solution" in result
 
@@ -407,6 +407,16 @@ class TestGeneratePacket:
         result = generate_packet(output_format="unknown")
         assert result.startswith("Error generating packet:")
         assert "Unknown format" in result
+
+    def test_returns_unknown_view_errors(
+        self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
+        from clarity_agent.mcp.server import generate_packet
+
+        result = generate_packet(view="unknown")
+        assert result.startswith("Error generating packet:")
+        assert "Unknown view" in result
 
 
 class TestCheckFailureState:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -6,10 +6,12 @@ core tools produce sensible output when pointed at test fixtures.
 
 from __future__ import annotations
 
+import base64
 import json
 from pathlib import Path
 
 import pytest
+from mcp import types
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -387,6 +389,27 @@ class TestGeneratePacket:
         assert isinstance(result, str)
         assert "Test Problem" in result
 
+    def test_generates_docx_embedded_resource(
+        self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
+        from clarity_agent.mcp.server import (
+            PACKET_DOCX_MIME_TYPE,
+            generate_packet,
+            write_protocol_document,
+        )
+
+        write_protocol_document("goal/problem.md", "# Test Problem\n\nA real problem.")
+
+        result = generate_packet(output_format="docx")
+
+        assert isinstance(result, types.EmbeddedResource)
+        resource = result.resource
+        assert isinstance(resource, types.BlobResourceContents)
+        assert str(resource.uri) == "clarity-packet://generated/packet-complete.docx"
+        assert resource.mimeType == PACKET_DOCX_MIME_TYPE
+        assert base64.b64decode(resource.blob)[:2] == b"PK"
+
     def test_accepts_packet_view(
         self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -409,6 +432,18 @@ class TestGeneratePacket:
         result = generate_packet(view="unknown")
         assert result.startswith("Error generating packet:")
         assert "Unknown view" in result
+
+    def test_rejects_unsupported_output_format(
+        self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
+        from clarity_agent.mcp.server import generate_packet
+
+        result = generate_packet(output_format="html")
+
+        assert isinstance(result, str)
+        assert result.startswith("Error generating packet:")
+        assert "Unsupported MCP packet output format" in result
 
 
 class TestCheckFailureState:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -58,6 +58,7 @@ def test_all_tools_registered() -> None:
         "write_protocol_document",
         "record_decision",
         "record_failure",
+        "generate_packet",
         "record_suggestion",
     }
     assert expected == tool_names, (
@@ -81,7 +82,6 @@ def test_no_internal_tools_exposed() -> None:
         "list_thinkers",
         "read_thinker_guide",
         "read_behaviors",
-        "generate_packet",
         "get_mailbox_status",
         "check_failure_state",
         "snapshot_mailbox",
@@ -385,6 +385,28 @@ class TestGeneratePacket:
         write_protocol_document("goal/problem.md", "# Test Problem\n\nA real problem.")
         result = generate_packet()
         assert isinstance(result, str)
+        assert "Test Problem" in result
+
+    def test_accepts_comma_separated_sections(
+        self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
+        from clarity_agent.mcp.server import generate_packet, write_protocol_document
+
+        write_protocol_document("goal/problem.md", "# Test Problem\n\nA real problem.")
+        write_protocol_document("solution/solution.md", "# Test Solution\n\nA real solution.")
+
+        result = generate_packet(sections="problem, solution")
+        assert "Test Problem" in result
+        assert "Test Solution" in result
+
+    def test_returns_packet_errors(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
+        from clarity_agent.mcp.server import generate_packet
+
+        result = generate_packet(output_format="unknown")
+        assert result.startswith("Error generating packet:")
+        assert "Unknown format" in result
 
 
 class TestCheckFailureState:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -400,14 +400,6 @@ class TestGeneratePacket:
         assert "Test Problem" in result
         assert "Test Solution" in result
 
-    def test_returns_packet_errors(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
-        from clarity_agent.mcp.server import generate_packet
-
-        result = generate_packet(output_format="unknown")
-        assert result.startswith("Error generating packet:")
-        assert "Unknown format" in result
-
     def test_returns_unknown_view_errors(
         self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:


### PR DESCRIPTION
## Summary
- Expose `generate_packet` as a public MCP tool for shareable review packets
- Return Markdown packets directly and report binary packet generation status for formats like DOCX
- Update MCP tests and docs/protocol guidance for the 9-tool surface

## Tests
- `uv run --extra dev ruff check src\clarity_agent\mcp\server.py tests\test_mcp_server.py`
- `uv run --extra dev python -m pytest tests/test_mcp_server.py -q`
- `uv run --extra dev python -m pytest -q`