### PR TITLE
Three Fixes

### DIFF
--- a/clarity.py
+++ b/clarity.py
@@ -36,6 +36,7 @@ if not getattr(sys, "frozen", False):
     sys.path.insert(0, str(Path(__file__).resolve().parent / "src"))
 
 from clarity_agent.app_paths import clarity_env_path, get_bundle_dir
+from clarity_agent.console import configure_stdio
 from clarity_agent.env_path import ensure_tool_paths
 
 # Ensure Homebrew, ~/.local/bin, etc. are visible — macOS GUI apps
@@ -470,6 +471,10 @@ def _cmd_status() -> None:
 # ---------------------------------------------------------------------------
 
 def main() -> None:
+    # Before anything prints: a redirected stdout defaults to the locale
+    # encoding, which can't carry our status glyphs on Windows.
+    configure_stdio()
+
     # Handled before the parser is built: `status` is a pass-through to the
     # packet-status CLI, which owns its own (larger) flag surface.
     if len(sys.argv) >= 2 and sys.argv[1] == "status":

--- a/clarity.py
+++ b/clarity.py
@@ -144,7 +144,9 @@ def _cmd_install(args: argparse.Namespace) -> None:
 def _cmd_embed(args: argparse.Namespace) -> None:
     from clarity_agent.setup.project import _cli_main as project_embed
 
-    project_embed([str(args.project_dir)], agent_dir=_SCRIPT_DIR.resolve())
+    argv = [str(args.project_dir)]
+    argv.append("--copy" if args.copy else "--link")
+    project_embed(argv, agent_dir=_SCRIPT_DIR.resolve())
 
 
 def _cmd_update(args: argparse.Namespace) -> None:
@@ -679,12 +681,41 @@ def main() -> None:
     embed_parser = subparsers.add_parser(
         "embed",
         help="Embed Clarity into an existing git repository",
+        description=(
+            "Add Clarity's project-side artifacts to a git repository: "
+            "the .clarity-protocol/ directory, a .clarity-agent entry "
+            "pointing at this installation, the AGENTS.md block, a "
+            "`clarity` wrapper, and .vscode/mcp.json.  All of it is "
+            "gitignored except the protocol directory and AGENTS.md."
+        ),
     )
     embed_parser.add_argument(
         "project_dir",
         type=Path,
         help="Path to the git repository to embed Clarity into",
     )
+    embed_how = embed_parser.add_mutually_exclusive_group()
+    embed_how.add_argument(
+        "--link",
+        dest="copy",
+        action="store_false",
+        help=(
+            "Light install (default): .clarity-agent is a symlink to this "
+            "Clarity installation, so the project tracks it automatically."
+        ),
+    )
+    embed_how.add_argument(
+        "--copy",
+        dest="copy",
+        action="store_true",
+        help=(
+            "Heavy install: copy this installation's process and thinker "
+            "guides into .clarity-agent/ instead of linking it.  "
+            "Self-contained, symlink-free, and committable; re-run "
+            "'clarity embed --copy' to refresh it."
+        ),
+    )
+    embed_parser.set_defaults(copy=False)
 
     # ---- clarity update ---------------------------------------------------
     update_parser = subparsers.add_parser(

--- a/clarity.py
+++ b/clarity.py
@@ -10,6 +10,7 @@ Usage::
     clarity cli [project_dir]         # interactive command-line session
     clarity process NAME [project_dir]# run a single process by name
     clarity packet [project_dir]      # generate a review packet
+    clarity status [project_dir]      # report/record protocol document state
     clarity install [--mode MODE]     # install clarity as a desktop app
     clarity embed <project-dir>       # embed clarity into a git repo
     clarity update                    # update clarity-agent to latest version
@@ -439,8 +440,27 @@ def _write_crash_log(exc: BaseException) -> Path | None:
 # Subcommand registry
 # ---------------------------------------------------------------------------
 
-_SUBCOMMANDS = ("app", "web", "cli", "process", "packet", "install", "embed", "update", "doctor", "help")
+_SUBCOMMANDS = (
+    "app", "web", "cli", "process", "packet", "status",
+    "install", "embed", "update", "doctor", "help",
+)
 _DEFAULT_COMMAND = "web"
+
+
+def _cmd_status() -> None:
+    """Dispatch ``clarity status`` to the packet-status CLI, verbatim.
+
+    This exists so the frozen desktop binary can run packet status without an
+    external Python interpreter — see
+    :mod:`clarity_agent.protocol.invocation`.  Arguments are forwarded
+    untouched rather than mirrored into our own parser, so the two entry
+    points can never drift; ``packet_status.main()`` also raises
+    ``SystemExit(1)`` when documents are stale, which callers rely on.
+    """
+    from clarity_agent.protocol import packet_status
+
+    sys.argv = ["clarity status", *sys.argv[2:]]
+    packet_status.main()
 
 
 # ---------------------------------------------------------------------------
@@ -448,6 +468,12 @@ _DEFAULT_COMMAND = "web"
 # ---------------------------------------------------------------------------
 
 def main() -> None:
+    # Handled before the parser is built: `status` is a pass-through to the
+    # packet-status CLI, which owns its own (larger) flag surface.
+    if len(sys.argv) >= 2 and sys.argv[1] == "status":
+        _cmd_status()
+        return
+
     parser = argparse.ArgumentParser(
         prog="clarity",
         description=(
@@ -587,6 +613,15 @@ def main() -> None:
         help="Disable saving conversation transcript",
     )
     _add_llm_args(packet_parser)
+
+    # ---- clarity status ---------------------------------------------------
+    # Registered for `clarity --help` only; the real dispatch happens at the
+    # top of main() so that packet_status's own flags pass through untouched.
+    subparsers.add_parser(
+        "status",
+        help="Report or record protocol document state (packet status)",
+        add_help=False,
+    )
 
     # ---- clarity install --------------------------------------------------
     install_parser = subparsers.add_parser(

--- a/src/clarity_agent/ai_actions/brainstorm.py
+++ b/src/clarity_agent/ai_actions/brainstorm.py
@@ -490,6 +490,9 @@ def _cli_main() -> None:
     """
     import argparse
 
+    from clarity_agent.console import configure_stdio
+    configure_stdio()
+
     parser = argparse.ArgumentParser(
         prog="python -m clarity_agent.ai_actions.brainstorm",
         description="Brainstorm tools CLI. Reads JSON from stdin.",

--- a/src/clarity_agent/ai_actions/suggestion.py
+++ b/src/clarity_agent/ai_actions/suggestion.py
@@ -187,6 +187,9 @@ def _cli_main() -> None:
     """
     import argparse
 
+    from clarity_agent.console import configure_stdio
+    configure_stdio()
+
     parser = argparse.ArgumentParser(
         prog="python -m clarity_agent.ai_actions.suggestion",
         description="Record a document suggestion. Reads JSON from stdin.",

--- a/src/clarity_agent/console.py
+++ b/src/clarity_agent/console.py
@@ -1,0 +1,80 @@
+"""Console output encoding — make our CLI text survive being redirected.
+
+Every Clarity CLI prints non-ASCII: status glyphs (``✓ ⚠ ✗``), arrows
+(``→ ↳``), rules (``━``), and em dashes all over the report text.  On
+Windows that's a crash waiting to happen.  The console itself is fine —
+since 3.6 CPython talks UTF-16 to it directly — but the moment stdout is
+a *pipe* (a subprocess call, a ``> out.txt``, CI capturing the run),
+Python falls back to the locale encoding, which on a US/Western Windows
+box is cp1252::
+
+    UnicodeEncodeError: 'charmap' codec can't encode character '\\u2713'
+
+That's a hard failure of an otherwise successful command, and it only
+appears when someone captures the output — exactly the case a developer
+running locally never sees and CI hits immediately.
+
+:func:`configure_stdio` fixes it once, at each CLI entry point, instead
+of asking every ``print`` to think about encodings.
+
+**Stdlib-only, no side effects on import.** Entry points call it; merely
+importing a module never reconfigures a stream out from under a host
+process (the desktop app, an MCP client, pytest).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+# Characters our CLIs actually print.  If a stream can carry these it
+# can carry our output, and we leave it exactly as the platform (or the
+# user's PYTHONIOENCODING) configured it.
+_PROBE = "✓✗⚠→↳━—"
+
+
+def _needs_utf8(stream: Any) -> bool:
+    """True when *stream* is a text stream that would fail on our glyphs."""
+    encoding = getattr(stream, "encoding", None)
+    if not encoding or not hasattr(stream, "reconfigure"):
+        # Not a reconfigurable text stream — a pytest capture object, an
+        # already-wrapped binary stream, something a host app installed.
+        # Not ours to touch.
+        return False
+    try:
+        _PROBE.encode(encoding)
+    except (LookupError, UnicodeEncodeError):
+        return True
+    return False
+
+
+def configure_stdio() -> None:
+    """Ensure ``stdout``/``stderr`` can encode the CLI's output.
+
+    Switches a stream to UTF-8 only when its current encoding would
+    raise on our glyphs — a working stream (any UTF-8 locale, the
+    Windows console itself, an explicit ``PYTHONIOENCODING`` that can
+    carry them) is left untouched.
+
+    The tradeoff when we do intervene: a cp1252 consumer sees UTF-8
+    bytes rather than the command dying halfway through its output.
+    Mojibake is recoverable; a ``UnicodeEncodeError`` mid-report is not.
+    ``errors="replace"`` is belt-and-braces for anything outside the
+    probe set.
+    """
+    # Typed as Any: what's on ``sys.stdout`` at runtime is whatever the
+    # host put there, and ``reconfigure`` is duck-typed — the presence
+    # check lives in :func:`_needs_utf8`.
+    streams: tuple[Any, ...] = (sys.stdout, sys.stderr)
+    for stream in streams:
+        if not _needs_utf8(stream):
+            continue
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")
+        except (OSError, ValueError):
+            # Couldn't re-encode; at least degrade to "?" instead of
+            # raising partway through a command's output.
+            try:
+                stream.reconfigure(errors="replace")
+            except (OSError, ValueError):
+                pass

--- a/src/clarity_agent/llm/impl/anthropic.py
+++ b/src/clarity_agent/llm/impl/anthropic.py
@@ -24,9 +24,9 @@ from clarity_agent.llm.types import (
 )
 
 _ANTHROPIC_TIER_DEFAULTS: dict[str, str] = {
-    "default": "claude-sonnet-4-6",
-    "deep": "claude-opus-4-7",
-    "fast": "claude-haiku-4-5",
+    "default": "claude-opus-5",
+    "deep": "claude-opus-5",
+    "fast": "claude-sonnet-5",
 }
 
 # Context-window size (in tokens) per model.  Co-located with the
@@ -42,6 +42,9 @@ _ANTHROPIC_TIER_DEFAULTS: dict[str, str] = {
 # compaction naturally keeps our trigger cold — we only fire as the
 # safety net when the provider isn't handling things itself.
 _ANTHROPIC_MODEL_CONTEXT_WINDOWS: dict[str, int] = {
+    "claude-sonnet-5": 1_000_000,
+    "claude-opus-5": 1_000_000,
+    "claude-fable-5": 1_000_000,
     "claude-opus-4-7": 200_000,
     "claude-sonnet-4-6": 200_000,
     "claude-haiku-4-5": 200_000,
@@ -113,11 +116,13 @@ class AnthropicClient(LLMClient):
             if block.type == "text":
                 content.append(TextBlock(text=block.text))
             elif block.type == "tool_use":
-                content.append(ToolUseBlock(
-                    id=block.id,
-                    name=block.name,
-                    input=block.input,
-                ))
+                content.append(
+                    ToolUseBlock(
+                        id=block.id,
+                        name=block.name,
+                        input=block.input,
+                    )
+                )
 
         usage = None
         if hasattr(response, "usage") and response.usage:
@@ -155,10 +160,10 @@ class AnthropicClient(LLMClient):
         if self.on_tool_use:
             self.on_tool_use(block.name, detail)
         if self.on_tool_call:
-            self.on_tool_call(ToolUseBlock(
-                id=block.id,
-                name=block.name,
-                input=block.input,
-            ))
-
-
+            self.on_tool_call(
+                ToolUseBlock(
+                    id=block.id,
+                    name=block.name,
+                    input=block.input,
+                )
+            )

--- a/src/clarity_agent/llm/impl/claude_sdk.py
+++ b/src/clarity_agent/llm/impl/claude_sdk.py
@@ -124,8 +124,7 @@ class SdkChatBackend(ChatBackend):
             import claude_agent_sdk
         except ImportError:
             raise ImportError(
-                "claude-agent-sdk is not installed. "
-                "Install it with: pip install claude-agent-sdk"
+                "claude-agent-sdk is not installed. Install it with: pip install claude-agent-sdk"
             ) from None
 
         super().__init__(transcript=transcript)
@@ -155,7 +154,6 @@ class SdkChatBackend(ChatBackend):
         # compaction twice across multiple ``_run_query`` calls.
         self._seen_compact_summary_uuids: set[str] = set()
 
-
     @property
     def llm_session_id(self) -> str | None:
         return self._session_id
@@ -172,7 +170,10 @@ class SdkChatBackend(ChatBackend):
         self._seen_compact_summary_uuids.clear()
 
     async def _on_pre_compact(
-        self, hook_input: dict, tool_use_id: str | None, context: dict,
+        self,
+        hook_input: dict,
+        tool_use_id: str | None,
+        context: dict,
     ) -> dict:
         """PreCompact hook handler.
 
@@ -267,13 +268,16 @@ class SdkChatBackend(ChatBackend):
             self.on_compaction_started()
         result = self._transcript.external_compaction_occurred(summary=summary)
         if self.on_compaction_complete:
-            self.on_compaction_complete(CompactionInfo(
-                summary=result.summary,
-                source_turn_count=result.source_turn_count,
-            ))
+            self.on_compaction_complete(
+                CompactionInfo(
+                    summary=result.summary,
+                    source_turn_count=result.source_turn_count,
+                )
+            )
 
     def _build_system_prompt(self, system_prompt: str | None = None) -> str:
         from clarity_agent.app_paths import protocol_dir as _protocol_dir
+
         pd = _protocol_dir(self.project_dir)
         base: str = (
             "You are running the Clarity Agent framework.  Clarity "
@@ -346,9 +350,7 @@ class SdkChatBackend(ChatBackend):
         # contain ``ANTHROPIC_API_KEY``.  ``env`` merges with parent
         # env (only the keys we list override), so omitting it when
         # we have no key is the equivalent of "inherit parent".
-        sdk_env: dict[str, str] = (
-            {"ANTHROPIC_API_KEY": self._api_key} if self._api_key else {}
-        )
+        sdk_env: dict[str, str] = {"ANTHROPIC_API_KEY": self._api_key} if self._api_key else {}
         options = self._sdk.ClaudeAgentOptions(
             system_prompt=self._current_system_prompt,
             allowed_tools=["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
@@ -363,7 +365,7 @@ class SdkChatBackend(ChatBackend):
             permission_mode="bypassPermissions",
             model=self.resolve_model(model),
             cwd=str(self.project_dir),
-            max_turns=25,
+            max_turns=200,
             resume=self._session_id,
             env=sdk_env,
             # PreCompact fires immediately before the SDK compacts
@@ -410,11 +412,13 @@ class SdkChatBackend(ChatBackend):
                             # parallel; consumers subscribe to
                             # whichever fits their needs.
                             if self.on_tool_call:
-                                self.on_tool_call(ToolUseBlock(
-                                    id=block.id,
-                                    name=block.name,
-                                    input=block.input,
-                                ))
+                                self.on_tool_call(
+                                    ToolUseBlock(
+                                        id=block.id,
+                                        name=block.name,
+                                        input=block.input,
+                                    )
+                                )
                 elif isinstance(message, self._sdk.ResultMessage):
                     self._session_id = message.session_id
                     if message.total_cost_usd is not None:
@@ -441,9 +445,7 @@ class SdkChatBackend(ChatBackend):
                     self.on_warning(warn_msg)
             elif stderr_lines:
                 stderr_text = "\n".join(stderr_lines[-20:])
-                raise RuntimeError(
-                    f"Claude CLI failed: {e}\n\nCLI stderr:\n{stderr_text}"
-                ) from e
+                raise RuntimeError(f"Claude CLI failed: {e}\n\nCLI stderr:\n{stderr_text}") from e
             else:
                 # No stderr captured.  If this looks like a CLI exit-code
                 # failure, provide an actionable message instead of the raw
@@ -490,6 +492,7 @@ class SdkChatBackend(ChatBackend):
         _ = tool_handler
         if tools and system_prompt is not None:
             from clarity_agent.ai_actions import format_tools_as_cli
+
             cli_section = format_tools_as_cli(tools)
             system_prompt = cli_section + "\n\n" + system_prompt
         return asyncio.run(self._async_chat(user_message, system_prompt, model=model))
@@ -530,12 +533,14 @@ class SdkChatBackend(ChatBackend):
         return "\n".join(parts)
 
     _TOOL_CALL_RE = re.compile(
-        r"```tool_call\s*\n(.*?)\n\s*```", re.DOTALL,
+        r"```tool_call\s*\n(.*?)\n\s*```",
+        re.DOTALL,
     )
 
     @classmethod
     def _parse_text_tool_calls(
-        cls, text: str,
+        cls,
+        text: str,
     ) -> list[dict[str, Any]]:
         """Extract tool-call JSON blocks from model text output."""
         results: list[dict[str, Any]] = []
@@ -645,11 +650,13 @@ class SdkChatBackend(ChatBackend):
                 if block.type == "text":
                     content.append(TextBlock(text=block.text))
                 elif block.type == "tool_use":
-                    content.append(ToolUseBlock(
-                        id=block.id,
-                        name=block.name,
-                        input=block.input,
-                    ))
+                    content.append(
+                        ToolUseBlock(
+                            id=block.id,
+                            name=block.name,
+                            input=block.input,
+                        )
+                    )
 
             usage = None
             if hasattr(api_response, "usage") and api_response.usage:
@@ -660,7 +667,9 @@ class SdkChatBackend(ChatBackend):
                 if self.on_usage:
                     self.on_usage(usage)
 
-            response = LLMResponse(content=content, stop_reason=api_response.stop_reason, usage=usage)
+            response = LLMResponse(
+                content=content, stop_reason=api_response.stop_reason, usage=usage
+            )
 
             # Process tool calls via handler and fire callbacks.
             tool_results: list[dict[str, Any]] = []
@@ -679,20 +688,24 @@ class SdkChatBackend(ChatBackend):
                 result_text: str = "OK"
                 if tool_handler is not None:
                     result_text = tool_handler(tc)
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": tc.id,
-                    "content": result_text,
-                })
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tc.id,
+                        "content": result_text,
+                    }
+                )
 
             if api_response.stop_reason != "tool_use":
                 return response
 
             # Feed assistant response and tool results back.
-            messages.append({
-                "role": "assistant",
-                "content": response.content_as_dicts,
-            })
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": response.content_as_dicts,
+                }
+            )
             messages.append({"role": "user", "content": tool_results})
 
     # ------------------------------------------------------------------
@@ -744,7 +757,8 @@ class SdkChatBackend(ChatBackend):
 
         text_parts: list[str] = []
         async for message in self._sdk.query(
-            prompt=enhanced_prompt, options=options,
+            prompt=enhanced_prompt,
+            options=options,
         ):
             if isinstance(message, self._sdk.AssistantMessage):
                 for block in message.content:

--- a/src/clarity_agent/mcp/server.py
+++ b/src/clarity_agent/mcp/server.py
@@ -692,7 +692,7 @@ def read_behaviors(project_dir: str | None = None) -> str:
     if not agents_md.exists():
         return (
             "AGENTS.md not found in this project. Open the project in "
-            "Clarity (or run `clarity install --embedded` for a git "
+            "Clarity (or run `clarity embed <dir>` for a git "
             "repo) to create it."
         )
     block = _extract_block(agents_md.read_text(encoding="utf-8"))

--- a/src/clarity_agent/mcp/server.py
+++ b/src/clarity_agent/mcp/server.py
@@ -37,6 +37,8 @@ from mcp import types
 from mcp.server.fastmcp import FastMCP
 from pydantic import AnyUrl
 
+from clarity_agent.protocol.invocation import render_guide
+
 DEFAULT_SSE_PORT = 8421
 MCP_PACKET_FORMATS = frozenset({"markdown", "docx"})
 PACKET_DOCX_MIME_TYPE = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
@@ -131,7 +133,7 @@ def run_clarity(project_dir: str | None = None) -> str:
     if not proto_dir.exists():
         agent_dir = _resolve_agent_dir()
         guide_path = agent_dir / "processes" / "clarity-agent.md"
-        guide = guide_path.read_text(encoding="utf-8") if guide_path.exists() else ""
+        guide = render_guide(guide_path.read_text(encoding="utf-8")) if guide_path.exists() else ""
         return (
             "# New Project\n\n"
             "No clarity protocol found. This is a new project.\n\n"
@@ -185,7 +187,7 @@ def run_clarity(project_dir: str | None = None) -> str:
             agent_dir = _resolve_agent_dir()
             guide_path = agent_dir / "processes" / f"{action['process']}.md"
             if guide_path.exists():
-                guide_content = guide_path.read_text(encoding="utf-8")
+                guide_content = render_guide(guide_path.read_text(encoding="utf-8"))
                 status_text += (
                     f"\n\n---\n\n"
                     f"## Process Guide: {action['process']}\n\n"
@@ -639,7 +641,7 @@ def read_process_guide(process_name: str) -> str:
                 f"Error: process guide not found: {process_name}\n"
                 f"Available: {', '.join(sorted(available))}"
             )
-    return guide_path.read_text(encoding="utf-8")
+    return render_guide(guide_path.read_text(encoding="utf-8"))
 
 
 def list_thinkers() -> str:
@@ -903,7 +905,7 @@ def process_guide_resource(name: str) -> str:
     guide_path = agent_dir / "processes" / f"{name}.md"
     if not guide_path.exists():
         return f"Process guide not found: {name}"
-    return guide_path.read_text(encoding="utf-8")
+    return render_guide(guide_path.read_text(encoding="utf-8"))
 
 
 @mcp.resource("clarity://thinkers/{name}")

--- a/src/clarity_agent/protocol/diagram.py
+++ b/src/clarity_agent/protocol/diagram.py
@@ -184,6 +184,9 @@ def generate_file(
 
 
 def main() -> None:
+    from clarity_agent.console import configure_stdio
+    configure_stdio()
+
     parser = argparse.ArgumentParser(description="Generate Mermaid threat model diagram")
     parser.add_argument("--input", help="JSON file with components and flows")
     parser.add_argument("--threats", help="JSON file with threat annotations")

--- a/src/clarity_agent/protocol/initialize.py
+++ b/src/clarity_agent/protocol/initialize.py
@@ -219,6 +219,9 @@ def init_protocol(
 def main() -> None:
     import argparse
 
+    from clarity_agent.console import configure_stdio
+    configure_stdio()
+
     parser: argparse.ArgumentParser = argparse.ArgumentParser(
         description="Initialize a .clarity-protocol/ directory for a project",
     )

--- a/src/clarity_agent/protocol/invocation.py
+++ b/src/clarity_agent/protocol/invocation.py
@@ -1,0 +1,89 @@
+"""How to re-invoke the packet-status CLI from wherever we happen to be running.
+
+The process guides in ``processes/*.md`` tell the agent to shell out to the
+packet-status tool to read and record document state.  Those guides are static
+markdown, so historically they hardcoded::
+
+    python -m clarity_agent.protocol.packet_status . --record goal/problem.md
+
+That command is wrong in two of the three environments Clarity runs in:
+
+- **Frozen desktop build (PyInstaller).**  There is no ``python`` on the PATH a
+  macOS GUI app inherits, and even if there were, ``clarity_agent`` is bundled
+  as data inside ``sys._MEIPASS`` rather than installed into any interpreter's
+  site-packages.  The agent gets ``command not found`` or
+  ``No module named clarity_agent`` and silently falls back to hand-editing
+  ``config.json`` — which then drifts from the hashes the tool would compute.
+- **Anywhere ``python`` means Python 2 or nothing at all.**  ``python3`` is the
+  only name guaranteed to exist on modern macOS and most Linux distros.
+
+Rather than teach every guide about every environment, the guides keep the
+canonical dev-mode spelling and we rewrite it at load time via
+:func:`render_guide`, substituting an invocation that is correct for the
+running process.  ``sys.executable`` is always the right interpreter by
+construction: it is the one that imported this module.
+"""
+
+from __future__ import annotations
+
+import shlex
+import sys
+from pathlib import Path
+
+from clarity_agent.app_paths import get_bundle_dir, is_frozen
+
+#: The literal command spelled in ``processes/*.md``.  Guides are written
+#: against the development environment; :func:`render_guide` rewrites this
+#: to whatever actually works here.
+GUIDE_COMMAND = "python -m clarity_agent.protocol.packet_status"
+
+
+def packet_status_command() -> str:
+    """Return a shell-ready command prefix that runs the packet-status CLI.
+
+    In a frozen build this is the Clarity binary's own ``status`` subcommand,
+    which needs no external interpreter and no importable ``clarity_agent``.
+    Note that a PyInstaller one-file binary re-extracts its bundle on each
+    launch, so this costs a second or so per call — acceptable for a command
+    the agent runs a handful of times per session, and the only invocation
+    that is guaranteed to work.
+
+    In development (and under the MCP server, and in tests) it is the current
+    interpreter with ``-m``.  That interpreter can import ``clarity_agent`` by
+    definition, since it imported this module.
+    """
+    exe = shlex.quote(sys.executable)
+    if is_frozen():
+        return f"{exe} status"
+    return f"{exe} -m clarity_agent.protocol.packet_status"
+
+
+def python_path_entry(agent_dir: Path | None = None) -> str:
+    """Return the directory to put on ``PYTHONPATH`` so ``clarity_agent`` imports.
+
+    Used when spawning child processes that may run bare ``python -m
+    clarity_agent...`` commands of their own.  The bundle layout differs from
+    the source layout: ``clarity-server.spec`` maps ``src/clarity_agent`` to
+    ``clarity_agent`` at the bundle root, so in a frozen build the importable
+    directory is ``sys._MEIPASS`` itself, *not* ``sys._MEIPASS/src`` — which
+    never exists.
+
+    *agent_dir* overrides the installation root for the source layout (an
+    embedded or explicitly configured install); it is ignored when frozen,
+    where the bundle is the only place the package exists.
+    """
+    if is_frozen():
+        return str(get_bundle_dir())
+    return str((agent_dir or get_bundle_dir()) / "src")
+
+
+def render_guide(text: str) -> str:
+    """Rewrite packet-status invocations in a process guide for this environment.
+
+    Returns *text* unchanged when the canonical spelling already works, so
+    guides read naturally in the common development case.
+    """
+    command = packet_status_command()
+    if command == GUIDE_COMMAND:
+        return text
+    return text.replace(GUIDE_COMMAND, command)

--- a/src/clarity_agent/protocol/mailbox.py
+++ b/src/clarity_agent/protocol/mailbox.py
@@ -517,6 +517,9 @@ def ensure_suggestion_box(protocol_dir: Path) -> Mailbox:
 def main() -> None:
     import argparse
 
+    from clarity_agent.console import configure_stdio
+    configure_stdio()
+
     parser: argparse.ArgumentParser = argparse.ArgumentParser(
         description="Manage clarity protocol mailboxes for async operations",
     )

--- a/src/clarity_agent/protocol/packet_status.py
+++ b/src/clarity_agent/protocol/packet_status.py
@@ -1182,6 +1182,9 @@ def format_decisions_for_agent(dreport: DecisionReport) -> str:
 def main() -> None:
     import argparse
 
+    from clarity_agent.console import configure_stdio
+    configure_stdio()
+
     parser: argparse.ArgumentParser = argparse.ArgumentParser(
         description="Check packet status of clarity protocol documents",
     )

--- a/src/clarity_agent/session.py
+++ b/src/clarity_agent/session.py
@@ -217,11 +217,18 @@ class ClaritySession:
         return block.strip() if block else ""
 
     def load_process(self, process_name: str) -> str:
-        """Load a process guide from the clarity agent directory."""
+        """Load a process guide from the clarity agent directory.
+
+        Shell commands in the guide are rewritten for the running environment
+        (see :func:`clarity_agent.protocol.invocation.render_guide`) so the
+        agent is handed a command that actually works here.
+        """
+        from clarity_agent.protocol.invocation import render_guide
+
         process_path: Path = self.clarity_agent_dir / "processes" / f"{process_name}.md"
         if not process_path.exists():
             raise FileNotFoundError(f"Process guide not found: {process_path}")
-        return process_path.read_text()
+        return render_guide(process_path.read_text())
 
     def load_thinker(self, thinker_name: str) -> str:
         """Load a thinker guide from the clarity agent directory."""

--- a/src/clarity_agent/setup/desktop.py
+++ b/src/clarity_agent/setup/desktop.py
@@ -693,6 +693,9 @@ def _cli_main(argv: Sequence[str] | None = None, source_dir: Path | None = None)
     """Parse args and build the desktop app."""
     import argparse
 
+    from clarity_agent.console import configure_stdio
+    configure_stdio()
+
     parser = argparse.ArgumentParser(
         description="Build Clarity as a desktop application",
     )

--- a/src/clarity_agent/setup/doctor.py
+++ b/src/clarity_agent/setup/doctor.py
@@ -1118,6 +1118,9 @@ def _run_repairs(results: list[CheckResult]) -> list[CheckResult]:
 def cli_main() -> None:
     """Full doctor CLI: run checks, display results, offer repairs."""
     from clarity_agent import get_agent_dir
+    from clarity_agent.console import configure_stdio
+
+    configure_stdio()
 
     agent_dir = get_agent_dir()
 

--- a/src/clarity_agent/setup/installer.py
+++ b/src/clarity_agent/setup/installer.py
@@ -853,6 +853,9 @@ def run_install(
 
 def _cli_main(argv: Sequence[str] | None = None) -> None:
     """Parse args and run install, printing coloured results."""
+    from clarity_agent.console import configure_stdio
+    configure_stdio()
+
     parser = argparse.ArgumentParser(
         description="Install clarity-agent (standalone or embedded mode)",
     )

--- a/src/clarity_agent/setup/installer.py
+++ b/src/clarity_agent/setup/installer.py
@@ -324,8 +324,24 @@ def clone_or_update(target: Path, clone_url: str) -> StepResult:
     return StepResult(Outcome.OK, f"Cloned clarity agent into {CLARITY_DIR}")
 
 
-def update_gitignore(layout: ProjectLayout) -> list[StepResult]:  # noqa: F821
-    """Ensure ``.clarity-agent/`` and clarity wrappers are in ``.gitignore``.
+def update_gitignore(  # noqa: F821
+    layout: ProjectLayout,
+    *,
+    ignore_agent_dir: bool = True,
+) -> list[StepResult]:
+    """Ensure the machine-specific Clarity artifacts are in ``.gitignore``.
+
+    Always ignores the ``clarity`` wrappers — they hardcode local
+    paths or resolve against the local PATH.
+
+    ``.clarity-agent/`` is ignored only when *ignore_agent_dir* is true,
+    i.e. when it's a symlink or a per-machine clone.  A ``--copy``
+    embed produces a real, portable snapshot that the repo may
+    legitimately want to commit, so that caller opts out.
+
+    Protocol *contents* — including ``transcripts/`` — are never
+    ignored: they're the record the protocol exists to produce, and
+    they belong in the repo with everything else.
 
     Reads the protocol-dir name from *layout* rather than re-deriving
     it via ``app_paths.protocol_dir`` — single source of truth for
@@ -339,9 +355,18 @@ def update_gitignore(layout: ProjectLayout) -> list[StepResult]:  # noqa: F821
 
     results: list[StepResult] = []
     additions: list[str] = []
-    proto_name = layout.protocol_dir_name()
-    entries = [f"/{CLARITY_DIR}", "/clarity", "/clarity.ps1", "/clarity.bat",
-               f"/{proto_name}/transcripts/"]
+    entries = ["/clarity", "/clarity.ps1", "/clarity.bat"]
+    if ignore_agent_dir:
+        entries.insert(0, f"/{CLARITY_DIR}")
+    elif f"/{CLARITY_DIR}" in existing or CLARITY_DIR in existing:
+        # Left over from an earlier link-style embed; it would hide the
+        # copy we just made.  Removing lines from a user's .gitignore
+        # is their call, not ours — say so instead.
+        results.append(StepResult(
+            Outcome.WARN,
+            f"/{CLARITY_DIR} is in .gitignore, so the copied install "
+            f"won't be committed — remove that line to commit it",
+        ))
     for entry in entries:
         if entry in existing or entry.lstrip("/") in existing:
             results.append(

--- a/src/clarity_agent/setup/layout.py
+++ b/src/clarity_agent/setup/layout.py
@@ -5,11 +5,14 @@ Three modes exist (see :class:`Mode`); each is a clean 1:1 mapping
 from install style to filesystem layout, with no hybrids:
 
   * **EMBEDDED** — a git repository the user explicitly installed
-    Clarity into (``clarity install --embedded``).  Clarity's code
-    lives at ``.clarity-agent/`` inside the repo; the protocol dir
-    is ``.clarity-protocol/`` (hidden, doesn't clutter the working
-    tree); the AGENTS.md snippet uses repo-relative paths so the
-    file commits identically across machines.
+    Clarity into (``clarity embed``).  Clarity's code is reachable
+    at ``.clarity-agent/`` inside the repo — a symlink to the
+    machine-wide install (``embed --link``, the default), a copy of
+    it (``embed --copy``), or a full clone from an older install;
+    the protocol dir is ``.clarity-protocol/`` (hidden, doesn't
+    clutter the working tree); the AGENTS.md snippet uses
+    repo-relative paths so the file commits identically across
+    machines.
 
   * **USERSPACE** — a regular project directory opened from the
     desktop / web app.  Clarity's code lives in the app bundle (the

--- a/src/clarity_agent/setup/project.py
+++ b/src/clarity_agent/setup/project.py
@@ -616,6 +616,9 @@ def run_project_embed(
 def _cli_main(argv: Sequence[str] | None = None, agent_dir: Path | None = None) -> None:
     import argparse
 
+    from clarity_agent.console import configure_stdio
+    configure_stdio()
+
     parser = argparse.ArgumentParser(
         description="Embed Clarity into a git project",
     )

--- a/src/clarity_agent/setup/project.py
+++ b/src/clarity_agent/setup/project.py
@@ -1,24 +1,47 @@
 """Embed Clarity into an existing git project.
 
 This is the lightweight counterpart to the desktop installer. It does not
-create a venv or copy the agent code — it assumes Clarity is already
+create a venv or pip-install anything — it assumes Clarity is already
 installed on the machine. It only adds the project-side artifacts:
 
   - ``.clarity-protocol/``  directory (for protocol outputs)
+  - ``.clarity-agent``      link (or copy) of the machine-wide install
   - ``CLAUDE.md`` / ``AGENTS.md``  updated with the Clarity snippet
   - A thin ``clarity`` wrapper that delegates to the system install
 
-The link to the system Clarity install is PATH-based, so it is never stored
-in the git repo.  If Clarity isn't on PATH the wrapper gives a helpful error.
+The ``.clarity-agent`` entry is what makes the result a *clean* EMBEDDED
+layout as far as :func:`~clarity_agent.setup.layout.detect_layout` is
+concerned — a protocol dir without it reads as a half-finished install
+and the app refuses to open the project — and it's what makes the
+repo-relative ``.clarity-agent/processes`` path the AGENTS.md block
+advertises resolve.  Two ways to provide it, selected by
+:class:`AgentDirStyle`:
 
-Entry point: ``clarity embed <project-dir>``
+  - :data:`AgentDirStyle.LINK` (default, "light") — a symlink to the
+    machine-wide install (a directory junction on Windows when symlinks
+    aren't permitted).  Nothing is duplicated; re-running ``embed``
+    repoints a stale link.
+  - :data:`AgentDirStyle.COPY` ("heavy") — a snapshot of the install's
+    protocol content (``processes/``, ``thinkers/``).  Self-contained
+    and symlink-free, at the cost of going stale until the next
+    ``embed``.
+
+A link is machine-specific and gets gitignored; a copy is portable, so
+it isn't — the team can commit the guidance their coding agents read.
+Running ``clarity`` stays PATH-based either way; if Clarity isn't on
+PATH the wrapper gives a helpful error.
+
+Entry point: ``clarity embed [--copy] <project-dir>``
 """
 
 from __future__ import annotations
 
 import os
+import shutil
+import subprocess
 import sys
 from collections.abc import Callable, Sequence
+from enum import Enum
 from pathlib import Path
 
 from clarity_agent.setup.installer import (
@@ -28,6 +51,7 @@ from clarity_agent.setup.installer import (
     update_gitignore,
 )
 from clarity_agent.setup.layout import (
+    EMBEDDED_AGENT_SUBDIR,
     PROTOCOL_DIR_DOT,
     PROTOCOL_DIR_VISIBLE,
     Mode,
@@ -170,10 +194,10 @@ def setup_userspace_project(
     Returns the :class:`ProjectLayout` so callers can register it
     or pass it to follow-up steps.
 
-    This is the lightweight counterpart to :func:`run_project_embed`,
-    which does the heavy embedded install (clone + venv + pip).
-    Both are explicit setup entry points; ``ensure_for_project`` at
-    runtime never invokes either.
+    This is the USERSPACE counterpart to :func:`run_project_embed`,
+    which sets up a git repo as EMBEDDED.  Both are explicit setup
+    entry points; ``ensure_for_project`` at runtime never invokes
+    either.
     """
     project_dir.mkdir(parents=True, exist_ok=True)
     # Create ``Clarity Protocol/`` *before* delegating to
@@ -221,6 +245,205 @@ def create_protocol_dir(layout: ProjectLayout) -> StepResult:
         return StepResult(Outcome.OK, f"Created {dir_name}/")
     except Exception as exc:
         return StepResult(Outcome.FAIL, f"{dir_name}/: {exc}")
+
+
+class AgentDirStyle(Enum):
+    """How ``embed`` provides ``.clarity-agent/`` inside the project."""
+
+    LINK = "link"
+    """Symlink to the machine-wide install (junction on Windows when
+    symlink creation isn't permitted).  The default: nothing is
+    duplicated, and the project tracks whatever the install becomes."""
+
+    COPY = "copy"
+    """Snapshot copy of the install's protocol content.  Self-contained
+    and symlink-free — for environments where symlinks are awkward
+    (some Windows setups, network shares, containers that bind-mount
+    only the project), or where the team wants to commit the guidance
+    their coding agents read."""
+
+
+# What a project-side ``.clarity-agent/`` is actually read for: the
+# process and thinker guides.  An allowlist, not a denylist — the
+# install root also holds a venv, a git checkout, npm/cargo caches and
+# build output, none of which a project needs and any of which can be
+# gigabytes.  Execution always goes through the PATH-based wrapper, so
+# the copy never has to be a *runnable* install.
+_COPY_INCLUDE: tuple[str, ...] = ("processes", "thinkers")
+
+# Junk to skip inside the copied trees.
+_COPY_IGNORE = shutil.ignore_patterns(
+    "__pycache__", "*.pyc", ".DS_Store",
+)
+
+
+def _link_target(path: Path) -> Path | None:
+    """Resolved target of *path* if it's a symlink or a Windows
+    directory junction, else ``None`` (a real directory, or missing).
+
+    Junctions are deliberately included: ``Path.is_symlink()`` reports
+    ``False`` for them, so a junction laid down by a previous ``embed``
+    on Windows would otherwise look like a real directory and never get
+    repointed.
+    """
+    if not path.is_symlink():
+        try:
+            os.readlink(path)  # succeeds for junctions, raises for real dirs
+        except OSError:
+            return None
+    try:
+        return path.resolve()
+    except OSError:
+        return None
+
+
+def _remove_link(path: Path) -> None:
+    """Remove a symlink or junction without touching its target."""
+    try:
+        path.unlink()
+    except OSError:
+        # Windows junctions can't be unlinked, but rmdir removes the
+        # reparse point itself and leaves the target alone.
+        os.rmdir(path)
+
+
+def _create_link(dest: Path, target: Path) -> StepResult:
+    """Symlink *dest* → *target*, falling back to a Windows junction."""
+    try:
+        os.symlink(target, dest, target_is_directory=True)
+        return StepResult(
+            Outcome.OK, f"Linked {EMBEDDED_AGENT_SUBDIR} -> {target}",
+        )
+    except OSError as exc:
+        if not _IS_WINDOWS:
+            return StepResult(
+                Outcome.FAIL, f"{EMBEDDED_AGENT_SUBDIR}: {exc}",
+            )
+        symlink_error = exc
+
+    # Windows without Developer Mode / SeCreateSymbolicLinkPrivilege:
+    # a directory junction needs no privileges and is transparent to
+    # every path consumer we care about.
+    try:
+        result = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(dest), str(target)],
+            capture_output=True, text=True, timeout=30, encoding="utf8",
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return StepResult(
+            Outcome.FAIL,
+            f"{EMBEDDED_AGENT_SUBDIR}: symlink failed ({symlink_error}); "
+            f"junction fallback failed ({exc})",
+        )
+    if result.returncode == 0:
+        return StepResult(
+            Outcome.OK,
+            f"Linked {EMBEDDED_AGENT_SUBDIR} -> {target} (junction)",
+        )
+    detail = (result.stderr or result.stdout or "").strip()
+    return StepResult(
+        Outcome.FAIL,
+        f"{EMBEDDED_AGENT_SUBDIR}: symlink failed ({symlink_error}) and "
+        f"junction fallback failed ({detail}). Enable Developer Mode, or "
+        f"re-run with --copy.",
+    )
+
+
+def _copy_agent_dir(dest: Path, target: Path) -> StepResult:
+    """Snapshot the install's protocol content from *target* into *dest*.
+
+    Copies only :data:`_COPY_INCLUDE`, and replaces rather than merges
+    each of those trees so a refresh drops guides that no longer exist
+    upstream instead of leaving them to rot in the project.
+    """
+    present = [name for name in _COPY_INCLUDE if (target / name).is_dir()]
+    if not present:
+        return StepResult(
+            Outcome.FAIL,
+            f"{EMBEDDED_AGENT_SUBDIR}: no protocol content found in {target} "
+            f"(expected {'/, '.join(_COPY_INCLUDE)}/)",
+        )
+    try:
+        dest.mkdir(parents=True, exist_ok=True)
+        for name in present:
+            sub = dest / name
+            if sub.exists():
+                shutil.rmtree(sub)
+            shutil.copytree(target / name, sub, ignore=_COPY_IGNORE)
+    except OSError as exc:
+        return StepResult(Outcome.FAIL, f"{EMBEDDED_AGENT_SUBDIR}: {exc}")
+    copied = ", ".join(f"{name}/" for name in present)
+    return StepResult(
+        Outcome.OK, f"Copied {copied} from {target} into {EMBEDDED_AGENT_SUBDIR}/",
+    )
+
+
+def provide_agent_dir(
+    layout: ProjectLayout,
+    style: AgentDirStyle = AgentDirStyle.LINK,
+) -> StepResult:
+    """Provide ``.clarity-agent/`` in the project, by link or by copy.
+
+    Without it the project is only half an EMBEDDED layout:
+    :func:`~clarity_agent.setup.layout.detect_layout` reports
+    ``PARTIAL_EMBEDDED_INSTALL`` and the app refuses to open it.
+
+    Idempotent, and never destructive of content it didn't create:
+
+    - Correct link already present → no-op.
+    - Stale link (install moved, or switching to ``COPY``) → replaced;
+      the link's target is untouched.
+    - Real directory already present (a full clone, or a previous
+      ``--copy``) → refreshed under ``COPY``, left alone under ``LINK``
+      with a WARN, since removing it could destroy a real checkout.
+    - Non-directory in the way → FAIL.
+    """
+    dest = layout.project_dir / EMBEDDED_AGENT_SUBDIR
+    target = layout.clarity_agent_dir.resolve()
+    project = layout.project_dir.resolve()
+
+    # Self-reference guard: the clarity-agent source repo dogfooding
+    # itself has ``project_dir == clarity_agent_dir``, and linking a
+    # directory into itself is at best a no-op loop.  No marker is
+    # needed there — ``detect_layout`` recognizes that repo
+    # structurally as CLARITY_AGENT_SOURCE before it looks for
+    # ``.clarity-agent/`` at all.
+    if target == project or project in target.parents:
+        return StepResult(
+            Outcome.SKIP,
+            f"{EMBEDDED_AGENT_SUBDIR}: install lives inside the project; "
+            f"no link needed",
+        )
+
+    linked = _link_target(dest)
+    if linked is not None:
+        if style is AgentDirStyle.LINK and linked == target:
+            return StepResult(
+                Outcome.OK, f"{EMBEDDED_AGENT_SUBDIR} already links to {target}",
+            )
+        try:
+            _remove_link(dest)
+        except OSError as exc:
+            return StepResult(
+                Outcome.FAIL,
+                f"{EMBEDDED_AGENT_SUBDIR}: could not replace existing link: {exc}",
+            )
+    elif dest.exists():
+        if not dest.is_dir():
+            return StepResult(
+                Outcome.FAIL,
+                f"{EMBEDDED_AGENT_SUBDIR} exists and is not a directory",
+            )
+        if style is AgentDirStyle.LINK:
+            return StepResult(
+                Outcome.WARN,
+                f"{EMBEDDED_AGENT_SUBDIR}/ is a real directory (full install?) "
+                f"— leaving it as-is; remove it first to switch to a link",
+            )
+
+    if style is AgentDirStyle.COPY:
+        return _copy_agent_dir(dest, target)
+    return _create_link(dest, target)
 
 
 def create_project_wrapper(layout: ProjectLayout) -> StepResult:
@@ -321,6 +544,7 @@ def run_project_embed(
     project_dir: Path,
     agent_dir: Path,
     *,
+    style: AgentDirStyle = AgentDirStyle.LINK,
     on_step: Callable[[StepResult], None] | None = None,
 ) -> list[StepResult]:
     """Embed Clarity into an existing git project.
@@ -333,6 +557,8 @@ def run_project_embed(
     Args:
         project_dir: Root of the git project to embed into.
         agent_dir:   The clarity-agent installation (for the snippet template).
+        style:       Whether ``.clarity-agent/`` is a link to *agent_dir*
+                     (default, light) or a copy of it (heavy).
         on_step:     Optional callback for real-time progress output.
     """
     results: list[StepResult] = []
@@ -364,10 +590,20 @@ def run_project_embed(
     if results[-1].outcome == Outcome.FAIL:
         return results
 
+    # Must succeed for the project to read as a clean EMBEDDED layout;
+    # without it the app will refuse to open what we just set up.
+    _record(provide_agent_dir(layout, style))
+    if results[-1].outcome == Outcome.FAIL:
+        return results
+
     _record(insert_agent_snippet(layout))
     _record(create_project_wrapper(layout))
     _record(create_mcp_json(layout))
-    for r in update_gitignore(layout):
+    # A copied install is a real, portable directory the repo may want
+    # to commit; a symlink never is.
+    for r in update_gitignore(
+        layout, ignore_agent_dir=style is AgentDirStyle.LINK,
+    ):
         _record(r)
 
     return results
@@ -388,6 +624,28 @@ def _cli_main(argv: Sequence[str] | None = None, agent_dir: Path | None = None) 
         type=Path,
         help="Path to the git repository to embed Clarity into",
     )
+    how = parser.add_mutually_exclusive_group()
+    how.add_argument(
+        "--link",
+        dest="style",
+        action="store_const",
+        const=AgentDirStyle.LINK,
+        help=(
+            "Light install (default): .clarity-agent is a symlink to this "
+            "Clarity installation"
+        ),
+    )
+    how.add_argument(
+        "--copy",
+        dest="style",
+        action="store_const",
+        const=AgentDirStyle.COPY,
+        help=(
+            "Heavy install: copy this installation's process and thinker "
+            "guides into .clarity-agent/ instead of linking it"
+        ),
+    )
+    parser.set_defaults(style=AgentDirStyle.LINK)
     args = parser.parse_args(argv)
 
     project_dir = args.project_dir.resolve()
@@ -410,8 +668,11 @@ def _cli_main(argv: Sequence[str] | None = None, agent_dir: Path | None = None) 
         color_fmt, plain_fmt = _FMT[result.outcome]
         print((color_fmt if use_color else plain_fmt).format(result.message))
 
-    info(f"Embedding Clarity into {project_dir}")
-    results = run_project_embed(project_dir, agent_dir, on_step=emit)
+    style: AgentDirStyle = args.style
+    info(f"Embedding Clarity into {project_dir} ({style.value} install)")
+    results = run_project_embed(
+        project_dir, agent_dir, style=style, on_step=emit,
+    )
 
     if any(r.outcome == Outcome.FAIL for r in results):
         print()

--- a/src/clarity_agent/setup/snippet.py
+++ b/src/clarity_agent/setup/snippet.py
@@ -297,8 +297,8 @@ def ensure_for_project(
       Clarity markers, or a partial/ambiguous install that the
       caller should surface a repair prompt for.  We don't
       implicitly create directories here; mode selection belongs in
-      the explicit setup entry points (``clarity install --embedded``
-      for git repos, the desktop "new project" flow for userspace).
+      the explicit setup entry points (``clarity embed`` for
+      git repos, the desktop "new project" flow for userspace).
     - **Write failure (OSError).** Read-only mount, permissions, etc.
       A stale ``AGENTS.md`` is better than a failed caller.
 

--- a/src/clarity_agent/web/launcher.py
+++ b/src/clarity_agent/web/launcher.py
@@ -377,11 +377,16 @@ def create_launcher(
             cmd.extend(["--session-id", project.llm_session_id])
         # Build a clean environment for the project server:
         # - Strip CLAUDECODE to avoid nested-session errors from the CLI.
-        # - Ensure PYTHONPATH includes the clarity-agent src/ directory so
-        #   that Bash commands like `python -m clarity_agent.protocol...`
-        #   work inside the Claude CLI subprocess.
+        # - Ensure PYTHONPATH points at the directory `clarity_agent` actually
+        #   lives in, so that any bare `python -m clarity_agent.protocol...`
+        #   still resolves inside the Claude CLI subprocess.  That directory
+        #   is *not* `<root>/src` in a frozen build — see
+        #   `invocation.python_path_entry`.  (Process guides no longer rely on
+        #   this; it stays as a backstop for anything else that shells out.)
+        from clarity_agent.protocol.invocation import python_path_entry
+
         env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
-        src_dir = str(clarity_agent_dir / "src")
+        src_dir = python_path_entry(clarity_agent_dir)
         existing_pp = env.get("PYTHONPATH", "")
         if src_dir not in existing_pp.split(os.pathsep):
             env["PYTHONPATH"] = f"{src_dir}{os.pathsep}{existing_pp}" if existing_pp else src_dir

--- a/src/clarity_agent/web/launcher.py
+++ b/src/clarity_agent/web/launcher.py
@@ -557,7 +557,7 @@ def create_launcher(
           USERSPACE setup, registers.  Returns 200.
         - ``intent="open_existing"`` + ``mode="embedded"``: returns
           200 ``{status: "embedded_install_required", command}`` with
-          the ``clarity install --embedded <path>`` command.  Does
+          the ``clarity embed <path>`` command.  Does
           NOT register — the install hasn't happened yet; the user
           will reopen once it has.
         """
@@ -647,7 +647,7 @@ def create_launcher(
                     # — the project isn't a valid Clarity setup yet.
                     return {
                         "status": "embedded_install_required",
-                        "command": f"clarity install --embedded {project_path}",
+                        "command": f"clarity embed {project_path}",
                         "path": str(project_path),
                     }
 

--- a/src/clarity_agent/web/session_manager.py
+++ b/src/clarity_agent/web/session_manager.py
@@ -153,7 +153,7 @@ class WebSessionAdapter:
         # (neither ``.clarity-protocol/`` nor ``Clarity Protocol/``
         # nor ``.clarity-agent/``), we skip the reconcile rather than
         # implicitly creating one: per-mode setup belongs in the
-        # explicit entry points (``clarity install --embedded`` for
+        # explicit entry points (``clarity embed`` for
         # git repos, the desktop "new project" flow for userspace),
         # not in every session-open.  Failures here log but don't
         # block the session — a stale AGENTS.md is preferable to a

--- a/tests/test_console_encoding.py
+++ b/tests/test_console_encoding.py
@@ -1,0 +1,126 @@
+"""Tests for CLI output surviving a non-UTF-8 stdout.
+
+The failure this covers is Windows-only in the wild — a redirected
+stdout falls back to the locale encoding (cp1252 on a Western Windows
+box), and the first ``✓`` we print raises ``UnicodeEncodeError``, so a
+command that did its work exits 1 with a traceback.  It reproduces
+anywhere by forcing the child's ``PYTHONIOENCODING``, which is how
+these tests run on every platform.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from clarity_agent.console import configure_stdio
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# A glyph from every family the CLIs print: status marks, arrows, rules.
+GLYPHS = "✓✗⚠→↳━—"
+
+
+def _cp1252_env() -> dict[str, str]:
+    """Child environment whose stdout can't encode our glyphs."""
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "cp1252"
+    return env
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    proto = tmp_path / ".clarity-protocol"
+    proto.mkdir()
+    (proto / "config.json").write_text("{}", encoding="utf-8")
+    (proto / "summary.md").write_text(
+        "# Summary\n\nSomething real.\n", encoding="utf-8",
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# configure_stdio
+# ---------------------------------------------------------------------------
+
+class TestConfigureStdio:
+    def test_switches_a_stream_that_cannot_carry_our_glyphs(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+        monkeypatch.setattr(sys, "stdout", stream)
+
+        configure_stdio()
+
+        assert stream.encoding.lower().replace("-", "") == "utf8"
+        stream.write(GLYPHS)  # would have raised before
+
+    def test_leaves_a_working_stream_alone(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An explicit, capable encoding is the user's choice to keep."""
+        stream = io.TextIOWrapper(io.BytesIO(), encoding="utf-16")
+        monkeypatch.setattr(sys, "stdout", stream)
+
+        configure_stdio()
+
+        assert stream.encoding == "utf-16"
+
+    def test_tolerates_streams_it_cannot_reconfigure(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """pytest capture objects, host-installed streams, ``None``."""
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+        monkeypatch.setattr(sys, "stderr", None)
+
+        configure_stdio()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the CLIs themselves
+# ---------------------------------------------------------------------------
+
+class TestCliOutputUnderCp1252:
+    """Each of these crashed with UnicodeEncodeError before the fix."""
+
+    def _run(self, args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            args, cwd=cwd, capture_output=True, text=True,
+            encoding="utf-8", env=_cp1252_env(),
+        )
+
+    def test_clarity_status_record(self, project: Path) -> None:
+        r = self._run(
+            [sys.executable, str(REPO_ROOT / "clarity.py"),
+             "status", ".", "--record", "summary.md"],
+            project,
+        )
+        assert r.returncode == 0, r.stderr
+        assert "✓" in r.stdout
+
+    def test_packet_status_module_entry_point(self, project: Path) -> None:
+        r = self._run(
+            [sys.executable, "-m", "clarity_agent.protocol.packet_status", "."],
+            project,
+        )
+        assert r.returncode == 0, r.stderr
+        assert "UnicodeEncodeError" not in r.stderr
+
+    def test_embed(self, tmp_path: Path) -> None:
+        # Redirected, embed reports in plain ASCII, so this is a guard
+        # against the non-ASCII that leaks in elsewhere — em dashes in
+        # step messages, a project path with non-Latin-1 characters.
+        repo = tmp_path / "répo—ünicode"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        r = self._run(
+            [sys.executable, str(REPO_ROOT / "clarity.py"), "embed", str(repo)],
+            tmp_path,
+        )
+        assert r.returncode == 0, r.stderr
+        assert "UnicodeEncodeError" not in r.stderr

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -275,22 +275,48 @@ class TestUpdateGitignore:
     def test_adds_all_entries(self, tmp_path: Path) -> None:
         (tmp_path / ".git").mkdir()  # simulate git repo
         results = update_gitignore(_embedded_layout(tmp_path))
-        assert len(results) == 5
+        assert len(results) == 4
         assert all(r.outcome == Outcome.OK for r in results)
         content = (tmp_path / ".gitignore").read_text()
         assert f"/{CLARITY_DIR}" in content
         assert "/clarity\n" in content
         assert "/clarity.ps1" in content
         assert "/clarity.bat" in content
-        assert "/.clarity-protocol/transcripts/" in content
+
+    def test_does_not_ignore_protocol_contents(self, tmp_path: Path) -> None:
+        """Transcripts are protocol output — they belong in the repo."""
+        (tmp_path / ".git").mkdir()
+        update_gitignore(_embedded_layout(tmp_path))
+        content = (tmp_path / ".gitignore").read_text()
+        assert ".clarity-protocol" not in content
+
+    def test_copy_style_leaves_agent_dir_committable(self, tmp_path: Path) -> None:
+        """``embed --copy`` produces a real directory the repo may want
+        to commit, so the agent-dir entry is not added."""
+        (tmp_path / ".git").mkdir()
+        results = update_gitignore(
+            _embedded_layout(tmp_path), ignore_agent_dir=False,
+        )
+        assert len(results) == 3
+        content = (tmp_path / ".gitignore").read_text()
+        assert CLARITY_DIR not in content
+
+    def test_copy_style_warns_about_stale_ignore(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".gitignore").write_text(f"/{CLARITY_DIR}\n")
+        results = update_gitignore(
+            _embedded_layout(tmp_path), ignore_agent_dir=False,
+        )
+        assert results[0].outcome == Outcome.WARN
+        assert CLARITY_DIR in results[0].message
 
     def test_already_present(self, tmp_path: Path) -> None:
         (tmp_path / ".git").mkdir()  # simulate git repo
         (tmp_path / ".gitignore").write_text(
-            f"/{CLARITY_DIR}\n/clarity\n/clarity.ps1\n/clarity.bat\n/.clarity-protocol/transcripts/\n"
+            f"/{CLARITY_DIR}\n/clarity\n/clarity.ps1\n/clarity.bat\n"
         )
         results = update_gitignore(_embedded_layout(tmp_path))
-        assert len(results) == 5
+        assert len(results) == 4
         assert all(r.outcome == Outcome.OK for r in results)
         assert "already" in results[0].message
 
@@ -298,7 +324,7 @@ class TestUpdateGitignore:
         (tmp_path / ".git").mkdir()  # simulate git repo
         (tmp_path / ".gitignore").write_text(f"/{CLARITY_DIR}\n")
         results = update_gitignore(_embedded_layout(tmp_path))
-        assert len(results) == 5
+        assert len(results) == 4
         content = (tmp_path / ".gitignore").read_text()
         assert "/clarity\n" in content
         assert "/clarity.ps1" in content

--- a/tests/test_invocation.py
+++ b/tests/test_invocation.py
@@ -1,0 +1,163 @@
+"""Tests for environment-correct packet-status invocation.
+
+Regression coverage for the desktop-build failure where process guides told
+the agent to run ``python -m clarity_agent.protocol.packet_status`` — a command
+with no ``python`` on the GUI PATH and no importable ``clarity_agent`` in the
+frozen bundle.
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from clarity_agent.protocol.invocation import (
+    GUIDE_COMMAND,
+    packet_status_command,
+    python_path_entry,
+    render_guide,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def frozen(monkeypatch: pytest.MonkeyPatch):
+    """Make the process look like a PyInstaller one-file bundle."""
+    def _apply(meipass: Path, executable: str = "/Apps/Clarity.app/MacOS/clarity-server"):
+        monkeypatch.setattr(sys, "frozen", True, raising=False)
+        monkeypatch.setattr(sys, "_MEIPASS", str(meipass), raising=False)
+        monkeypatch.setattr(sys, "executable", executable)
+    return _apply
+
+
+class TestPacketStatusCommand:
+    def test_development_uses_the_running_interpreter(self):
+        # Not bare "python": that name does not exist on a stock macOS PATH.
+        assert packet_status_command() == (
+            f"{shlex.quote(sys.executable)} -m clarity_agent.protocol.packet_status"
+        )
+
+    def test_frozen_uses_the_bundle_subcommand(self, frozen, tmp_path: Path):
+        frozen(tmp_path)
+        # No external interpreter, and no dependence on clarity_agent being
+        # importable from outside the bundle.
+        assert packet_status_command() == (
+            "/Apps/Clarity.app/MacOS/clarity-server status"
+        )
+
+    def test_frozen_path_with_spaces_is_quoted(self, frozen, tmp_path: Path):
+        frozen(tmp_path, executable="/Apps/My Clarity.app/MacOS/clarity-server")
+        command = packet_status_command()
+        # Must survive being pasted into a shell by the agent.
+        assert shlex.split(command) == [
+            "/Apps/My Clarity.app/MacOS/clarity-server", "status",
+        ]
+
+
+class TestPythonPathEntry:
+    def test_development_points_at_src(self):
+        assert python_path_entry() == str(REPO_ROOT / "src")
+
+    def test_explicit_agent_dir_is_honoured(self, tmp_path: Path):
+        assert python_path_entry(tmp_path) == str(tmp_path / "src")
+
+    def test_frozen_points_at_the_bundle_root_not_src(self, frozen, tmp_path: Path):
+        frozen(tmp_path)
+        # The regression: `<_MEIPASS>/src` never exists, because the spec maps
+        # src/clarity_agent -> clarity_agent at the bundle root.
+        assert python_path_entry() == str(tmp_path)
+        assert python_path_entry(Path("/somewhere/else")) == str(tmp_path)
+
+    def test_frozen_entry_would_make_the_package_importable(self, frozen, tmp_path: Path):
+        (tmp_path / "clarity_agent" / "protocol").mkdir(parents=True)
+        frozen(tmp_path)
+        entry = Path(python_path_entry())
+        assert (entry / "clarity_agent" / "protocol").is_dir()
+
+
+class TestRenderGuide:
+    def test_development_leaves_guides_untouched(self):
+        # sys.executable -m ... is what the placeholder means here; we still
+        # substitute the absolute interpreter path, so only assert the shape.
+        text = f"```bash\n{GUIDE_COMMAND} . --record summary.md\n```"
+        assert "clarity_agent.protocol.packet_status" in render_guide(text)
+
+    def test_frozen_rewrites_every_occurrence(self, frozen, tmp_path: Path):
+        frozen(tmp_path)
+        text = (
+            f"{GUIDE_COMMAND} . --agent\n"
+            f"and later\n"
+            f"{GUIDE_COMMAND} . --record goal/problem.md\n"
+        )
+        rendered = render_guide(text)
+        assert GUIDE_COMMAND not in rendered
+        assert rendered.count("clarity-server status") == 2
+        assert ". --record goal/problem.md" in rendered
+
+    def test_unrelated_text_is_preserved(self, frozen, tmp_path: Path):
+        frozen(tmp_path)
+        text = "Read `.clarity-protocol/notes.md` first.\n"
+        assert render_guide(text) == text
+
+
+class TestGuidesUseTheCanonicalSpelling:
+    """The rewrite is a literal substring replace, so the guides must match."""
+
+    @pytest.mark.parametrize(
+        "guide", sorted((REPO_ROOT / "processes").glob("*.md")), ids=lambda p: p.name
+    )
+    def test_no_unrewritable_packet_status_invocation(self, guide: Path):
+        text = guide.read_text(encoding="utf-8")
+        for line_no, line in enumerate(text.splitlines(), 1):
+            if "packet_status" not in line or "python" not in line:
+                continue
+            assert GUIDE_COMMAND in line, (
+                f"{guide.name}:{line_no} invokes packet_status in a spelling "
+                f"render_guide() cannot rewrite: {line.strip()!r}"
+            )
+
+
+class TestClarityStatusSubcommand:
+    """`clarity status` must behave exactly like the module entry point."""
+
+    def _run(self, args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(REPO_ROOT / "clarity.py"), *args],
+            cwd=cwd, capture_output=True, text=True,
+        )
+
+    @pytest.fixture
+    def project(self, tmp_path: Path) -> Path:
+        proto = tmp_path / ".clarity-protocol"
+        proto.mkdir()
+        (proto / "config.json").write_text("{}")
+        (proto / "summary.md").write_text("# Summary\n\nSomething real.\n")
+        return tmp_path
+
+    def test_matches_the_module_entry_point(self, project: Path):
+        via_module = subprocess.run(
+            [sys.executable, "-m", "clarity_agent.protocol.packet_status", ".", "--agent"],
+            cwd=project, capture_output=True, text=True,
+        )
+        via_subcommand = self._run(["status", ".", "--agent"], project)
+        assert via_subcommand.stdout == via_module.stdout
+        assert via_subcommand.returncode == via_module.returncode
+
+    def test_record_persists_state(self, project: Path):
+        result = self._run(["status", ".", "--record", "summary.md"], project)
+        assert result.returncode == 0, result.stderr
+        config = (project / ".clarity-protocol" / "config.json").read_text()
+        assert "documentState" in config
+        assert "summary.md" in config
+
+    def test_does_not_fall_through_to_the_web_default(self, project: Path):
+        # `status` must be in _SUBCOMMANDS, or argparse would insert "web"
+        # and launch a server instead.
+        result = self._run(["status", ".", "--json"], project)
+        assert result.returncode in (0, 1)
+        assert "documentState" in result.stdout or "summary" in result.stdout

--- a/tests/test_invocation.py
+++ b/tests/test_invocation.py
@@ -126,9 +126,12 @@ class TestClarityStatusSubcommand:
     """`clarity status` must behave exactly like the module entry point."""
 
     def _run(self, args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+        # encoding is explicit: the CLI emits UTF-8 (see
+        # ``clarity_agent.console``), while ``text=True`` alone would
+        # decode with the parent's locale — cp1252 on a Windows runner.
         return subprocess.run(
             [sys.executable, str(REPO_ROOT / "clarity.py"), *args],
-            cwd=cwd, capture_output=True, text=True,
+            cwd=cwd, capture_output=True, text=True, encoding="utf-8",
         )
 
     @pytest.fixture
@@ -142,7 +145,7 @@ class TestClarityStatusSubcommand:
     def test_matches_the_module_entry_point(self, project: Path):
         via_module = subprocess.run(
             [sys.executable, "-m", "clarity_agent.protocol.packet_status", ".", "--agent"],
-            cwd=project, capture_output=True, text=True,
+            cwd=project, capture_output=True, text=True, encoding="utf-8",
         )
         via_subcommand = self._run(["status", ".", "--agent"], project)
         assert via_subcommand.stdout == via_module.stdout

--- a/tests/test_launcher_create_project_endpoint.py
+++ b/tests/test_launcher_create_project_endpoint.py
@@ -265,7 +265,7 @@ class TestOpenExistingWithExplicitMode:
         assert r.status_code == 200, r.text
         body = r.json()
         assert body["status"] == "embedded_install_required"
-        assert "clarity install --embedded" in body["command"]
+        assert "clarity embed" in body["command"]
         assert str(project) in body["command"]
         # Verify nothing was registered.
         listing = client.get("/api/projects").json()

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -10,12 +10,16 @@ import pytest
 from clarity_agent.setup.installer import CLARITY_DIR, Outcome
 from clarity_agent.setup.layout import (
     PROTOCOL_DIR_DOT,
+    LayoutBroken,
     Mode,
     ProjectLayout,
+    detect_layout,
 )
 from clarity_agent.setup.project import (
+    AgentDirStyle,
     create_project_wrapper,
     create_protocol_dir,
+    provide_agent_dir,
     run_project_embed,
 )
 
@@ -73,6 +77,181 @@ class TestCreateProjectWrapper:
 
 
 # ---------------------------------------------------------------------------
+# provide_agent_dir
+# ---------------------------------------------------------------------------
+
+def _fake_install(root: Path) -> Path:
+    """A stand-in for a machine-wide Clarity install: the protocol
+    content a project reads, plus the bulky dev artifacts (venv, git
+    checkout, Rust build cache) a copy must not drag along."""
+    agent = root / "install"
+    (agent / "processes").mkdir(parents=True)
+    (agent / "processes" / "guide.md").write_text("guidance")
+    (agent / "thinkers").mkdir()
+    (agent / "thinkers" / "skeptic.md").write_text("be skeptical")
+    (agent / ".git").mkdir()
+    (agent / ".git" / "HEAD").write_text("ref: refs/heads/main")
+    (agent / ".venv" / "bin").mkdir(parents=True)
+    (agent / "src-tauri" / "target").mkdir(parents=True)
+    (agent / "src-tauri" / "target" / "huge.bin").write_text("x" * 1024)
+    return agent
+
+
+class TestProvideAgentDir:
+    """The step that makes an embedded project a *clean* EMBEDDED
+    layout rather than a PARTIAL_EMBEDDED_INSTALL."""
+
+    def test_link_exposes_install_content(self, tmp_path: Path) -> None:
+        project = tmp_path / "repo"
+        project.mkdir()
+        agent = _fake_install(tmp_path)
+
+        r = provide_agent_dir(_layout(project, agent))
+
+        assert r.outcome == Outcome.OK
+        dest = project / CLARITY_DIR
+        assert dest.is_dir()
+        assert dest.resolve() == agent.resolve()
+        assert (dest / "processes" / "guide.md").read_text() == "guidance"
+
+    def test_link_tracks_the_install(self, tmp_path: Path) -> None:
+        """A link, not a copy: later changes to the install show up."""
+        project = tmp_path / "repo"
+        project.mkdir()
+        agent = _fake_install(tmp_path)
+        provide_agent_dir(_layout(project, agent))
+
+        (agent / "processes" / "new.md").write_text("added later")
+
+        assert (project / CLARITY_DIR / "processes" / "new.md").exists()
+
+    def test_link_idempotent(self, tmp_path: Path) -> None:
+        project = tmp_path / "repo"
+        project.mkdir()
+        agent = _fake_install(tmp_path)
+        provide_agent_dir(_layout(project, agent))
+
+        r = provide_agent_dir(_layout(project, agent))
+
+        assert r.outcome == Outcome.OK
+        assert "already links" in r.message
+
+    def test_link_repoints_when_install_moves(self, tmp_path: Path) -> None:
+        project = tmp_path / "repo"
+        project.mkdir()
+        agent = _fake_install(tmp_path)
+        provide_agent_dir(_layout(project, agent))
+
+        moved = tmp_path / "moved"
+        agent.rename(moved)
+        r = provide_agent_dir(_layout(project, moved))
+
+        assert r.outcome == Outcome.OK
+        assert (project / CLARITY_DIR).resolve() == moved.resolve()
+
+    def test_copy_snapshots_content_without_dev_artifacts(
+        self, tmp_path: Path,
+    ) -> None:
+        project = tmp_path / "repo"
+        project.mkdir()
+        agent = _fake_install(tmp_path)
+
+        r = provide_agent_dir(_layout(project, agent), AgentDirStyle.COPY)
+
+        assert r.outcome == Outcome.OK
+        dest = project / CLARITY_DIR
+        assert not dest.is_symlink()
+        assert dest.resolve() == dest  # a real directory, not a link
+        assert (dest / "processes" / "guide.md").read_text() == "guidance"
+        assert (dest / "thinkers" / "skeptic.md").read_text() == "be skeptical"
+        # Allowlist, not denylist: everything else stays behind, however
+        # it's named.  (src-tauri/target alone is gigabytes in practice.)
+        assert sorted(p.name for p in dest.iterdir()) == ["processes", "thinkers"]
+
+    def test_copy_drops_content_removed_upstream(self, tmp_path: Path) -> None:
+        project = tmp_path / "repo"
+        project.mkdir()
+        agent = _fake_install(tmp_path)
+        provide_agent_dir(_layout(project, agent), AgentDirStyle.COPY)
+
+        (agent / "processes" / "guide.md").unlink()
+        provide_agent_dir(_layout(project, agent), AgentDirStyle.COPY)
+
+        assert not (project / CLARITY_DIR / "processes" / "guide.md").exists()
+
+    def test_copy_fails_when_install_has_no_content(self, tmp_path: Path) -> None:
+        project = tmp_path / "repo"
+        project.mkdir()
+        empty = tmp_path / "not-an-install"
+        empty.mkdir()
+
+        r = provide_agent_dir(_layout(project, empty), AgentDirStyle.COPY)
+
+        assert r.outcome == Outcome.FAIL
+
+    def test_copy_replaces_a_link(self, tmp_path: Path) -> None:
+        project = tmp_path / "repo"
+        project.mkdir()
+        agent = _fake_install(tmp_path)
+        provide_agent_dir(_layout(project, agent))
+
+        r = provide_agent_dir(_layout(project, agent), AgentDirStyle.COPY)
+
+        assert r.outcome == Outcome.OK
+        dest = project / CLARITY_DIR
+        assert not dest.is_symlink()
+        # The link's target is left intact.
+        assert (agent / "processes" / "guide.md").exists()
+
+    def test_copy_refreshes_in_place(self, tmp_path: Path) -> None:
+        project = tmp_path / "repo"
+        project.mkdir()
+        agent = _fake_install(tmp_path)
+        provide_agent_dir(_layout(project, agent), AgentDirStyle.COPY)
+
+        (agent / "processes" / "new.md").write_text("added later")
+        r = provide_agent_dir(_layout(project, agent), AgentDirStyle.COPY)
+
+        assert r.outcome == Outcome.OK
+        assert (project / CLARITY_DIR / "processes" / "new.md").exists()
+
+    def test_link_leaves_a_real_directory_alone(self, tmp_path: Path) -> None:
+        """A full clone (or an earlier --copy) is content we didn't
+        create; warn rather than delete it."""
+        project = tmp_path / "repo"
+        project.mkdir()
+        agent = _fake_install(tmp_path)
+        existing = project / CLARITY_DIR
+        existing.mkdir()
+        (existing / "local.md").write_text("do not delete me")
+
+        r = provide_agent_dir(_layout(project, agent))
+
+        assert r.outcome == Outcome.WARN
+        assert (existing / "local.md").read_text() == "do not delete me"
+
+    def test_fails_on_non_directory_in_the_way(self, tmp_path: Path) -> None:
+        project = tmp_path / "repo"
+        project.mkdir()
+        agent = _fake_install(tmp_path)
+        (project / CLARITY_DIR).write_text("not a directory")
+
+        r = provide_agent_dir(_layout(project, agent))
+
+        assert r.outcome == Outcome.FAIL
+
+    def test_skips_when_install_lives_inside_the_project(
+        self, tmp_path: Path,
+    ) -> None:
+        """The clarity-agent source repo dogfooding itself — detection
+        recognizes it structurally, so no marker is needed."""
+        r = provide_agent_dir(_layout(tmp_path, tmp_path))
+
+        assert r.outcome == Outcome.SKIP
+        assert not (tmp_path / CLARITY_DIR).exists()
+
+
+# ---------------------------------------------------------------------------
 # run_project_embed
 # ---------------------------------------------------------------------------
 
@@ -85,6 +264,49 @@ class TestRunProjectEmbed:
 
         assert not any(r.outcome == Outcome.FAIL for r in results)
         assert (tmp_path / ".clarity-protocol").is_dir()
+
+    def test_result_is_a_clean_embedded_layout(self, tmp_path: Path) -> None:
+        """The whole point: what embed leaves on disk must be something
+        ``detect_layout`` accepts, or the app refuses to open it."""
+        project = tmp_path / "repo"
+        project.mkdir()
+        (project / ".git").mkdir()
+        agent = _fake_install(tmp_path)
+
+        results = run_project_embed(project, agent)
+        assert not any(r.outcome == Outcome.FAIL for r in results)
+
+        layout = detect_layout(project, bundled_clarity_agent_dir=agent)
+        assert not isinstance(layout, LayoutBroken)
+        assert isinstance(layout, ProjectLayout)
+        assert layout.mode is Mode.EMBEDDED
+        assert layout.clarity_agent_dir == agent.resolve()
+
+    def test_copy_style_is_also_a_clean_layout(self, tmp_path: Path) -> None:
+        project = tmp_path / "repo"
+        project.mkdir()
+        (project / ".git").mkdir()
+        agent = _fake_install(tmp_path)
+
+        results = run_project_embed(project, agent, style=AgentDirStyle.COPY)
+        assert not any(r.outcome == Outcome.FAIL for r in results)
+
+        layout = detect_layout(project, bundled_clarity_agent_dir=agent)
+        assert isinstance(layout, ProjectLayout)
+        assert layout.mode is Mode.EMBEDDED
+        assert layout.clarity_agent_dir == (project / CLARITY_DIR).resolve()
+        # A copy is committable, so it isn't gitignored.
+        assert CLARITY_DIR not in (project / ".gitignore").read_text()
+
+    def test_link_style_is_gitignored(self, tmp_path: Path) -> None:
+        project = tmp_path / "repo"
+        project.mkdir()
+        (project / ".git").mkdir()
+        agent = _fake_install(tmp_path)
+
+        run_project_embed(project, agent)
+
+        assert f"/{CLARITY_DIR}" in (project / ".gitignore").read_text()
 
     def test_fails_when_dir_missing(self, tmp_path: Path) -> None:
         results = run_project_embed(tmp_path / "nope", tmp_path)

--- a/web/src/components/ProjectSwitcher.tsx
+++ b/web/src/components/ProjectSwitcher.tsx
@@ -745,7 +745,7 @@ export default function ProjectSwitcher({ currentProject }: ProjectSwitcherProps
                 <p className="text-xs text-body-muted mb-4">
                   {prompt.brokenness === "ambiguous_protocol_dirs"
                     ? "Both .clarity-protocol/ and Clarity Protocol/ are present. Please remove one before reopening."
-                    : "Found a partial embedded install (.clarity-agent/ or .clarity-protocol/ but not both). Either complete the install with `clarity install --embedded`, or remove the stray directory and reopen as a userspace project."}
+                    : "Found a partial embedded install (.clarity-agent/ or .clarity-protocol/ but not both). Either complete the install with `clarity embed`, or remove the stray directory and reopen as a userspace project."}
                 </p>
                 <button
                   onClick={() => setPrompt(null)}


### PR DESCRIPTION
1. Bump the versions of all the various Anthropic models to match current reality.
2. Fix Mac binary's ability to find Python, ensuring it always knows the right directories.
3. Fix `clarity embed`, which wasn't actually creating the .clarity-agent directory even though the app required it.