### PR TITLE
Default execution log side pane to closed (#152)

### DIFF
--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -52,7 +52,7 @@ export default function ChatPanel() {
   const autoStarted = useRef(false);
   const [protocolExists, setProtocolExists] = useState<boolean | null>(null);
   const [sessionInfo, setSessionInfo] = useState<SessionInfo | null>(null);
-  const [logPaneOpen, setLogPaneOpen] = useState(true);
+  const [logPaneOpen, setLogPaneOpen] = useState(false);
   const [logPaneWidth, setLogPaneWidth] = useState(DEFAULT_LOG_PANE_WIDTH);
   const [seenLogCount, setSeenLogCount] = useState(0);
   const visibleMessages = useMemo(


### PR DESCRIPTION
Closes #152. The execution log side pane opens by default on session load and takes 460px of horizontal space, which squeezes the chat area on smaller windows. Default it back to closed. The collapsed rail and unread badge still appear when new log lines arrive.