### PR TITLE
Guard optional copilot SDK imports against incompatible versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Clarity are documented here. This project uses
 
 ## [Unreleased]
 
+### Fixed
+- Guard optional GitHub Copilot SDK imports so an incompatible `github-copilot-sdk`
+  version (e.g. 1.0.4, which dropped `SubprocessConfig`) no longer crashes every
+  command at startup.
+
 ## [0.1.3] - 2026-06-18
 
 ### Changed

--- a/src/clarity_agent/llm/impl/github_copilot.py
+++ b/src/clarity_agent/llm/impl/github_copilot.py
@@ -37,13 +37,17 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from clarity_agent.transcript import Transcript
 
-from copilot import CopilotClient, SubprocessConfig
-from copilot.generated.session_events import SessionEvent, SessionEventType
-from copilot.session import (
-    CopilotSession,
-    PermissionHandler,
-    SystemMessageCustomizeConfig,
-)
+try:
+    from copilot import CopilotClient, SubprocessConfig
+    from copilot.generated.session_events import SessionEvent, SessionEventType
+    from copilot.session import (
+        CopilotSession,
+        PermissionHandler,
+        SystemMessageCustomizeConfig,
+    )
+except ImportError:
+    CopilotClient = None  # type: ignore[assignment,misc]
+    SubprocessConfig = None  # type: ignore[assignment,misc]
 
 from clarity_agent.llm.chat import ChatBackend
 from clarity_agent.llm.types import CompactionInfo, ToolHandler, ToolUseBlock


### PR DESCRIPTION
github-copilot-sdk 1.0.4 dropped the SubprocessConfig export, so the top-level import in github_copilot.py raised ImportError. Because the provider registry imports every backend module at startup, this crashed every command for all users, not just GitHub Copilot users. Wrap the optional copilot imports in try/except ImportError so an incompatible or absent SDK degrades gracefully.## Problem

`src/clarity_agent/llm/impl/github_copilot.py` imports `SubprocessConfig`
(and other symbols) from the `copilot` package at module top level:

```python
from copilot import CopilotClient, SubprocessConfig

github-copilot-sdk 1.0.4 no longer exports SubprocessConfig, so this
import raises:

ImportError: cannot import name 'SubprocessConfig' from 'copilot'

Because the LLM provider registry imports every backend module at startup to
build its registry, this crashes every command for every user — including
users on Anthropic/Claude or OpenAI who never touch GitHub Copilot. The app
fails to launch entirely:

Error: cannot import name 'SubprocessConfig' from 'copilot'
Full traceback written to: ~/.clarity/clarity-crash.log

It also breaks the test suite at collection time
(tests/test_github_copilot.py), which blocks clarity install unless
--skip-tests is passed.

Fix

Wrap the optional copilot SDK imports in try/except ImportError and fall
back to None, so an incompatible (or absent) SDK degrades gracefully instead
of taking down the whole app. The GitHub Copilot backend is only instantiated
when actually selected, so guarding the import is sufficient.

Reproduction

- github-copilot-sdk==1.0.4, Python 3.12
- python -c "import clarity_agent.llm.impl.github_copilot" → ImportError
- With this patch → imports cleanly (CopilotClient is None)

Environment

- Ubuntu Linux, Python 3.12.3, github-copilot-sdk 1.0.4