### PR TITLE
Show tool download link when setup connection test fails (#124)

### DIFF
--- a/src/clarity_agent/llm/config.py
+++ b/src/clarity_agent/llm/config.py
@@ -170,6 +170,11 @@ _PROVIDERS: dict[str, dict[str, Any]] = {
                 ),
                 "package": "azure.identity",
                 "env_var": None,
+                "setup_help": (
+                    "This uses your existing Azure CLI session. You must have "
+                    "installed the Azure CLI and run 'az login' first."
+                ),
+                "setup_url": "https://learn.microsoft.com/cli/azure/install-azure-cli",
                 "fields": [],
             },
             {

--- a/src/clarity_agent/web/setup_routes.py
+++ b/src/clarity_agent/web/setup_routes.py
@@ -120,8 +120,36 @@ def _write_env(
     s.save()
 
 
+def _setup_url(provider: str, auth_mode: str) -> str | None:
+    """Return the download / credential URL for a provider's auth mode.
+
+    Falls back to the provider-level ``setup_url`` when the specific
+    auth mode doesn't define one, so a failure always has somewhere to
+    point the user.  The registry (``_PROVIDERS``) is the single source
+    of truth — e.g. the ``gh`` auth mode carries
+    ``https://cli.github.com/``, so a "GitHub CLI is not installed"
+    error can surface a clickable install link rather than bare prose.
+    """
+    from clarity_agent.llm.config import _PROVIDERS, get_auth_mode_info
+
+    mode = get_auth_mode_info(provider, auth_mode)
+    if mode and mode.get("setup_url"):
+        return mode["setup_url"]
+    info = _PROVIDERS.get(provider)
+    if info and info.get("setup_url"):
+        return info["setup_url"]
+    return None
+
+
 def _test_connection(provider: str, auth_mode: str) -> dict[str, Any]:
-    """Probe the provider and return {ok, message, hint?}."""
+    """Probe the provider and return ``{ok, message, hint?, setup_url?}``.
+
+    On failure we attach ``setup_url`` — a direct link to the tool's
+    download / credential page — so the wizard can render a clickable
+    install link right next to the error.  Without it a user who is
+    missing a required CLI (e.g. ``gh``) only sees prose telling them
+    to "install it" with no link to follow (issue #124).
+    """
     from clarity_agent.setup.doctor import _classify_error, _probe_api, _probe_sdk
 
     try:
@@ -132,10 +160,28 @@ def _test_connection(provider: str, auth_mode: str) -> dict[str, Any]:
             result = _probe_copilot(_clarity_agent_dir)
         else:
             result = _probe_api(_clarity_agent_dir, provider)
-        return {"ok": result.status.value == "pass", "message": result.message}
+        ok = result.status.value == "pass"
+        response: dict[str, Any] = {"ok": ok, "message": result.message}
+        if not ok:
+            _attach_setup_url(response, provider, auth_mode)
+        return response
     except Exception as e:
-        hint = _classify_error(e, provider)
-        return {"ok": False, "message": str(e), "hint": hint}
+        response = {
+            "ok": False,
+            "message": str(e),
+            "hint": _classify_error(e, provider),
+        }
+        _attach_setup_url(response, provider, auth_mode)
+        return response
+
+
+def _attach_setup_url(
+    response: dict[str, Any], provider: str, auth_mode: str,
+) -> None:
+    """Add ``setup_url`` to a failed-probe *response* when one exists."""
+    url = _setup_url(provider, auth_mode)
+    if url:
+        response["setup_url"] = url
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_setup_routes.py
+++ b/tests/test_setup_routes.py
@@ -1,0 +1,107 @@
+"""Tests for the setup-wizard API helpers in
+:mod:`clarity_agent.web.setup_routes`.
+
+Focus: a failed connection test must carry a ``setup_url`` — a direct
+link to the tool's download / credential page — so the wizard can
+render a clickable install link next to the error instead of bare
+"install it" prose (issue #124).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clarity_agent.llm.config import _PROVIDERS, get_auth_mode_names
+from clarity_agent.setup import doctor
+from clarity_agent.setup.doctor import CheckResult, Status
+from clarity_agent.web import setup_routes
+
+
+class TestSetupUrlLookup:
+    """``_setup_url`` resolves the download/credential link, with a
+    provider-level fallback so failures always have somewhere to point."""
+
+    def test_returns_auth_mode_url_when_present(self) -> None:
+        # The gh auth mode is the issue's motivating example.
+        assert (
+            setup_routes._setup_url("github", "gh_cli")
+            == "https://cli.github.com/"
+        )
+
+    def test_falls_back_to_provider_level_url(self) -> None:
+        # azure/device_code defines no setup_url of its own, so the
+        # lookup should fall back to the provider-level Azure URL.
+        assert _PROVIDERS["azure"].get("setup_url")
+        assert (
+            setup_routes._setup_url("azure", "device_code")
+            == _PROVIDERS["azure"]["setup_url"]
+        )
+
+    def test_returns_none_for_unknown_provider(self) -> None:
+        assert setup_routes._setup_url("nonexistent", "api_key") is None
+
+    def test_every_provider_and_mode_resolves_a_url(self) -> None:
+        """Invariant: every provider/auth-mode combination resolves a
+        setup_url. This guarantees a missing-tool error can always show
+        a link, and guards against a new mode landing without one."""
+        for provider in _PROVIDERS:
+            for mode in get_auth_mode_names(provider):
+                assert setup_routes._setup_url(provider, mode), (
+                    f"{provider}/{mode} has no resolvable setup_url — a "
+                    "failed test would show no download link"
+                )
+
+
+class TestTestConnectionSetupUrl:
+    """``_test_connection`` attaches ``setup_url`` on failure only."""
+
+    def _patch_probe(self, monkeypatch: pytest.MonkeyPatch, fn) -> None:
+        # _test_connection routes non-anthropic-sdk, non-github
+        # providers through _probe_api.
+        monkeypatch.setattr(doctor, "_probe_api", fn)
+
+    def test_attaches_url_when_probe_raises(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def boom(*_a, **_k):
+            raise RuntimeError("The GitHub CLI (gh) is not installed.")
+
+        self._patch_probe(monkeypatch, boom)
+        result = setup_routes._test_connection("openai", "api_key")
+
+        assert result["ok"] is False
+        assert result["setup_url"] == "https://platform.openai.com/api-keys"
+        # The classifier hint is still present alongside the link.
+        assert "hint" in result
+
+    def test_attaches_url_when_probe_reports_non_pass(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def warn(*_a, **_k):
+            return CheckResult(
+                name="Backend health",
+                status=Status.WARN,
+                message="Empty response",
+            )
+
+        self._patch_probe(monkeypatch, warn)
+        result = setup_routes._test_connection("openai", "api_key")
+
+        assert result["ok"] is False
+        assert result["setup_url"] == "https://platform.openai.com/api-keys"
+
+    def test_no_url_on_success(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        def ok(*_a, **_k):
+            return CheckResult(
+                name="Backend health",
+                status=Status.PASS,
+                message="Provider responded successfully",
+            )
+
+        self._patch_probe(monkeypatch, ok)
+        result = setup_routes._test_connection("openai", "api_key")
+
+        assert result["ok"] is True
+        assert "setup_url" not in result

--- a/web/src/components/PreferencesPanel.tsx
+++ b/web/src/components/PreferencesPanel.tsx
@@ -64,7 +64,7 @@ function ProviderTab({ settings, onSaved }: { settings: AppSettings; onSaved: ()
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [switching, setSwitching] = useState(false);
-  const [result, setResult] = useState<{ ok: boolean; message: string; hint?: string } | null>(null);
+  const [result, setResult] = useState<{ ok: boolean; message: string; hint?: string; setup_url?: string } | null>(null);
 
   useEffect(() => {
     getSetupProviders()
@@ -428,6 +428,19 @@ function ProviderTab({ settings, onSaved }: { settings: AppSettings; onSaved: ()
                       }`}>
                         {result.ok ? "\u2713" : "\u2717"} {result.message}
                         {result.hint && <p className="text-xs mt-1 opacity-80">{result.hint}</p>}
+                        {!result.ok && result.setup_url && (
+                          <p className="text-xs mt-2">
+                            <span className="opacity-80">Get it here: </span>
+                            <a
+                              href={result.setup_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-accent-focus hover:underline break-all"
+                            >
+                              {result.setup_url}
+                            </a>
+                          </p>
+                        )}
                       </div>
                     )}
                   </div>

--- a/web/src/components/SetupWizard.tsx
+++ b/web/src/components/SetupWizard.tsx
@@ -17,7 +17,7 @@ export default function SetupWizard({ onComplete, onCancel }: SetupWizardProps) 
   const [selectedMode, setSelectedMode] = useState<AuthModeInfo | null>(null);
   const [credentials, setCredentials] = useState<Record<string, string>>({});
   const [testing, setTesting] = useState(false);
-  const [testResult, setTestResult] = useState<{ ok: boolean; message: string; hint?: string } | null>(null);
+  const [testResult, setTestResult] = useState<{ ok: boolean; message: string; hint?: string; setup_url?: string } | null>(null);
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
@@ -368,6 +368,19 @@ export default function SetupWizard({ onComplete, onCancel }: SetupWizardProps) 
                     <p className="text-sm">{testResult.message}</p>
                     {testResult.hint && (
                       <p className="text-xs mt-1 opacity-80">{testResult.hint}</p>
+                    )}
+                    {!testResult.ok && testResult.setup_url && (
+                      <p className="text-xs mt-2">
+                        <span className="opacity-80">Get it here: </span>
+                        <a
+                          href={testResult.setup_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-accent-focus hover:underline break-all"
+                        >
+                          {testResult.setup_url}
+                        </a>
+                      </p>
                     )}
                   </div>
                 </div>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -225,6 +225,9 @@ export interface ConfigureResult {
   ok: boolean;
   message: string;
   hint?: string;
+  // On failure, a direct link to the tool's download / credential page
+  // so the UI can render a clickable install link next to the error.
+  setup_url?: string;
 }
 
 // Projects (launcher mode)


### PR DESCRIPTION
When a provider connection test fails during setup — whether a required tool is missing (e.g. the GitHub CLI `gh`) or a credential is wrong — the error only told users to "install it" with no clickable link. The `setup_url` guidance box was hidden the moment a test failed, so the one place a user needs the link — staring at the error — had none.

This affects both the first-run setup wizard and the in-app **Preferences → Provider** settings; both are fixed.

- **setup_routes**: attach `setup_url` (from the provider registry, with a provider-level fallback) to failed connection-test responses.
- **config**: give the Azure CLI / Managed Identity mode a `setup_url` + `setup_help` — the only tool-based auth mode that lacked a link.
- **SetupWizard / PreferencesPanel**: render `setup_url` as a clickable, copyable link inside the failure box.
- **test_setup_routes**: covers the failure-attaches-url contract and a registry invariant that every provider/mode resolves a link.

**SetupWizard example:**
<img width="1231" height="783" alt="Screenshot 2026-07-17 at 5 04 01 PM" src="https://github.com/user-attachments/assets/2bdbea20-8dc0-47de-8ff5-062b1d7a88f3" />

**Preferences → Provider example:**
<img width="610" height="1157" alt="Screenshot 2026-07-17 at 4 46 39 PM" src="https://github.com/user-attachments/assets/5746c468-a474-494a-b1dc-3e18d5d6f8b0" />

Fixes #124