### PR TITLE
Clarify MCP-first Clarity process guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ Several registries are intentionally decoupled (packet status graph, packet rend
 
 <!-- clarity-begin -->
 <!-- clarity-meta
-schema_version: 1
+schema_version: 3
 mode: embedded
 protocol_dir_name: .clarity-protocol
 processes_dir: processes
@@ -109,13 +109,13 @@ processes_dir: processes
 
 ## Clarity Protocol
 
-This project uses the Clarity Protocol for structured thinking about consequential decisions — what to build and why, how it should be designed, where it might fail. Protocol documents live in `.clarity-protocol/`. Process guides live in `processes/`; the entry point for any Clarity work is `processes/clarity-agent.md`.
+This project uses the Clarity Protocol for structured thinking about consequential decisions: what to build and why, how it should be designed, where it might fail. Protocol documents live in `.clarity-protocol/`. A Clarity MCP server is configured for this project (see `.vscode/mcp.json`). Use its tools to interact with the protocol. The MCP responses include the relevant process guidance, so do not inspect the clarity-agent repository, read process files, install Clarity, or run Clarity CLI commands to find Clarity process instructions unless the MCP tools are unavailable.
 
 ### When to engage
 
 **Before building — think when it matters.** Two triggers:
 
-1. *The user asks.* When they want to explore what to build, clarify requirements, brainstorm risks, or work through a decision: first check whether the `run_clarity` MCP tool is in your available tools. If it is, use the MCP tools. If it isn't, read and follow `processes/clarity-agent.md` directly. Don't ask the user which to use; make this determination yourself.
+1. *The user asks.* When they want to explore what to build, clarify requirements, brainstorm risks, or work through a decision: call the `run_clarity` MCP tool. Follow the guidance returned by that tool instead of searching the repo for Clarity instructions.
 
 2. *You recognize an inflection point.* Before making choices that would be expensive to reverse — new services, auth/trust models, data schemas, external integrations, significant API contracts — call `check_decision` with what you plan to do. It returns existing decisions, requirements, and architecture so you can check for conflicts. Don't interrupt for routine implementation. The test: "If this turns out wrong, is it a 5-minute fix or a multi-day rework?" Interrupt for the latter.
 

--- a/src/clarity_agent/mcp/server.py
+++ b/src/clarity_agent/mcp/server.py
@@ -40,6 +40,11 @@ from pydantic import AnyUrl
 DEFAULT_SSE_PORT = 8421
 MCP_PACKET_FORMATS = frozenset({"markdown", "docx"})
 PACKET_DOCX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+PROCESS_GUIDE_USAGE_NOTE = (
+    "Use the process guide included in this response. Do not inspect the "
+    "clarity-agent source repository or run Clarity CLI commands to find "
+    "Clarity process instructions."
+)
 
 mcp = FastMCP(
     "clarity-agent",
@@ -51,7 +56,9 @@ mcp = FastMCP(
         "significant API contracts), call check_decision with a "
         "description of what you plan to do. "
         "Call run_clarity when starting work on a project or returning "
-        "after a break. "
+        "after a break. Use MCP tool responses as the authority for "
+        "process guidance; do not inspect the clarity-agent source "
+        "repository or run Clarity CLI commands to operate the protocol. "
         "After completing significant implementation, call "
         "get_packet_status to check if protocol documents need updating. "
         "Call generate_packet when the user needs a shareable review packet."
@@ -128,7 +135,7 @@ def run_clarity(project_dir: str | None = None) -> str:
         return (
             "# New Project\n\n"
             "No clarity protocol found. This is a new project.\n\n"
-            "Follow the clarity-agent process guide below to get started.\n\n"
+            f"{PROCESS_GUIDE_USAGE_NOTE}\n\n"
             "---\n\n" + guide
         )
 
@@ -182,6 +189,7 @@ def run_clarity(project_dir: str | None = None) -> str:
                 status_text += (
                     f"\n\n---\n\n"
                     f"## Process Guide: {action['process']}\n\n"
+                    f"{PROCESS_GUIDE_USAGE_NOTE}\n\n"
                     f"{guide_content}"
                 )
             else:

--- a/src/clarity_agent/protocol/packet_status.py
+++ b/src/clarity_agent/protocol/packet_status.py
@@ -1010,9 +1010,11 @@ def format_for_agent(report: PacketStatusReport) -> str:
     lines.append("### Process Availability")
     lines.append("")
     lines.append(
-        "Each process name below corresponds to a process guide in `processes/`. "
-        "To run a recommended process, load and follow that guide — "
-        "do not attempt the task directly."
+        "Each process name below identifies the next Clarity workflow. "
+        "If you are using MCP, call `run_clarity` for the inline guide and "
+        "follow the returned guidance. Do not inspect the clarity-agent "
+        "repository or run Clarity CLI commands to find Clarity process "
+        "instructions."
     )
     lines.append("")
     if recommended:

--- a/src/clarity_agent/setup/snippet.md
+++ b/src/clarity_agent/setup/snippet.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD041 -->
 <!-- clarity-begin -->
 <!-- clarity-meta
-schema_version: 2
+schema_version: 3
 mode: {{MODE}}
 protocol_dir_name: {{PROTOCOL_DIR_NAME}}
 processes_dir: {{PROCESSES_DIR}}
@@ -10,13 +10,13 @@ processes_dir: {{PROCESSES_DIR}}
 
 ## Clarity Protocol
 
-This project uses the Clarity Protocol for structured thinking about consequential decisions — what to build and why, how it should be designed, where it might fail. Protocol documents live in `{{PROTOCOL_DIR_NAME}}/`. A Clarity MCP server is configured for this project (see `.vscode/mcp.json`). Use its tools to interact with the protocol — do not try to install or run Clarity directly.
+This project uses the Clarity Protocol for structured thinking about consequential decisions: what to build and why, how it should be designed, where it might fail. Protocol documents live in `{{PROTOCOL_DIR_NAME}}/`. A Clarity MCP server is configured for this project (see `.vscode/mcp.json`). Use its tools to interact with the protocol. The MCP responses include the relevant process guidance, so do not inspect the clarity-agent repository, read process files, install Clarity, or run Clarity CLI commands to find Clarity process instructions unless the MCP tools are unavailable.
 
 ### When to engage
 
 **Before building — think when it matters.** Two triggers:
 
-1. *The user asks.* When they want to explore what to build, clarify requirements, brainstorm risks, or work through a decision: call the `run_clarity` MCP tool.
+1. *The user asks.* When they want to explore what to build, clarify requirements, brainstorm risks, or work through a decision: call the `run_clarity` MCP tool. Follow the guidance returned by that tool instead of searching the repo for Clarity instructions.
 
 2. *You recognize an inflection point.* Before making choices that would be expensive to reverse — new services, auth/trust models, data schemas, external integrations, significant API contracts — call `check_decision` with what you plan to do. It returns existing decisions, requirements, and architecture so you can check for conflicts. Don't interrupt for routine implementation. The test: "If this turns out wrong, is it a 5-minute fix or a multi-day rework?" Interrupt for the latter.
 

--- a/src/clarity_agent/setup/snippet.py
+++ b/src/clarity_agent/setup/snippet.py
@@ -39,7 +39,7 @@ END_DELIMITER = "<!-- clarity-end -->"
 # the per-project values (mode / protocol_dir_name / processes_dir)
 # have moved.  Resist bumping for cosmetic copy edits; the resulting
 # in-place rewrites are an upgrade-time tax on every user.
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 _META_BEGIN = "<!-- clarity-meta"
 _META_END = "-->"

--- a/tests/test_init_protocol.py
+++ b/tests/test_init_protocol.py
@@ -206,6 +206,9 @@ class TestSnippetInsertion:
         content = (project / "AGENTS.md").read_text()
         assert "run_clarity" in content
         assert "check_decision" in content
+        assert "MCP responses include the relevant process guidance" in content
+        assert "do not inspect the clarity-agent repository" in content
+        assert "processes/clarity-agent.md" not in content
         assert "{{PROCESSES_DIR}}" not in content
 
     def test_no_snippet_without_clarity_agent_dir(self, tmp_path: Path) -> None:

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -850,6 +850,9 @@ class TestInsertAgentSnippet:
         content = (tmp_path / "AGENTS.md").read_text()
         assert "run_clarity" in content
         assert "check_decision" in content
+        assert "MCP responses include the relevant process guidance" in content
+        assert "do not inspect the clarity-agent repository" in content
+        assert "processes/clarity-agent.md" not in content
         assert "{{PROCESSES_DIR}}" not in content
 
     def test_skip_when_no_template(self, tmp_path: Path) -> None:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -120,6 +120,7 @@ class TestRunClarity:
         from clarity_agent.mcp.server import run_clarity
         result = run_clarity()
         assert "New Project" in result
+        assert "Do not inspect the clarity-agent source repository" in result
 
     def test_existing_project(self, initialized_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("CLARITY_PROJECT_DIR", str(initialized_project))
@@ -134,6 +135,7 @@ class TestRunClarity:
         result = run_clarity()
         if "Process Guide:" in result:
             assert "##" in result
+            assert "Do not inspect the clarity-agent source repository" in result
 
 
 class TestCheckDecision:

--- a/tests/test_packet_status.py
+++ b/tests/test_packet_status.py
@@ -740,6 +740,9 @@ class TestFormatForAgent:
         report = check_packet_status(protocol_dir)
         output = format_for_agent(report)
         assert "Process Availability" in output
+        assert "call `run_clarity` for the inline guide" in output
+        assert "Do not inspect the clarity-agent repository" in output
+        assert "load and follow that guide" not in output
         # The old Failure Management State section no longer appears.
         assert "Failure Management State" not in output
 
@@ -843,5 +846,3 @@ class TestCheckMailboxStatus:
         result = check_mailbox_status(protocol_dir)
         names = [r["name"] for r in result]
         assert names == sorted(names)
-
-

--- a/tests/test_snippet.py
+++ b/tests/test_snippet.py
@@ -119,6 +119,18 @@ class TestRenderSnippet:
         # Absolute path from tmp_path must NOT leak in.
         assert str(tmp_path) not in out
 
+    def test_render_directs_agents_to_mcp_outputs(
+        self, tmp_path: Path,
+    ) -> None:
+        layout = _embedded_layout(tmp_path)
+        out = render_snippet(layout)
+
+        assert "run_clarity" in out
+        assert "MCP responses include the relevant process guidance" in out
+        assert "do not inspect the clarity-agent repository" in out
+        assert "searching the repo for Clarity instructions" in out
+        assert "processes/clarity-agent.md" not in out
+
     def test_returns_only_marker_bounded_block(self, tmp_path: Path) -> None:
         # The template carries an out-of-band ``markdownlint-disable``
         # comment above ``<!-- clarity-begin -->`` to suppress an


### PR DESCRIPTION
Updates Clarity’s embedded agent guidance and MCP responses so coding agents treat the MCP server as the authoritative process interface when it is available. The instructions now tell agents to call run_clarity and follow the returned inline guidance instead of searching the clarity-agent repo, reading process files, installing Clarity, or running CLI commands to find process instructions.

Also updates packet-status guidance to avoid directing MCP users back to processes/, and adds regression coverage for snippet rendering, init/embed output, MCP run_clarity responses, and packet-status output.